### PR TITLE
fix: Coherence between municipality list and map legend

### DIFF
--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -477,7 +477,16 @@ export const ChoroplethMap = ({
           observations: [],
         }
     : undefined;
-  const d = extent(observations, (d) => d.value);
+
+  const valuesExtent = useMemo(() => {
+    const meansByMunicipality = rollup(
+      observations,
+      (values) => mean(values, (d) => d.value),
+      (d) => d.municipality
+    ).values();
+    return extent(meansByMunicipality, (d) => d) as [number, number];
+  }, [observations]);
+
   const m = medianValue;
 
   const getFillColor = useMemo(() => {
@@ -710,7 +719,9 @@ export const ChoroplethMap = ({
                 ml: 3,
               }}
             >
-              <MapPriceColorLegend stats={[d[0], m, d[1]]} />
+              <MapPriceColorLegend
+                stats={[valuesExtent[0], m, valuesExtent[1]]}
+              />
             </Box>
 
             <DeckGL


### PR DESCRIPTION
For cases where there are multiple operator, we need to consider the
mean, otherwise there can be a discrepancy between the extent of thelegend
and the municipality list.

## Example

Zurich has prices 1, 7
Bale has prices 3

If we do not consider the mean for the legend, we have min,max = 1, 7, while in the municipality list it will be written Zurich 4 ((1 + 7) / 2) , Bale 3.
For legend to be in cohere with municipality list it needs to do the mean, so that it shows min, max = 1, 4

## How to test

### Before

1. Open https://www.strompreis.elcom.admin.ch/?category=H1&period=2024
2. Sort municipalities by "Teuerste zuerst"
3. See that most expensive municipality has price 55.45, while legend has price 64


### After

1. Open https://elcom-electricity-price-website-git-fix-coherence-legend-ixt1.vercel.app/?vercelToolbarCode=EhekYW-4HrPwWZ_&period=2024&category=H1
2. Sort municipalities by "Teuerste zuerst"
3. See that teuerst is 55.45, same values as the max of the legend


