### PR TITLE
feat: Add document download debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "micromark-extension-gfm": "^0.3.3",
     "next": "^11.0.1",
     "nextjs-basic-auth-middleware": "^0.2.1",
+    "nextkit": "^3.4.3",
     "node-fetch": "2.6",
     "nprogress": "^0.2.0",
     "rdf-cube-view-query": "^1.3.1",

--- a/src/domain/gever/message.ts
+++ b/src/domain/gever/message.ts
@@ -369,7 +369,10 @@ const makeSearchRequest = async (
     "Content-Type": "application/soap+xml; charset=utf-8",
   }).then((x) => x.text());
 
-  return resp;
+  return {
+    request: req3,
+    response: resp,
+  };
 };
 
 /**
@@ -442,7 +445,17 @@ type SearchOptions = {
 export const searchGeverDocuments = async (searchOptions: SearchOptions) => {
   console.log("Search gever documents", searchOptions);
   const authResp = await makeAuthRequest();
-  const searchResp = await makeSearchRequest(authResp, searchOptions);
-  fs.writeFileSync("/tmp/search-resp.xml", searchResp);
-  return parseSearchResponse(searchResp);
+  const { request, response } = await makeSearchRequest(
+    authResp,
+    searchOptions
+  );
+  fs.writeFileSync("/tmp/search-resp.xml", response);
+  return {
+    debug: {
+      response,
+      request,
+      bindings,
+    },
+    docs: parseSearchResponse(response),
+  };
 };

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -406,10 +406,10 @@ const Operator: OperatorResolvers = {
   },
 
   geverDocuments: async ({ id: operatorId }) => {
-    const operatorInfo = await fetchOperatorInfo({ operatorId });
+    const { data: operatorInfo } = await fetchOperatorInfo({ operatorId });
     const uid = operatorInfo?.uid;
     try {
-      const docs = await searchGeverDocuments({
+      const { docs } = await searchGeverDocuments({
         operatorId,
         uid,
       });

--- a/src/pages/api/debug-download.ts
+++ b/src/pages/api/debug-download.ts
@@ -1,0 +1,56 @@
+import { NextApiHandler, NextApiRequest } from "next";
+import { fetchOperatorInfo } from "../../rdf/search-queries";
+import { searchGeverDocuments } from "../../domain/gever";
+import { api } from "../../server/nextkit";
+import { InferAPIResponse } from "nextkit";
+import { endpointUrl } from "../../rdf/sparql-client";
+
+const secret =
+  process.env.DEBUG_DOWNLOAD_SECRET ||
+  "GqQF$t$Fm^oddinivkY8TT8F^kRuRUJ$NJ5Jt%vQ";
+
+const handler = api({
+  GET: async ({ req, res }) => {
+    const { oid: queryOid, uid: queryUid, secret: querySecret } = req.query;
+
+    if (!querySecret || querySecret !== secret) {
+      throw new Error("Incorrect secret");
+    }
+
+    if (!queryOid && !queryUid) {
+      throw new Error("Need oid or uid in the query params");
+    }
+
+    if (Array.isArray(queryOid) || Array.isArray(queryUid)) {
+      throw new Error("queryOid or queryUid should not be arrays");
+    }
+
+    let uid: string;
+    let lindasInfo: Awaited<ReturnType<typeof fetchOperatorInfo>> | null = null;
+    if (queryUid && !Array.isArray(queryUid)) {
+      console.log(1);
+      uid = queryUid;
+    } else if (queryOid && !Array.isArray(queryOid)) {
+      console.log(2);
+      lindasInfo = await fetchOperatorInfo({ operatorId: queryOid });
+      uid = lindasInfo?.data.uid;
+    } else {
+      uid = "Not found";
+    }
+
+    const searchResp = await searchGeverDocuments({
+      operatorId: queryOid,
+      uid,
+    });
+    return {
+      lindasEndpoint: endpointUrl,
+      lindasInfo,
+      uid,
+      searchResp,
+    };
+  },
+});
+
+export type DebugDownloadGetResponse = InferAPIResponse<typeof handler, "GET">;
+
+export default handler;

--- a/src/rdf/search-queries.ts
+++ b/src/rdf/search-queries.ts
@@ -212,12 +212,15 @@ export const fetchOperatorInfo = async ({
     console.warn(`No uid results for operator id ${operatorId}`);
   }
 
-  return results.map((d) => {
-    const uid = d.uid.value;
-    return {
-      uid,
-    };
-  })[0];
+  return {
+    query: sparqlQuery.build(),
+    data: results.map((d) => {
+      const uid = d.uid.value;
+      return {
+        uid,
+      };
+    })[0],
+  };
 };
 
 export const search = async ({

--- a/src/rdf/sparql-client.ts
+++ b/src/rdf/sparql-client.ts
@@ -1,6 +1,7 @@
 import ParsingClient from "sparql-http-client/ParsingClient";
 
+export const endpointUrl = process.env.SPARQL_ENDPOINT;
+
 export const sparqlClient = new ParsingClient({
-  endpointUrl:
-    process.env.SPARQL_ENDPOINT ?? "https://test.lindas.admin.ch/query",
+  endpointUrl: endpointUrl ?? "https://test.lindas.admin.ch/query",
 });

--- a/src/server/nextkit.ts
+++ b/src/server/nextkit.ts
@@ -1,0 +1,24 @@
+// This server defines a basic implementation of the nextkit API.
+import nextkit from "nextkit";
+
+export const api = nextkit({
+  // On error is responsible for shipping an error message and a status back to the client.
+  async onError(req, res, error) {
+    console.error("error", error);
+
+    return {
+      message: "An error occurred.",
+      status: 500,
+    };
+  },
+
+  // Context is optional, can be used to pass information such as the current user
+  // or even the date. I'm not a fan of middleware as it's not very extensible and
+  // the idea of context can type safe (as it is here).
+  async getContext(req) {
+    const ip = (req.headers["x-forwarded-for"] ??
+      req.socket.remoteAddress) as string;
+
+    return { ip };
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9302,6 +9302,11 @@ nextjs-basic-auth-middleware@^0.2.1:
     basic-auth "2.0.1"
     tsscmp "1.0.6"
 
+nextkit@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/nextkit/-/nextkit-3.4.3.tgz#40e47e5c7542e3b6defa6a437b79979a7721aed2"
+  integrity sha512-p7WKSXYXb4oC9EG26fQjaC2b6OROkaDRI9Mg8s0XGsXAxKKHU1h9bnoTLkunY8mH3YtPL53C2hxAwhxfDmTPog==
+
 no-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"


### PR DESCRIPTION
Since the download document process is so convoluted, I made a route that gives us more information on each step.

First, if the conversion from OID (275) to UID (CHE-100-000-11) through Lindas was succesful, then the search request and response. Also there are the endpoints used for the SAML requests. The route is protected by a password (stored in 1Password and changeable through environment variable).