### PR TITLE
feat: Adds support for endpoints that can cache their results per cube

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,7 @@
 # Production endpoint
-SPARQL_ENDPOINT=https://lindas-cached.apps.cluster.ldbar.ch/query
-SPARQL_EDITOR=https://lindas-cached.apps.cluster.ldbar.ch/sparql
+SPARQL_ENDPOINT=https://lindas-cached.cluster.ldbar.ch/query
+SPARQL_ENDPOINT_SUPPORTS_CACHING_PER_CUBE=true
+SPARQL_EDITOR=https://lindas-cached.cluster.ldbar.ch/sparql
 
 # Dev endpoint
 # SPARQL_ENDPOINT=https://int.lindas.admin.ch/query

--- a/README.md
+++ b/README.md
@@ -2,22 +2,23 @@
 
 ## Configuration through Environment Variables
 
-| Variable                    | Required | Example Value                                                                                    |
-| --------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `SPARQL_ENDPOINT`           | yes      | `https://lindas.admin.ch/query`                                                                  |
-| `SPARQL_EDITOR`             | yes      | `https://lindas.admin.ch/sparql`                                                                 |
-| `GITLAB_WIKI_TOKEN`         | yes      | `xyz`                                                                                            |
-| `GITLAB_WIKI_URL`           | yes      | `https://gitlab.ldbar.ch/api/v4/projects/9999/wikis`                                             |
-| `I18N_DOMAINS`              |          | `{"de": "www.elcom.local", "fr": "fr.elcom.local", "it": "it.elcom.local"}`                      |
-| `BASIC_AUTH_CREDENTIALS`    |          | `user:password`                                                                                  |
-| `MATOMO_ID`                 |          | `123`                                                                                            |
-| `CURRENT_PERIOD`            |          | `2022`                                                                                           |
-| `FIRST_PERIOD`              |          | `2009`                                                                                           |
-| `EIAM_CERTIFICATE_PASSWORD` | yes      | See in Elcom PWD certificates in 1Password                                                       |
-| `EIAM_CERTIFICATE_CONTENT`  | yes      | See in Elcom PWD certificates in 1Password. Result of `cat certificate.p12 \| base64`            |
-| `GEVER_BINDING_IPSTS`       |          | `https://idp-cert.gate-r.eiam.admin.ch/auth/sts/v14/certificatetransport`. Ask Roger Flurry.     |
-| `GEVER_BINDING_RPSTS`       |          | `https://feds-r.eiam.admin.ch/adfs/services/trust/13/issuedtokenmixedsymmetricbasic256`          |
-| `GEVER_BINDING_SERVICE`     |          | `https://api-bv.egov-abn.uvek.admin.ch/BusinessManagement/GeverService/GeverServiceAdvanced.svc` |
+| Variable                                    | Required | Example Value                                                                                    |
+| ------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `SPARQL_ENDPOINT`                           | yes      | `https://lindas.admin.ch/query`                                                                  |
+| `SPARQL_EDITOR`                             | yes      | `https://lindas.admin.ch/sparql`                                                                 |
+| `SPARQL_ENDPOINT_SUPPORTS_CACHING_PER_CUBE` | no       | false                                                                                            |
+| `GITLAB_WIKI_TOKEN`                         | yes      | `xyz`                                                                                            |
+| `GITLAB_WIKI_URL`                           | yes      | `https://gitlab.ldbar.ch/api/v4/projects/9999/wikis`                                             |
+| `I18N_DOMAINS`                              |          | `{"de": "www.elcom.local", "fr": "fr.elcom.local", "it": "it.elcom.local"}`                      |
+| `BASIC_AUTH_CREDENTIALS`                    |          | `user:password`                                                                                  |
+| `MATOMO_ID`                                 |          | `123`                                                                                            |
+| `CURRENT_PERIOD`                            |          | `2022`                                                                                           |
+| `FIRST_PERIOD`                              |          | `2009`                                                                                           |
+| `EIAM_CERTIFICATE_PASSWORD`                 | yes      | See in Elcom PWD certificates in 1Password                                                       |
+| `EIAM_CERTIFICATE_CONTENT`                  | yes      | See in Elcom PWD certificates in 1Password. Result of `cat certificate.p12 \| base64`            |
+| `GEVER_BINDING_IPSTS`                       |          | `https://idp-cert.gate-r.eiam.admin.ch/auth/sts/v14/certificatetransport`. Ask Roger Flurry.     |
+| `GEVER_BINDING_RPSTS`                       |          | `https://feds-r.eiam.admin.ch/adfs/services/trust/13/issuedtokenmixedsymmetricbasic256`          |
+| `GEVER_BINDING_SERVICE`                     |          | `https://api-bv.egov-abn.uvek.admin.ch/BusinessManagement/GeverService/GeverServiceAdvanced.svc` |
 
 ## Development Environment
 
@@ -113,7 +114,7 @@ the gitlab content. The proxy is configured via the `./configure-proxy.js` scrip
 required in the `package.json` start command. It uses the `HTTP_PROXY` environment variable
 
 - For some of the server requests (SAML requests), we must _not_ use this proxy, and the agent
-is configured there manually.
+  is configured there manually.
 - For external requests that should use the proxy, we can use `https.globalAgent`.
 
 ```

--- a/src/env/schema.js
+++ b/src/env/schema.js
@@ -50,4 +50,18 @@ export const serverSchema = z.object({
   // Sparql
   SPARQL_EDITOR: z.string().optional(),
   SPARQL_ENDPOINT: z.string().default("https://test.lindas.admin.ch/query"),
+
+  /**
+   * Whether the SPARQL endpoint supports caching per cube.
+   *
+   * When this is set to true, the cubeIri is appended to the URL of the SPARQL
+   * endpoint.
+   * The "cube" endpoints' cache is only flushed when the cube is updated, whereas
+   * the "global" endpoint's cache is flushed when any cube is updated.
+   */
+  SPARQL_ENDPOINT_SUPPORTS_CACHING_PER_CUBE: z
+    .string()
+    .optional()
+    .default("false")
+    .transform((value) => value === "true"),
 });

--- a/src/rdf/queries.ts
+++ b/src/rdf/queries.ts
@@ -29,11 +29,15 @@ export const CANTON_OBSERVATIONS_CUBE =
 export const SWISS_OBSERVATIONS_CUBE =
   "https://energy.ld.admin.ch/elcom/electricityprice-swiss";
 
-export const createSource = () => {
+export const createSource = (cubeIri: string | undefined) => {
   assert(!!serverEnv, "serverEnv is not defined");
+  const endpointUrl =
+    cubeIri && serverEnv.SPARQL_ENDPOINT_SUPPORTS_CACHING_PER_CUBE
+      ? `${serverEnv.SPARQL_ENDPOINT}/${encodeURIComponent(cubeIri)}`
+      : serverEnv.SPARQL_ENDPOINT;
   return new Source({
     queryOperation: "postDirect",
-    endpointUrl: serverEnv.SPARQL_ENDPOINT,
+    endpointUrl,
   });
 };
 
@@ -42,7 +46,7 @@ export const getCube = async ({
 }: {
   iri: string;
 }): Promise<Cube | null> => {
-  const source = createSource();
+  const source = createSource(iri);
   const cube = await source.cube(iri);
 
   if (!cube) {


### PR DESCRIPTION
Now that we use the lindas cluster endpoint, we can add the cube iri to the endpoint,
this way, we use a cache that is only updated when the cube's is updated, not when
*any* cube is updated.

- [x] Update environment variables on [Vercel](https://vercel.com/ixt/elcom-electricity-price-website/settings/environment-variables)
- [x] Update environment variables for ABN
- [ ] Update environment variables for PROD
- [x] Cherry-pick commit onto `next` branch