### PR TITLE
Add cube health to status page

### DIFF
--- a/src/graphql/queries.graphql
+++ b/src/graphql/queries.graphql
@@ -183,3 +183,10 @@ query SystemInfo {
     VERSION
   }
 }
+
+query CubeHealth {
+  cubeHealth {
+    ok
+    dimensions
+  }
+}

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -4,10 +4,12 @@ export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];
 };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
-  { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
-  { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -43,6 +45,12 @@ export type CantonResult = SearchResult & {
   __typename: "CantonResult";
   id: Scalars["String"];
   name: Scalars["String"];
+};
+
+export type CubeHealth = {
+  __typename: "CubeHealth";
+  ok: Scalars["Boolean"];
+  dimensions: Array<Scalars["String"]>;
 };
 
 export type Municipality = {
@@ -154,6 +162,7 @@ export type Query = {
   cantonMedianObservations?: Maybe<Array<CantonMedianObservation>>;
   swissMedianObservations?: Maybe<Array<SwissMedianObservation>>;
   wikiContent?: Maybe<WikiContent>;
+  cubeHealth?: Maybe<CubeHealth>;
 };
 
 export type QueryMunicipalitiesArgs = {
@@ -483,6 +492,17 @@ export type SystemInfoQuery = {
   };
 };
 
+export type CubeHealthQueryVariables = Exact<{ [key: string]: never }>;
+
+export type CubeHealthQuery = {
+  __typename: "Query";
+  cubeHealth?: Maybe<{
+    __typename: "CubeHealth";
+    ok: boolean;
+    dimensions: Array<string>;
+  }>;
+};
+
 export const OperatorObservationFieldsFragmentDoc = gql`
   fragment operatorObservationFields on OperatorObservation {
     period
@@ -757,6 +777,23 @@ export function useSystemInfoQuery(
 ) {
   return Urql.useQuery<SystemInfoQuery>({
     query: SystemInfoDocument,
+    ...options,
+  });
+}
+export const CubeHealthDocument = gql`
+  query CubeHealth {
+    cubeHealth {
+      ok
+      dimensions
+    }
+  }
+`;
+
+export function useCubeHealthQuery(
+  options: Omit<Urql.UseQueryArgs<CubeHealthQueryVariables>, "query"> = {}
+) {
+  return Urql.useQuery<CubeHealthQuery>({
+    query: CubeHealthDocument,
     ...options,
   });
 }

--- a/src/graphql/resolver-types.ts
+++ b/src/graphql/resolver-types.ts
@@ -14,14 +14,15 @@ export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];
 };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
-  { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
-  { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
 export type RequireFields<T, K extends keyof T> = {
   [X in Exclude<keyof T, K>]?: T[X];
-} &
-  { [P in K]-?: NonNullable<T[P]> };
+} & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -56,6 +57,12 @@ export type CantonResult = SearchResult & {
   __typename?: "CantonResult";
   id: Scalars["String"];
   name: Scalars["String"];
+};
+
+export type CubeHealth = {
+  __typename?: "CubeHealth";
+  ok: Scalars["Boolean"];
+  dimensions: Array<Scalars["String"]>;
 };
 
 export type Municipality = {
@@ -167,6 +174,7 @@ export type Query = {
   cantonMedianObservations?: Maybe<Array<CantonMedianObservation>>;
   swissMedianObservations?: Maybe<Array<SwissMedianObservation>>;
   wikiContent?: Maybe<WikiContent>;
+  cubeHealth?: Maybe<CubeHealth>;
 };
 
 export type QueryMunicipalitiesArgs = {
@@ -283,8 +291,12 @@ export type ResolversObject<TObject> = WithIndex<TObject>;
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
 
+export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
-  ResolverFn<TResult, TParent, TContext, TArgs>;
+  | ResolverFn<TResult, TParent, TContext, TArgs>
+  | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
@@ -389,8 +401,9 @@ export type ResolversTypes = ResolversObject<{
   CantonMedianObservation: ResolverTypeWrapper<ResolvedCantonMedianObservation>;
   Float: ResolverTypeWrapper<Scalars["Float"]>;
   CantonResult: ResolverTypeWrapper<ResolvedSearchResult>;
-  Municipality: ResolverTypeWrapper<ResolvedMunicipality>;
+  CubeHealth: ResolverTypeWrapper<CubeHealth>;
   Boolean: ResolverTypeWrapper<Scalars["Boolean"]>;
+  Municipality: ResolverTypeWrapper<ResolvedMunicipality>;
   MunicipalityResult: ResolverTypeWrapper<ResolvedSearchResult>;
   Observation: ResolverTypeWrapper<ResolvedObservation>;
   ObservationFilters: ObservationFilters;
@@ -418,8 +431,9 @@ export type ResolversParentTypes = ResolversObject<{
   CantonMedianObservation: ResolvedCantonMedianObservation;
   Float: Scalars["Float"];
   CantonResult: ResolvedSearchResult;
-  Municipality: ResolvedMunicipality;
+  CubeHealth: CubeHealth;
   Boolean: Scalars["Boolean"];
+  Municipality: ResolvedMunicipality;
   MunicipalityResult: ResolvedSearchResult;
   Observation: ResolvedObservation;
   ObservationFilters: ObservationFilters;
@@ -483,6 +497,19 @@ export type CantonResultResolvers<
 > = ResolversObject<{
   id?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
   name?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type CubeHealthResolvers<
+  ContextType = ServerContext,
+  ParentType extends ResolversParentTypes["CubeHealth"] = ResolversParentTypes["CubeHealth"]
+> = ResolversObject<{
+  ok?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
+  dimensions?: Resolver<
+    Array<ResolversTypes["String"]>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -701,6 +728,11 @@ export type QueryResolvers<
     ContextType,
     RequireFields<QueryWikiContentArgs, "locale" | "slug">
   >;
+  cubeHealth?: Resolver<
+    Maybe<ResolversTypes["CubeHealth"]>,
+    ParentType,
+    ContextType
+  >;
 }>;
 
 export type SearchResultResolvers<
@@ -752,6 +784,7 @@ export type Resolvers<ContextType = ServerContext> = ResolversObject<{
   Canton?: CantonResolvers<ContextType>;
   CantonMedianObservation?: CantonMedianObservationResolvers<ContextType>;
   CantonResult?: CantonResultResolvers<ContextType>;
+  CubeHealth?: CubeHealthResolvers<ContextType>;
   Municipality?: MunicipalityResolvers<ContextType>;
   MunicipalityResult?: MunicipalityResultResolvers<ContextType>;
   Observation?: ObservationResolvers<ContextType>;

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -37,6 +37,23 @@ var gfmHtml = require("micromark-extension-gfm/html");
 
 import * as ns from "../rdf/namespace";
 import { ApolloError } from "apollo-server-errors";
+import { difference } from "d3";
+
+const expectedCubeDimensions = [
+  "https://energy.ld.admin.ch/elcom/electricityprice/dimension/category",
+  "https://energy.ld.admin.ch/elcom/electricityprice/dimension/municipality",
+  "https://energy.ld.admin.ch/elcom/electricityprice/dimension/operator",
+  "https://energy.ld.admin.ch/elcom/electricityprice/dimension/period",
+  "https://energy.ld.admin.ch/elcom/electricityprice/dimension/aidfee",
+  "https://energy.ld.admin.ch/elcom/electricityprice/dimension/charge",
+  "https://energy.ld.admin.ch/elcom/electricityprice/dimension/energy",
+  "https://energy.ld.admin.ch/elcom/electricityprice/dimension/fixcosts",
+  "https://energy.ld.admin.ch/elcom/electricityprice/dimension/fixcostspercent",
+  "https://energy.ld.admin.ch/elcom/electricityprice/dimension/gridusage",
+  "https://energy.ld.admin.ch/elcom/electricityprice/dimension/total",
+  "https://energy.ld.admin.ch/elcom/electricityprice/dimension/product",
+  "https://cube.link/observedBy",
+];
 
 const Query: QueryResolvers = {
   systemInfo: async () => {
@@ -356,6 +373,15 @@ const Query: QueryResolvers = {
     });
 
     return results[0];
+  },
+  cubeHealth: async () => {
+    const cube = await getObservationsCube();
+    const dimensions = cube.dimensions.map((d) => d.path.value);
+    const missingDimensions = difference(expectedCubeDimensions, dimensions);
+    return {
+      ok: missingDimensions.size === 0,
+      dimensions,
+    };
   },
   wikiContent: async (_, { locale, slug }) => {
     // Exit early if home-banner is requested and it's disabled

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -120,6 +120,11 @@ type SystemInfo {
   VERSION: String!
 }
 
+type CubeHealth {
+  ok: Boolean!
+  dimensions: [String!]!
+}
+
 type Query {
   systemInfo: SystemInfo!
   municipalities(
@@ -168,4 +173,7 @@ type Query {
   ): [SwissMedianObservation!]
 
   wikiContent(locale: String!, slug: String!): WikiContent
+
+  cubeHealth: CubeHealth
+
 }

--- a/src/pages/_system/api-status.tsx
+++ b/src/pages/_system/api-status.tsx
@@ -162,7 +162,7 @@ const ObservationsStatus = () => {
   });
   return (
     <Status
-      title="Municipalitiy Observations (All Price Components)"
+      title="Municipality Observations (All Price Components)"
       query={query}
     />
   );
@@ -206,6 +206,12 @@ const SwissMedianStatus = () => {
   return <Status title="Swiss Median Observations " query={query} />;
 };
 
+const CubeHealth = () => {
+  const [query] = Queries.useCubeHealthQuery();
+
+  return <Status title="Cube health" query={query} />;
+};
+
 const Page = () => {
   return (
     <Box sx={{ p: 5 }}>
@@ -222,6 +228,8 @@ const Page = () => {
       <Heading variant="heading2" sx={{ mt: 3 }}>
         Data
       </Heading>
+
+      <CubeHealth />
 
       <ObservationsStatus />
 


### PR DESCRIPTION
Map was not working because of missing dimensions in the cube shape
(only on lindas cached, not on normal lindas). Here I added a cube
health endpoint whose result is shown on the api-status page.

This way, we can check if all the dimensions are there. Since this
page is monitored by betteruptime, we will be warned if it ever
happens again.﻿
