### PR TITLE
feat: Remove displaying and querying legacy documents from old database

### DIFF
--- a/src/components/operator-documents.tsx
+++ b/src/components/operator-documents.tsx
@@ -71,14 +71,11 @@ export const OperatorDocuments = ({ id }: { id: string }) => {
     variables: { locale, id },
   });
 
-  const legacyDocuments =
-    documentsQuery.data?.operator?.documents ?? EMPTY_ARRAY;
   const geverDocuments =
     documentsQuery.data?.operator?.geverDocuments ?? EMPTY_ARRAY;
 
-  // Deduplicate documents taking in priority GEVER documents
   const documents = uniqBy(
-    [...geverDocuments, ...legacyDocuments],
+    geverDocuments,
     (doc) => `${doc.category} - ${doc.year}`
   );
 

--- a/src/graphql/queries.graphql
+++ b/src/graphql/queries.graphql
@@ -161,13 +161,6 @@ query ObservationsWithAllPriceComponents(
 
 query OperatorDocuments($id: String!, $locale: String!) {
   operator(id: $id, locale: $locale) {
-    documents {
-      id
-      name
-      url
-      year
-      category
-    }
     geverDocuments {
       id
       name

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -35,11 +35,8 @@ import {
   SwissMedianObservationResolvers,
 } from "./resolver-types";
 
-
 const gfmSyntax = require("micromark-extension-gfm");
 const gfmHtml = require("micromark-extension-gfm/html");
-
-
 
 const expectedCubeDimensions = [
   "https://energy.ld.admin.ch/elcom/electricityprice/dimension/category",
@@ -399,10 +396,6 @@ const Operator: OperatorResolvers = {
       dimensionKey: "municipality",
       filters: { operator: [id] },
     });
-  },
-
-  documents: async ({ id }) => {
-    return getOperatorDocuments({ operatorId: id });
   },
 
   geverDocuments: async ({ id: operatorId }) => {


### PR DESCRIPTION
Remove legacy documents now that documents are provided via the GEVER database.
