### PR TITLE
Automatically show banner if data not available

### DIFF
--- a/src/components/info-banner.tsx
+++ b/src/components/info-banner.tsx
@@ -3,14 +3,27 @@ import { useWikiContentQuery } from "../graphql/queries";
 import { useLocale } from "../lib/use-locale";
 import { HintBlue } from "./hint";
 
-export const InfoBanner = () => {
+export const InfoBanner = ({
+  bypassBannerEnabled,
+}: {
+  bypassBannerEnabled: boolean;
+}) => {
   const locale = useLocale();
   const [contentQuery] = useWikiContentQuery({
     variables: { locale, slug: "home-banner" },
   });
 
   // Don't show loading/error state for banner
-  if (contentQuery.fetching || !contentQuery.data?.wikiContent) {
+  if (contentQuery.fetching) {
+    return null;
+  }
+
+  if (!contentQuery.data?.wikiContent) {
+    return null;
+  }
+
+  const wikiContent = contentQuery.data?.wikiContent;
+  if (!wikiContent.info.bannerEnabled && !bypassBannerEnabled) {
     return null;
   }
 

--- a/src/graphql/queries.graphql
+++ b/src/graphql/queries.graphql
@@ -181,6 +181,7 @@ query OperatorDocuments($id: String!, $locale: String!) {
 query WikiContent($locale: String!, $slug: String!) {
   wikiContent(locale: $locale, slug: $slug) {
     html
+    info
   }
 }
 

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -19,6 +19,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  WikiContentInfo: any;
 };
 
 export enum CacheControlScope {
@@ -281,6 +282,7 @@ export type SystemInfo = {
 export type WikiContent = {
   __typename: "WikiContent";
   html: Scalars["String"];
+  info?: Maybe<Scalars["WikiContentInfo"]>;
 };
 
 export type MunicipalitiesQueryVariables = Exact<{
@@ -516,7 +518,11 @@ export type WikiContentQueryVariables = Exact<{
 
 export type WikiContentQuery = {
   __typename: "Query";
-  wikiContent?: { __typename: "WikiContent"; html: string } | null;
+  wikiContent?: {
+    __typename: "WikiContent";
+    html: string;
+    info?: any | null;
+  } | null;
 };
 
 export type SystemInfoQueryVariables = Exact<{ [key: string]: never }>;
@@ -794,6 +800,7 @@ export const WikiContentDocument = gql`
   query WikiContent($locale: String!, $slug: String!) {
     wikiContent(locale: $locale, slug: $slug) {
       html
+      info
     }
   }
 `;

--- a/src/graphql/resolver-types.ts
+++ b/src/graphql/resolver-types.ts
@@ -1,4 +1,8 @@
-import { GraphQLResolveInfo } from "graphql";
+import {
+  GraphQLResolveInfo,
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig,
+} from "graphql";
 import {
   ResolvedCanton,
   ResolvedMunicipality,
@@ -31,6 +35,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  WikiContentInfo: any;
 };
 
 export enum CacheControlScope {
@@ -293,6 +298,7 @@ export type SystemInfo = {
 export type WikiContent = {
   __typename?: "WikiContent";
   html: Scalars["String"];
+  info?: Maybe<Scalars["WikiContentInfo"]>;
 };
 
 export type WithIndex<TObject> = TObject & Record<string, any>;
@@ -433,6 +439,7 @@ export type ResolversTypes = ResolversObject<{
   SwissMedianObservation: ResolverTypeWrapper<ResolvedSwissMedianObservation>;
   SystemInfo: ResolverTypeWrapper<SystemInfo>;
   WikiContent: ResolverTypeWrapper<WikiContent>;
+  WikiContentInfo: ResolverTypeWrapper<Scalars["WikiContentInfo"]>;
 }>;
 
 /** Mapping between all available schema types and the resolvers parents */
@@ -461,6 +468,7 @@ export type ResolversParentTypes = ResolversObject<{
   SwissMedianObservation: ResolvedSwissMedianObservation;
   SystemInfo: SystemInfo;
   WikiContent: WikiContent;
+  WikiContentInfo: Scalars["WikiContentInfo"];
 }>;
 
 export type CacheControlDirectiveArgs = {
@@ -808,8 +816,18 @@ export type WikiContentResolvers<
   ParentType extends ResolversParentTypes["WikiContent"] = ResolversParentTypes["WikiContent"]
 > = ResolversObject<{
   html?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  info?: Resolver<
+    Maybe<ResolversTypes["WikiContentInfo"]>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
+
+export interface WikiContentInfoScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["WikiContentInfo"], any> {
+  name: "WikiContentInfo";
+}
 
 export type Resolvers<ContextType = ServerContext> = ResolversObject<{
   Canton?: CantonResolvers<ContextType>;
@@ -828,6 +846,7 @@ export type Resolvers<ContextType = ServerContext> = ResolversObject<{
   SwissMedianObservation?: SwissMedianObservationResolvers<ContextType>;
   SystemInfo?: SystemInfoResolvers<ContextType>;
   WikiContent?: WikiContentResolvers<ContextType>;
+  WikiContentInfo?: GraphQLScalarType;
 }>;
 
 export type DirectiveResolvers<ContextType = ServerContext> = ResolversObject<{

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -350,18 +350,7 @@ const Query: QueryResolvers = {
   },
   wikiContent: async (_, { locale, slug }) => {
     // Exit early if home-banner is requested and it's disabled
-    if (slug === "home-banner") {
-      const bannerEnabled = (await getWikiPage("home"))?.content.match(
-        /home_banner_enabled:\W*true/
-      )
-        ? true
-        : false;
-
-      if (!bannerEnabled) {
-        return null;
-      }
-    }
-
+    const extraInfo = await getExtraInfo(slug);
     const wikiPage = await getWikiPage(`${slug}/${locale}`);
 
     if (!wikiPage) {
@@ -369,6 +358,7 @@ const Query: QueryResolvers = {
     }
 
     return {
+      info: extraInfo,
       html: micromark(wikiPage.content, {
         allowDangerousHtml: true,
         extensions: [gfmSyntax()],
@@ -376,6 +366,17 @@ const Query: QueryResolvers = {
       }),
     };
   },
+};
+
+const getExtraInfo = async (slug: string) => {
+  if (slug === "home-banner") {
+    const bannerEnabled = (await getWikiPage("home"))?.content.match(
+      /home_banner_enabled:\W*true/
+    );
+    return { bannerEnabled };
+  } else {
+    return {};
+  }
 };
 
 const Municipality: MunicipalityResolvers = {

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -124,8 +124,10 @@ enum ObservationKind {
   Municipality
 }
 
-type WikiContent @cacheControl(maxAge: 300) {
+scalar WikiContentInfo
+type WikiContent @cacheControl(maxAge: 60) {
   html: String!
+  info: WikiContentInfo
 }
 
 type SystemInfo {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -269,7 +269,15 @@ const IndexPage = ({ locale }: Props) => {
             position: "relative",
           }}
         >
-          <InfoBanner />
+          <InfoBanner
+            bypassBannerEnabled={
+              !!(
+                observationsQuery.fetching === false &&
+                observationsQuery.data &&
+                !medianValue
+              )
+            }
+          />
           <Flex
             sx={{
               py: 8,


### PR DESCRIPTION
A banner whose content is configured in the wiki can be activated
or deactivated from the wiki.

Now, it is shown also when no median value can be found in the
data.

