### PR TITLE
refactor: General clean up

### DIFF
--- a/src/components/VisuallyHidden.tsx
+++ b/src/components/VisuallyHidden.tsx
@@ -1,7 +1,0 @@
-import { visuallyHidden } from "@mui/utils";
-
-const VisuallyHidden = ({ children }: { children: React.ReactNode }) => (
-  <div style={visuallyHidden}>{children}</div>
-);
-
-export default VisuallyHidden;

--- a/src/components/charts-generic/annotation/annotation-x.tsx
+++ b/src/components/charts-generic/annotation/annotation-x.tsx
@@ -1,15 +1,15 @@
 import { Box } from "@mui/material";
 import * as React from "react";
 
-import { GenericObservation } from "../../../domain/data";
-import { getLocalizedLabel } from "../../../domain/translation";
-import { DOT_RADIUS } from "../rangeplot/rangeplot-state";
+import { DOT_RADIUS } from "src/components/charts-generic/rangeplot/rangeplot-state";
 import {
   HistogramState,
   RangePlotState,
   useChartState,
-} from "../use-chart-state";
-import { useChartTheme } from "../use-chart-theme";
+} from "src/components/charts-generic/use-chart-state";
+import { useChartTheme } from "src/components/charts-generic/use-chart-theme";
+import { GenericObservation } from "src/domain/data";
+import { getLocalizedLabel } from "src/domain/translation";
 
 export const ANNOTATION_DOT_RADIUS = 2.5;
 export const ANNOTATION_TRIANGLE_WIDTH = 5;

--- a/src/components/charts-generic/annotation/annotation-x.tsx
+++ b/src/components/charts-generic/annotation/annotation-x.tsx
@@ -98,7 +98,6 @@ export const AnnotationXDataPoint = () => {
                   margins.top + (margins.annotations ?? 0)
                 })`}
               >
-                {/* Data Point indicator */}
                 <circle
                   cx={a.x}
                   cy={a.y + DOT_RADIUS}

--- a/src/components/charts-generic/annotation/annotation-x.tsx
+++ b/src/components/charts-generic/annotation/annotation-x.tsx
@@ -32,12 +32,11 @@ export const AnnotationX = () => {
   const { bounds, annotations } = useChartState() as
     | RangePlotState
     | HistogramState;
-
   const { margins } = bounds;
   const {
     annotationLineColor,
     annotationColor,
-    annotationfontSize,
+    annotationFontSize,
     annotationLabelUnderlineColor,
   } = useChartTheme();
 
@@ -46,7 +45,7 @@ export const AnnotationX = () => {
       {annotations &&
         annotations.map((a, i) => {
           const x = margins.left + a.x;
-          const y1 = a.yLabel + annotationfontSize * a.nbOfLines;
+          const y1 = a.yLabel + annotationFontSize * a.nbOfLines;
           return (
             <React.Fragment key={i}>
               <g transform={`translate(0, 0)`}>
@@ -85,7 +84,6 @@ export const AnnotationXDataPoint = () => {
   const { bounds, annotations } = useChartState() as
     | RangePlotState
     | HistogramState;
-
   const { margins } = bounds;
   const { annotationColor } = useChartTheme();
 
@@ -119,10 +117,9 @@ export const AnnotationXLabel = () => {
   const { bounds, annotations } = useChartState() as
     | RangePlotState
     | HistogramState;
-
-  const { annotationfontSize, fontFamily, annotationColor } = useChartTheme();
-
+  const { annotationFontSize, fontFamily, annotationColor } = useChartTheme();
   const { width } = bounds;
+
   return (
     <>
       {annotations &&
@@ -140,7 +137,7 @@ export const AnnotationXLabel = () => {
               textAlign: "left",
               transform: `translate3d(${ANNOTATION_TRIANGLE_WIDTH}px, -40%, 0)`,
               fontFamily,
-              fontSize: annotationfontSize,
+              fontSize: annotationFontSize,
               color: annotationColor,
               bgcolor: "transparent",
               hyphens: "auto",

--- a/src/components/charts-generic/axis/axis-height-linear.tsx
+++ b/src/components/charts-generic/axis/axis-height-linear.tsx
@@ -1,17 +1,16 @@
 import { axisLeft } from "d3-axis";
 import { select, Selection } from "d3-selection";
-import * as React from "react";
 import { useEffect, useRef } from "react";
 
-import { useFormatCurrency, useFormatNumber } from "../../../domain/helpers";
-import { getLocalizedLabel } from "../../../domain/translation";
 import {
   AreasState,
   ColumnsState,
   LinesState,
   useChartState,
-} from "../use-chart-state";
-import { useChartTheme } from "../use-chart-theme";
+} from "src/components/charts-generic/use-chart-state";
+import { useChartTheme } from "src/components/charts-generic/use-chart-theme";
+import { useFormatCurrency, useFormatNumber } from "src/domain/helpers";
+import { getLocalizedLabel } from "src/domain/translation";
 
 const TICK_MIN_HEIGHT = 50;
 

--- a/src/components/charts-generic/axis/axis-width-histogram.tsx
+++ b/src/components/charts-generic/axis/axis-width-histogram.tsx
@@ -20,20 +20,13 @@ export const AxisWidthHistogram = () => {
   const xAxisRef = useRef<SVGGElement>(null);
 
   const mkAxis = (g: Selection<SVGGElement, unknown, null, undefined>) => {
-    // const tickValues = xScale.ticks(ticks);
     const minValue = min(data, (d) => getX(d)) || 0;
     const maxValue = max(data, (d) => getX(d)) || 10000;
-    const tickValues = [
-      minValue,
-      //...colors.domain(),
-      maxValue,
-    ];
+    const tickValues = [minValue, maxValue];
     g.call(
       axisBottom(xScale)
         .tickValues(tickValues)
-        // .tickValues(tickValues)
         .tickSizeInner(16)
-        // .tickSizeInner(-chartHeight)
         .tickSizeOuter(xAxisLabel ? -chartHeight : 0)
         .tickFormat(formatCurrency)
     );

--- a/src/components/charts-generic/axis/axis-width-histogram.tsx
+++ b/src/components/charts-generic/axis/axis-width-histogram.tsx
@@ -1,12 +1,14 @@
-import { min, max } from "d3-array";
+import { max, min } from "d3-array";
 import { axisBottom } from "d3-axis";
 import { select, Selection } from "d3-selection";
-import * as React from "react";
 import { useEffect, useRef } from "react";
 
-import { useFormatCurrency } from "../../../domain/helpers";
-import { HistogramState, useChartState } from "../use-chart-state";
-import { useChartTheme } from "../use-chart-theme";
+import {
+  HistogramState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
+import { useChartTheme } from "src/components/charts-generic/use-chart-theme";
+import { useFormatCurrency } from "src/domain/helpers";
 
 export const AxisWidthHistogram = () => {
   const formatCurrency = useFormatCurrency();

--- a/src/components/charts-generic/axis/axis-width-linear.tsx
+++ b/src/components/charts-generic/axis/axis-width-linear.tsx
@@ -1,14 +1,15 @@
 import { t } from "@lingui/macro";
 import { axisBottom, axisTop } from "d3-axis";
 import { select, Selection } from "d3-selection";
-import * as React from "react";
 import { useEffect, useRef } from "react";
 
+import {
+  RangePlotState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
+import { useChartTheme } from "src/components/charts-generic/use-chart-theme";
+import { useFormatCurrency } from "src/domain/helpers";
 import { estimateTextWidth } from "src/lib/estimate-text-width";
-
-import { useFormatCurrency } from "../../../domain/helpers";
-import { RangePlotState, useChartState } from "../use-chart-state";
-import { useChartTheme } from "../use-chart-theme";
 
 export const AxisWidthLinear = ({ position }: { position: "top" | "bottom" }) =>
   position === "bottom" ? <AxisWidthLinearBottom /> : <AxisWidthLinearTop />;

--- a/src/components/charts-generic/axis/axis-width-linear.tsx
+++ b/src/components/charts-generic/axis/axis-width-linear.tsx
@@ -11,8 +11,21 @@ import { useChartTheme } from "src/components/charts-generic/use-chart-theme";
 import { useFormatCurrency } from "src/domain/helpers";
 import { estimateTextWidth } from "src/lib/estimate-text-width";
 
-export const AxisWidthLinear = ({ position }: { position: "top" | "bottom" }) =>
-  position === "bottom" ? <AxisWidthLinearBottom /> : <AxisWidthLinearTop />;
+export const AxisWidthLinear = ({
+  position,
+}: {
+  position: "top" | "bottom";
+}) => {
+  switch (position) {
+    case "top":
+      return <AxisWidthLinearTop />;
+    case "bottom":
+      return <AxisWidthLinearBottom />;
+    default:
+      const _exhaustiveCheck: never = position;
+      return _exhaustiveCheck;
+  }
+};
 
 export const AxisWidthLinearBottom = () => {
   const formatCurrency = useFormatCurrency();
@@ -54,25 +67,11 @@ export const AxisWidthLinearBottom = () => {
   });
 
   return (
-    <>
-      {/*
-      <g transform={`translate(${margins.left}, ${margins.top})`}>
-     <text
-          x={chartWidth}
-          y={chartHeight + margins.bottom}
-          dy={-labelFontSize}
-          fontSize={labelFontSize}
-          textAnchor="end"
-        >
-          {xAxisLabel}
-        </text>
-      </g> */}
-      <g
-        ref={xAxisRef}
-        key="x-axis-linear"
-        transform={`translate(${margins.left}, ${chartHeight + margins.top})`}
-      />
-    </>
+    <g
+      ref={xAxisRef}
+      key="x-axis-linear"
+      transform={`translate(${margins.left}, ${chartHeight + margins.top})`}
+    />
   );
 };
 

--- a/src/components/charts-generic/axis/axis-width-time.tsx
+++ b/src/components/charts-generic/axis/axis-width-time.tsx
@@ -1,11 +1,14 @@
 import { axisBottom, axisTop } from "d3-axis";
 import { select, Selection } from "d3-selection";
-import * as React from "react";
 import { useEffect, useRef } from "react";
 
-import { useFormatShortDateAuto } from "../../../domain/helpers";
-import { AreasState, LinesState, useChartState } from "../use-chart-state";
-import { useChartTheme } from "../use-chart-theme";
+import {
+  AreasState,
+  LinesState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
+import { useChartTheme } from "src/components/charts-generic/use-chart-theme";
+import { useFormatShortDateAuto } from "src/domain/helpers";
 
 export const AxisTime = () => {
   const bottomRef = useRef<SVGGElement>(null);

--- a/src/components/charts-generic/axis/axis-width-time.tsx
+++ b/src/components/charts-generic/axis/axis-width-time.tsx
@@ -36,7 +36,6 @@ export const AxisTime = () => {
         .ticks(ticks)
         .tickSize(0)
         .tickSizeInner(4)
-        // .ticks(timeYear.every(every))
         .tickFormat((x) => formatDateAuto(x as Date))
     );
     g.select(".domain").attr("stroke", "#ededed");
@@ -84,9 +83,7 @@ export const AxisTime = () => {
 
 export const AxisTimeDomain = () => {
   const ref = useRef<SVGGElement>(null);
-
   const { xScale, yScale, bounds } = useChartState() as LinesState | AreasState;
-
   const { domainColor } = useChartTheme();
 
   const mkAxis = (g: Selection<SVGGElement, unknown, null, undefined>) => {

--- a/src/components/charts-generic/bars/bars-grouped-state.tsx
+++ b/src/components/charts-generic/bars/bars-grouped-state.tsx
@@ -59,7 +59,6 @@ const useGroupedBarsState = ({
     [fields.style]
   );
 
-  // segments ordered
   const segments = data
     .sort(
       (a, b) =>
@@ -83,7 +82,6 @@ const useGroupedBarsState = ({
     .domain(colorDomain)
     .range(getPalette(fields.segment?.palette));
 
-  // opacity
   const opacityDomain = fields.style?.opacityDomain
     ? fields.style?.opacityDomain
     : [];
@@ -92,7 +90,6 @@ const useGroupedBarsState = ({
     .domain(opacityDomain.sort((a, b) => descending(a, b)))
     .range(getOpacityRanges(opacityDomain.length));
 
-  // x
   const xScale = scaleLinear().domain(fields.x.domain).nice();
 
   const chartHeight = BAR_HEIGHT * segments.length;

--- a/src/components/charts-generic/bars/bars-grouped-state.tsx
+++ b/src/components/charts-generic/bars/bars-grouped-state.tsx
@@ -1,17 +1,22 @@
 import { ascending, descending } from "d3-array";
 import { scaleBand, scaleLinear, scaleOrdinal } from "d3-scale";
-import * as React from "react";
 import { ReactNode, useCallback } from "react";
 
+import {
+  BAR_HEIGHT,
+  BOTTOM_MARGIN_OFFSET,
+} from "src/components/charts-generic/constants";
+import {
+  ChartContext,
+  ChartProps,
+  GroupedBarsState,
+} from "src/components/charts-generic/use-chart-state";
+import { InteractionProvider } from "src/components/charts-generic/use-interaction";
+import { Observer, useWidth } from "src/components/charts-generic/use-width";
+import { BarFields } from "src/domain/config-types";
+import { GenericObservation } from "src/domain/data";
+import { getOpacityRanges, getPalette } from "src/domain/helpers";
 import { sortByIndex } from "src/lib/array";
-
-import { BarFields } from "../../../domain/config-types";
-import { GenericObservation } from "../../../domain/data";
-import { getOpacityRanges, getPalette } from "../../../domain/helpers";
-import { BAR_HEIGHT, BOTTOM_MARGIN_OFFSET } from "../constants";
-import { ChartContext, ChartProps, GroupedBarsState } from "../use-chart-state";
-import { InteractionProvider } from "../use-interaction";
-import { Observer, useWidth } from "../use-width";
 
 const useGroupedBarsState = ({
   data,

--- a/src/components/charts-generic/bars/bars-grouped.tsx
+++ b/src/components/charts-generic/bars/bars-grouped.tsx
@@ -1,12 +1,12 @@
-import * as React from "react";
-
-import { useFormatCurrency } from "../../../domain/helpers";
-import { getLocalizedLabel } from "../../../domain/translation";
-import { EXPANDED_TAG } from "../../detail-page/price-components-bars";
-import { GroupedBarsState, useChartState } from "../use-chart-state";
-import { useChartTheme } from "../use-chart-theme";
-
-import { Bar } from "./bars-simple";
+import { Bar } from "src/components/charts-generic/bars/bars-simple";
+import {
+  GroupedBarsState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
+import { useChartTheme } from "src/components/charts-generic/use-chart-theme";
+import { EXPANDED_TAG } from "src/components/detail-page/price-components-bars";
+import { useFormatCurrency } from "src/domain/helpers";
+import { getLocalizedLabel } from "src/domain/translation";
 
 export const BarsGroupedAxis = ({
   title,

--- a/src/components/charts-generic/bars/bars-simple.tsx
+++ b/src/components/charts-generic/bars/bars-simple.tsx
@@ -1,9 +1,12 @@
 import { useTheme } from "@mui/material";
 import * as React from "react";
 
-import { BAR_HEIGHT } from "../constants";
-import { BarsState, useChartState } from "../use-chart-state";
-import { useChartTheme } from "../use-chart-theme";
+import { BAR_HEIGHT } from "src/components/charts-generic/constants";
+import {
+  BarsState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
+import { useChartTheme } from "src/components/charts-generic/use-chart-theme";
 
 export const Bars = () => {
   const { sortedData, bounds, getX, xScale, getY, yScale } =

--- a/src/components/charts-generic/columns/columns-simple.tsx
+++ b/src/components/charts-generic/columns/columns-simple.tsx
@@ -1,7 +1,10 @@
 import { useTheme } from "@mui/material";
 import * as React from "react";
 
-import { ColumnsState, useChartState } from "../use-chart-state";
+import {
+  ColumnsState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
 
 export const Columns = () => {
   const { sortedData, bounds, getX, xScale, getY, yScale } =

--- a/src/components/charts-generic/containers/div.tsx
+++ b/src/components/charts-generic/containers/div.tsx
@@ -1,6 +1,6 @@
-import React, { ReactNode } from "react";
+import { ReactNode } from "react";
 
-import { useChartState } from "../use-chart-state";
+import { useChartState } from "src/components/charts-generic/use-chart-state";
 
 export const ChartContainer = ({ children }: { children: ReactNode }) => {
   const { bounds } = useChartState();

--- a/src/components/charts-generic/containers/svg.tsx
+++ b/src/components/charts-generic/containers/svg.tsx
@@ -1,6 +1,6 @@
-import React, { ReactNode } from "react";
+import { ReactNode } from "react";
 
-import { useChartState } from "../use-chart-state";
+import { useChartState } from "src/components/charts-generic/use-chart-state";
 
 export const ChartSvg = ({ children }: { children: ReactNode }) => {
   const { bounds } = useChartState();

--- a/src/components/charts-generic/histogram/histogram-min-max-values.tsx
+++ b/src/components/charts-generic/histogram/histogram-min-max-values.tsx
@@ -1,11 +1,13 @@
 import { t } from "@lingui/macro";
-import { min, max } from "d3-array";
-import * as React from "react";
+import { max, min } from "d3-array";
 
-import { useFormatCurrency } from "../../../domain/helpers";
-import { getLocalizedLabel } from "../../../domain/translation";
-import { HistogramState, useChartState } from "../use-chart-state";
-import { useChartTheme } from "../use-chart-theme";
+import {
+  HistogramState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
+import { useChartTheme } from "src/components/charts-generic/use-chart-theme";
+import { useFormatCurrency } from "src/domain/helpers";
+import { getLocalizedLabel } from "src/domain/translation";
 
 export const HistogramMinMaxValues = () => {
   const { data, bounds, getX, xScale } = useChartState() as HistogramState;

--- a/src/components/charts-generic/histogram/histogram-state.tsx
+++ b/src/components/charts-generic/histogram/histogram-state.tsx
@@ -44,8 +44,7 @@ const useHistogramState = ({
 }): HistogramState => {
   const width = useWidth();
   const formatCurrency = useFormatCurrency();
-
-  const { annotationfontSize, palette } = useChartTheme();
+  const { annotationFontSize, palette } = useChartTheme();
 
   const getX = useCallback(
     (d: GenericObservation) => d[fields.x.componentIri] as number,
@@ -113,7 +112,7 @@ const useHistogramState = ({
         getLabel,
         format: formatCurrency,
         width,
-        annotationfontSize,
+        annotationFontSize,
       })
     : [{ height: 0, nbOfLines: 1 }];
 

--- a/src/components/charts-generic/histogram/histogram-state.tsx
+++ b/src/components/charts-generic/histogram/histogram-state.tsx
@@ -80,7 +80,6 @@ const useHistogramState = ({
     .value((x) => getX(x))
     .domain([mkNumber(minValue), mkNumber(maxValue)])
     .thresholds(xScale.ticks(25))(data);
-  // .thresholds(thresholdSturges)(data);
 
   const yScale = scaleLinear().domain([0, max(bins, (d) => d.length) || 100]);
 
@@ -93,7 +92,6 @@ const useHistogramState = ({
       )
     )
   );
-  // const piecewiseColor = piecewise(interpolateHsl, palette.diverging);
 
   const margins = {
     top: 70,
@@ -155,7 +153,6 @@ const useHistogramState = ({
   xScale.range([0, chartWidth]);
   yScale.range([chartHeight, annotationSpace || 0]);
 
-  // Annotations
   const annotations =
     annotation &&
     annotation

--- a/src/components/charts-generic/histogram/histogram-state.tsx
+++ b/src/components/charts-generic/histogram/histogram-state.tsx
@@ -1,26 +1,28 @@
-import { Typography, Box } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { interpolateHsl } from "d3";
 import { ascending, histogram, max, min } from "d3-array";
 import { scaleLinear } from "d3-scale";
-import * as React from "react";
 import { ReactNode, useCallback } from "react";
 
-import { estimateTextWidth } from "src/lib/estimate-text-width";
-
-import { HistogramFields } from "../../../domain/config-types";
-import { GenericObservation } from "../../../domain/data";
+import { LEFT_MARGIN_OFFSET } from "src/components/charts-generic/constants";
+import { Tooltip } from "src/components/charts-generic/interaction/tooltip";
+import { LegendSymbol } from "src/components/charts-generic/legends/color";
+import {
+  ChartContext,
+  ChartProps,
+  HistogramState,
+} from "src/components/charts-generic/use-chart-state";
+import { useChartTheme } from "src/components/charts-generic/use-chart-theme";
+import { InteractionProvider } from "src/components/charts-generic/use-interaction";
+import { Observer, useWidth } from "src/components/charts-generic/use-width";
+import { HistogramFields } from "src/domain/config-types";
+import { GenericObservation } from "src/domain/data";
 import {
   getAnnotationSpaces,
   mkNumber,
   useFormatCurrency,
-} from "../../../domain/helpers";
-import { LEFT_MARGIN_OFFSET } from "../constants";
-import { Tooltip } from "../interaction/tooltip";
-import { LegendSymbol } from "../legends/color";
-import { ChartContext, ChartProps, HistogramState } from "../use-chart-state";
-import { useChartTheme } from "../use-chart-theme";
-import { InteractionProvider } from "../use-interaction";
-import { Observer, useWidth } from "../use-width";
+} from "src/domain/helpers";
+import { estimateTextWidth } from "src/lib/estimate-text-width";
 
 export const ANNOTATION_DOT_RADIUS = 2.5;
 export const ANNOTATION_LABEL_HEIGHT = 20;
@@ -115,7 +117,7 @@ const useHistogramState = ({
       })
     : [{ height: 0, nbOfLines: 1 }];
 
-  const getAnnotationInfo = (d: typeof bins[number]): Tooltip => {
+  const getAnnotationInfo = (d: (typeof bins)[number]): Tooltip => {
     return {
       datum: undefined,
       placement: { x: "center", y: "top" },

--- a/src/components/charts-generic/histogram/histogram.tsx
+++ b/src/components/charts-generic/histogram/histogram.tsx
@@ -1,8 +1,11 @@
 import { useTheme } from "@mui/material";
 import * as React from "react";
 
-import { Column } from "../columns/columns-simple";
-import { HistogramState, useChartState } from "../use-chart-state";
+import { Column } from "src/components/charts-generic/columns/columns-simple";
+import {
+  HistogramState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
 
 export const HistogramColumns = () => {
   const { bounds, xScale, getY, yScale, bins, colors } =

--- a/src/components/charts-generic/histogram/median.tsx
+++ b/src/components/charts-generic/histogram/median.tsx
@@ -7,14 +7,16 @@ import { useFormatCurrency } from "src/domain/helpers";
 import { getLocalizedLabel } from "src/domain/translation";
 
 export const HistogramMedian = ({ label }: { label: string }) => {
-  const { medianValue, bounds, xScale, yScale } =
-    useChartState() as HistogramState;
+  const {
+    medianValue: m,
+    bounds,
+    xScale,
+    yScale,
+  } = useChartState() as HistogramState;
   const { margins } = bounds;
   const { labelColor, domainColor, labelFontSize, fontFamily } =
     useChartTheme();
   const formatCurrency = useFormatCurrency();
-
-  const m = medianValue;
 
   return (
     <>

--- a/src/components/charts-generic/histogram/median.tsx
+++ b/src/components/charts-generic/histogram/median.tsx
@@ -1,9 +1,10 @@
-import * as React from "react";
-
-import { useFormatCurrency } from "../../../domain/helpers";
-import { getLocalizedLabel } from "../../../domain/translation";
-import { HistogramState, useChartState } from "../use-chart-state";
-import { useChartTheme } from "../use-chart-theme";
+import {
+  HistogramState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
+import { useChartTheme } from "src/components/charts-generic/use-chart-theme";
+import { useFormatCurrency } from "src/domain/helpers";
+import { getLocalizedLabel } from "src/domain/translation";
 
 export const HistogramMedian = ({ label }: { label: string }) => {
   const { medianValue, bounds, xScale, yScale } =

--- a/src/components/charts-generic/interaction/hover-dots-multiple.tsx
+++ b/src/components/charts-generic/interaction/hover-dots-multiple.tsx
@@ -1,10 +1,10 @@
 import { Box } from "@mui/material";
 import * as React from "react";
 
-import { GenericObservation } from "../../../domain/data";
-import { LinesState } from "../lines/lines-state";
-import { useChartState } from "../use-chart-state";
-import { useInteraction } from "../use-interaction";
+import { LinesState } from "src/components/charts-generic/lines/lines-state";
+import { useChartState } from "src/components/charts-generic/use-chart-state";
+import { useInteraction } from "src/components/charts-generic/use-interaction";
+import { GenericObservation } from "src/domain/data";
 
 export const HoverDotMultiple = () => {
   const [state] = useInteraction();

--- a/src/components/charts-generic/interaction/hover-dots-multiple.tsx
+++ b/src/components/charts-generic/interaction/hover-dots-multiple.tsx
@@ -8,7 +8,6 @@ import { GenericObservation } from "src/domain/data";
 
 export const HoverDotMultiple = () => {
   const [state] = useInteraction();
-
   const { visible, d } = state.interaction;
 
   return <>{visible && d && <HoverDots d={d} />}</>;
@@ -16,7 +15,6 @@ export const HoverDotMultiple = () => {
 
 const HoverDots = ({ d }: { d: GenericObservation }) => {
   const { getAnnotationInfo, bounds } = useChartState() as LinesState;
-
   const { xAnchor, values } = getAnnotationInfo(d);
 
   return (

--- a/src/components/charts-generic/interaction/ruler.tsx
+++ b/src/components/charts-generic/interaction/ruler.tsx
@@ -1,13 +1,14 @@
 import { Box } from "@mui/material";
-import React from "react";
 
-import { GenericObservation } from "../../../domain/data";
-import { LinesState } from "../lines/lines-state";
-import { useChartState } from "../use-chart-state";
-import { useInteraction } from "../use-interaction";
-import { Margins } from "../use-width";
-
-import { TooltipValue, TooltipPlacement } from "./tooltip";
+import {
+  TooltipPlacement,
+  TooltipValue,
+} from "src/components/charts-generic/interaction/tooltip";
+import { LinesState } from "src/components/charts-generic/lines/lines-state";
+import { useChartState } from "src/components/charts-generic/use-chart-state";
+import { useInteraction } from "src/components/charts-generic/use-interaction";
+import { Margins } from "src/components/charts-generic/use-width";
+import { GenericObservation } from "src/domain/data";
 
 export const Ruler = () => {
   const [state] = useInteraction();

--- a/src/components/charts-generic/interaction/ruler.tsx
+++ b/src/components/charts-generic/interaction/ruler.tsx
@@ -13,6 +13,7 @@ import { GenericObservation } from "src/domain/data";
 export const Ruler = () => {
   const [state] = useInteraction();
   const { visible, d } = state.interaction;
+
   return <>{visible && d && <RulerInner d={d} />}</>;
 };
 
@@ -35,7 +36,12 @@ const RulerInner = ({ d }: { d: GenericObservation }) => {
   );
 };
 
-interface RulerContentProps {
+export const RulerContent = ({
+  xValue,
+  chartHeight,
+  margins,
+  xAnchor,
+}: {
   xValue: string;
   values: TooltipValue[] | undefined;
   chartHeight: number;
@@ -44,14 +50,7 @@ interface RulerContentProps {
   yAnchor: number;
   datum: TooltipValue;
   placement: TooltipPlacement;
-}
-
-export const RulerContent = ({
-  xValue,
-  chartHeight,
-  margins,
-  xAnchor,
-}: RulerContentProps) => {
+}) => {
   return (
     <>
       <Box

--- a/src/components/charts-generic/interaction/tooltip-box.tsx
+++ b/src/components/charts-generic/interaction/tooltip-box.tsx
@@ -5,12 +5,12 @@ import {
   TOOLTIP_OFFSET,
   TRIANGLE_SIZE,
   TooltipPlacement,
-  Xplacement,
-  Yplacement,
+  XPlacement,
+  YPlacement,
 } from "src/components/charts-generic/interaction/tooltip";
 import { Margins } from "src/components/charts-generic/use-width";
 
-export interface TooltipBoxProps {
+type TooltipBoxProps = {
   x: number | undefined;
   y: number | undefined;
   placement: TooltipPlacement;
@@ -18,12 +18,13 @@ export interface TooltipBoxProps {
   children: ReactNode;
   style?: React.HTMLAttributes<HTMLDivElement>["style"];
   interactive?: boolean;
-}
+};
 
 export const TooltipBox = forwardRef<HTMLDivElement, TooltipBoxProps>(
   ({ x, y, placement, margins, children, style, interactive = false }, ref) => {
     const triangle = mkTriangle(placement);
     const theme = useTheme();
+
     return (
       <Box
         ref={ref}
@@ -82,6 +83,7 @@ export const TooltipBoxWithoutChartState = ({
 }: TooltipBoxProps) => {
   const triangle = mkTriangle(placement);
   const theme = useTheme();
+
   return (
     <Box
       style={{
@@ -128,21 +130,6 @@ export const TooltipBoxWithoutChartState = ({
   );
 };
 
-// PLACEMENT ---------------------------------------------------------------------------------------------------
-export interface TooltipAnchorAndPlacementProps {
-  xRef: number;
-  xOffset: number;
-  yRef: number;
-  chartWidth: number;
-  chartHeight: number;
-}
-export interface TooltipAnchorAndPlacement {
-  xAnchor: number;
-  yAnchor: number;
-  xPlacement: Xplacement;
-  yPlacement: Yplacement;
-}
-
 // tooltip anchor position
 const mxYOffset = (yAnchor: number, p: TooltipPlacement) =>
   p.y === "top"
@@ -155,9 +142,9 @@ const mxYOffset = (yAnchor: number, p: TooltipPlacement) =>
 const mkTranslation = (p: TooltipPlacement) =>
   `translate3d(${mkXTranslation(p.x, p.y)}, ${mkYTranslation(p.y)}, 0)`;
 
-type Xtranslation = "-100%" | "-50%" | 0 | string;
+type XTranslation = "-100%" | "-50%" | 0 | string;
 type YTranslation = "-100%" | "-50%" | 0;
-const mkXTranslation = (xP: Xplacement, yP: Yplacement): Xtranslation => {
+const mkXTranslation = (xP: XPlacement, yP: YPlacement): XTranslation => {
   if (yP !== "middle") {
     return xP === "left" ? "-100%" : xP === "center" ? "-50%" : 0;
   } else {
@@ -168,7 +155,7 @@ const mkXTranslation = (xP: Xplacement, yP: Yplacement): Xtranslation => {
       : `${TRIANGLE_SIZE + TOOLTIP_OFFSET}px`;
   }
 };
-const mkYTranslation = (yP: Yplacement): YTranslation =>
+const mkYTranslation = (yP: YPlacement): YTranslation =>
   yP === "top" ? "-100%" : yP === "middle" ? "-50%" : 0;
 
 // triangle position
@@ -251,7 +238,7 @@ const mkTriangle = (p: TooltipPlacement) => {
     case p.x === "left" && p.y === "middle":
       return {
         left: "100%",
-        right: "unset", // -TRIANGLE_SIZE, //`calc(100% + ${TRIANGLE_SIZE * 2}px)`,
+        right: "unset",
         bottom: "unset",
         top: `calc(50% - ${TRIANGLE_SIZE}px)`,
         borderWidth: `${TRIANGLE_SIZE}px 0 ${TRIANGLE_SIZE}px ${TRIANGLE_SIZE}px`,
@@ -262,7 +249,7 @@ const mkTriangle = (p: TooltipPlacement) => {
       };
     case p.x === "right" && p.y === "middle":
       return {
-        left: `${-TRIANGLE_SIZE}px`, //`calc(100% + ${TRIANGLE_SIZE * 2}px)`,
+        left: `${-TRIANGLE_SIZE}px`,
         right: "unset",
         bottom: "unset",
         top: `calc(50% - ${TRIANGLE_SIZE}px)`,
@@ -274,7 +261,7 @@ const mkTriangle = (p: TooltipPlacement) => {
       };
     case p.x === "center" && p.y === "middle":
       return {
-        left: `${-TRIANGLE_SIZE}px`, //`calc(100% + ${TRIANGLE_SIZE * 2}px)`,
+        left: `${-TRIANGLE_SIZE}px`,
         right: "unset",
         bottom: "unset",
         top: `calc(50% - ${TRIANGLE_SIZE}px)`,
@@ -284,7 +271,6 @@ const mkTriangle = (p: TooltipPlacement) => {
         borderBottomColor: `transparent`,
         borderLeftColor: `transparent`,
       };
-
     default:
       return {
         left: `calc(100% - ${TRIANGLE_SIZE * 2}px)`,

--- a/src/components/charts-generic/interaction/tooltip-box.tsx
+++ b/src/components/charts-generic/interaction/tooltip-box.tsx
@@ -1,16 +1,14 @@
-import { Box } from "@mui/material";
-import { useTheme } from "@mui/material";
+import { Box, useTheme } from "@mui/material";
 import React, { ReactNode, forwardRef } from "react";
 
-import { Margins } from "../use-width";
-
 import {
-  TRIANGLE_SIZE,
   TOOLTIP_OFFSET,
+  TRIANGLE_SIZE,
   TooltipPlacement,
   Xplacement,
   Yplacement,
-} from "./tooltip";
+} from "src/components/charts-generic/interaction/tooltip";
+import { Margins } from "src/components/charts-generic/use-width";
 
 export interface TooltipBoxProps {
   x: number | undefined;

--- a/src/components/charts-generic/interaction/tooltip-content.tsx
+++ b/src/components/charts-generic/interaction/tooltip-content.tsx
@@ -6,7 +6,6 @@ import {
   LegendSymbol,
 } from "src/components/charts-generic/legends/color";
 
-// Generic
 export const TooltipSingle = ({
   xValue,
   segment,
@@ -62,7 +61,6 @@ export const TooltipMultiple = ({
   );
 };
 
-// Chart Specific
 export const TooltipHistogram = ({
   firstLine,
   secondLine,

--- a/src/components/charts-generic/interaction/tooltip-content.tsx
+++ b/src/components/charts-generic/interaction/tooltip-content.tsx
@@ -1,8 +1,10 @@
 import { Box, Typography } from "@mui/material";
 
-import { LegendItem, LegendSymbol } from "../legends/color";
-
-import { TooltipValue } from "./tooltip";
+import { TooltipValue } from "src/components/charts-generic/interaction/tooltip";
+import {
+  LegendItem,
+  LegendSymbol,
+} from "src/components/charts-generic/legends/color";
 
 // Generic
 export const TooltipSingle = ({

--- a/src/components/charts-generic/interaction/tooltip.tsx
+++ b/src/components/charts-generic/interaction/tooltip.tsx
@@ -1,12 +1,17 @@
-import React, { ReactNode } from "react";
+import { ReactNode } from "react";
 
-import { GenericObservation } from "../../../domain/data";
-import { LinesState } from "../lines/lines-state";
-import { HistogramState, useChartState } from "../use-chart-state";
-import { useInteraction } from "../use-interaction";
-
-import { TooltipBox } from "./tooltip-box";
-import { TooltipMultiple, TooltipSingle } from "./tooltip-content";
+import { TooltipBox } from "src/components/charts-generic/interaction/tooltip-box";
+import {
+  TooltipMultiple,
+  TooltipSingle,
+} from "src/components/charts-generic/interaction/tooltip-content";
+import { LinesState } from "src/components/charts-generic/lines/lines-state";
+import {
+  HistogramState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
+import { useInteraction } from "src/components/charts-generic/use-interaction";
+import { GenericObservation } from "src/domain/data";
 
 export const TRIANGLE_SIZE = 8;
 export const TOOLTIP_OFFSET = 4;

--- a/src/components/charts-generic/interaction/tooltip.tsx
+++ b/src/components/charts-generic/interaction/tooltip.tsx
@@ -19,23 +19,22 @@ export const TOOLTIP_OFFSET = 4;
 export const Tooltip = ({ type = "single" }: { type: TooltipType }) => {
   const [state] = useInteraction();
   const { visible, mouse, d } = state.interaction;
+
   return (
     <>{visible && d && <TooltipInner d={d} mouse={mouse} type={type} />}</>
   );
 };
 
-export type Xplacement = "left" | "center" | "right";
-export type Yplacement = "top" | "middle" | "bottom";
-export type TooltipPlacement = { x: Xplacement; y: Yplacement };
-
-export type TooltipType = "single" | "multiple" | "histogram";
-export interface TooltipValue {
+export type XPlacement = "left" | "center" | "right";
+export type YPlacement = "top" | "middle" | "bottom";
+export type TooltipPlacement = { x: XPlacement; y: YPlacement };
+type TooltipType = "single" | "multiple" | "histogram";
+export type TooltipValue = {
   label?: string;
   value: string;
   color?: string;
   yPos?: number;
-}
-
+};
 type TooltipCommon = {
   xAnchor: number;
   yAnchor: number;

--- a/src/components/charts-generic/legends/color.tsx
+++ b/src/components/charts-generic/legends/color.tsx
@@ -47,7 +47,7 @@ export const LegendSymbol = ({
         borderRadius: symbol === "circle" ? "50%" : 0,
         bgcolor: color,
       }}
-    ></Box>
+    />
   );
 };
 

--- a/src/components/charts-generic/legends/color.tsx
+++ b/src/components/charts-generic/legends/color.tsx
@@ -1,8 +1,10 @@
 import { Box } from "@mui/material";
-import * as React from "react";
 import { memo } from "react";
 
-import { ColumnsState, useChartState } from "../use-chart-state";
+import {
+  ColumnsState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
 
 type LegendSymbol = "square" | "line" | "circle";
 

--- a/src/components/charts-generic/lines/lines-state.tsx
+++ b/src/components/charts-generic/lines/lines-state.tsx
@@ -105,13 +105,11 @@ const useLinesState = ({
     [fields.style]
   );
 
-  // data
   const sortedData = useMemo(
     () => [...data].sort((a, b) => ascending(getX(a), getX(b))),
     [data, getX]
   );
 
-  // x
   const xUniqueValues = sortedData
     .map((d) => getX(d))
     .filter(
@@ -125,20 +123,16 @@ const useLinesState = ({
   const xAxisLabel =
     measures.find((d) => d.iri === fields.x.componentIri)?.label ??
     fields.x.componentIri;
-  // y
+
   const minValue = min(sortedData, getY) || 0;
   const maxValue = max(sortedData, getY) as number;
   const yDomain = [minValue, maxValue];
 
-  let yScale = scaleLinear().domain(yDomain).nice(4);
-  yScale = roundDomain(yScale);
-
+  const yScale = roundDomain(scaleLinear().domain(yDomain).nice(4));
   const yAxisLabel = "unit";
 
-  // segments
   const segments = [...new Set(sortedData.map(getSegment))];
 
-  // Map ordered segments to colors
   const colorDomain = fields.style?.colorDomain
     ? fields.style?.colorDomain
     : [""];
@@ -158,6 +152,7 @@ const useLinesState = ({
       const thisYear = lineData[1].find(
         (d) => getX(d).getFullYear() === xValue.getFullYear()
       );
+
       if (!thisYear) {
         lineData[1].push({
           period: `${xValue.getFullYear()}`,
@@ -180,7 +175,6 @@ const useLinesState = ({
   const floatingPointExtra =
     Math.abs(yDomain[yDomain.length - 1] - yDomain[0]) === 1 ? 10 : 0;
 
-  // Dimensions
   const left = Math.max(
     estimateTextWidth(minText) + floatingPointExtra,
     estimateTextWidth(maxText) + floatingPointExtra
@@ -222,7 +216,7 @@ const useLinesState = ({
   }
 
   const entity = fields.style?.entity || "";
-  // Tooltip
+
   const getAnnotationInfo = (datum: GenericObservation): Tooltip => {
     const xAnchor = xScale(getX(datum));
     const yAnchor = yScale(getY(datum));
@@ -230,7 +224,6 @@ const useLinesState = ({
     const tooltipValues = data.filter(
       (j) => getX(j).getTime() === getX(datum).getTime()
     );
-    // console.log({ tooltipValues });
     const groupedTooltipValues = groups(
       tooltipValues,
       (d: GenericObservation) => getColor(d),
@@ -265,14 +258,7 @@ const useLinesState = ({
       )
     );
 
-    // const sortedTooltipValues = sortByIndex({
-    //   data: tooltipValues,
-    //   order: segments,
-    //   getCategory: getSegment,
-    //   sortOrder: "asc",
-    // });
     const xPlacement = xAnchor < chartWidth * 0.5 ? "right" : "left";
-
     const yPlacement = "middle";
 
     return {

--- a/src/components/charts-generic/lines/lines-state.tsx
+++ b/src/components/charts-generic/lines/lines-state.tsx
@@ -16,25 +16,30 @@ import {
   ScaleTime,
   scaleTime,
 } from "d3-scale";
-import * as React from "react";
 import { ReactNode, useCallback, useMemo } from "react";
 
-import { estimateTextWidth } from "src/lib/estimate-text-width";
-
-import { LineFields } from "../../../domain/config-types";
-import { GenericObservation, ObservationValue } from "../../../domain/data";
+import { LEFT_MARGIN_OFFSET } from "src/components/charts-generic/constants";
+import { Tooltip } from "src/components/charts-generic/interaction/tooltip";
+import {
+  ChartContext,
+  ChartProps,
+} from "src/components/charts-generic/use-chart-state";
+import { InteractionProvider } from "src/components/charts-generic/use-interaction";
+import {
+  Bounds,
+  Observer,
+  useWidth,
+} from "src/components/charts-generic/use-width";
+import { LineFields } from "src/domain/config-types";
+import { GenericObservation, ObservationValue } from "src/domain/data";
 import {
   getPalette,
   parseDate,
   useFormatCurrency,
   useFormatFullDateAuto,
-} from "../../../domain/helpers";
-import { getLocalizedLabel } from "../../../domain/translation";
-import { LEFT_MARGIN_OFFSET } from "../constants";
-import { Tooltip } from "../interaction/tooltip";
-import { ChartContext, ChartProps } from "../use-chart-state";
-import { InteractionProvider } from "../use-interaction";
-import { Bounds, Observer, useWidth } from "../use-width";
+} from "src/domain/helpers";
+import { getLocalizedLabel } from "src/domain/translation";
+import { estimateTextWidth } from "src/lib/estimate-text-width";
 
 export interface LinesState {
   data: GenericObservation[];

--- a/src/components/charts-generic/lines/lines.tsx
+++ b/src/components/charts-generic/lines/lines.tsx
@@ -3,10 +3,9 @@ import { ascending } from "d3-array";
 import { line } from "d3-shape";
 import * as React from "react";
 
-import { GenericObservation } from "../../../domain/data";
-import { useChartState } from "../use-chart-state";
-
-import { LinesState } from "./lines-state";
+import { LinesState } from "src/components/charts-generic/lines/lines-state";
+import { useChartState } from "src/components/charts-generic/use-chart-state";
+import { GenericObservation } from "src/domain/data";
 
 export const Lines = () => {
   const { getX, xScale, getY, yScale, grouped, colors, getColor, bounds } =

--- a/src/components/charts-generic/lines/lines.tsx
+++ b/src/components/charts-generic/lines/lines.tsx
@@ -16,44 +16,27 @@ export const Lines = () => {
     .x((d) => xScale(getX(d)))
     .y((d) => yScale(getY(d)))
     .defined((d) => !isNaN(getY(d)) || getY(d) === undefined);
+
   return (
-    <>
-      {/* <g transform={`translate(${bounds.margins.left} ${bounds.margins.top})`}>
-        {grouped.map((lineData, index) => {
-          return (
-            <>
-              {lineData[1].map((d) => (
-                <circle
-                  cx={xScale(getX(d))}
-                  cy={yScale(getY(d))}
-                  r={4}
-                  fill="hotpink"
-                />
-              ))}
-            </>
-          );
-        })}
-      </g> */}
-      <g transform={`translate(${bounds.margins.left} ${bounds.margins.top})`}>
-        {grouped.map((lineData, index) => {
-          return (
-            <Line
-              key={index}
-              path={
-                lineGenerator(
-                  lineData[1].sort((a, b) => ascending(getX(a), getX(b)))
-                ) as string
-              }
-              color={
-                grouped.length > 1
-                  ? colors(getColor(lineData[1][0]))
-                  : theme.palette.primary.main
-              }
-            />
-          );
-        })}
-      </g>
-    </>
+    <g transform={`translate(${bounds.margins.left} ${bounds.margins.top})`}>
+      {grouped.map((lineData, index) => {
+        return (
+          <Line
+            key={index}
+            path={
+              lineGenerator(
+                lineData[1].sort((a, b) => ascending(getX(a), getX(b)))
+              ) as string
+            }
+            color={
+              grouped.length > 1
+                ? colors(getColor(lineData[1][0]))
+                : theme.palette.primary.main
+            }
+          />
+        );
+      })}
+    </g>
   );
 };
 

--- a/src/components/charts-generic/overlay/interaction-histogram.tsx
+++ b/src/components/charts-generic/overlay/interaction-histogram.tsx
@@ -53,7 +53,7 @@ export const InteractionHistogram = ({
       </g>
       {debug && (
         <>
-          <g transform={`translate(0, 0)`}>
+          <g>
             <rect
               x={0}
               y={0}

--- a/src/components/charts-generic/overlay/interaction-histogram.tsx
+++ b/src/components/charts-generic/overlay/interaction-histogram.tsx
@@ -1,8 +1,9 @@
-import * as React from "react";
-
-import { GenericObservation } from "../../../domain/data";
-import { HistogramState, useChartState } from "../use-chart-state";
-import { useInteraction } from "../use-interaction";
+import {
+  HistogramState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
+import { useInteraction } from "src/components/charts-generic/use-interaction";
+import { GenericObservation } from "src/domain/data";
 
 export const InteractionHistogram = ({
   debug = false,

--- a/src/components/charts-generic/overlay/interaction-horizontal.tsx
+++ b/src/components/charts-generic/overlay/interaction-horizontal.tsx
@@ -2,9 +2,12 @@ import { bisector, pointer } from "d3";
 import * as React from "react";
 import { useRef } from "react";
 
-import { GenericObservation } from "../../../domain/data";
-import { AreasState, useChartState } from "../use-chart-state";
-import { useInteraction } from "../use-interaction";
+import {
+  AreasState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
+import { useInteraction } from "src/components/charts-generic/use-interaction";
+import { GenericObservation } from "src/domain/data";
 
 export const InteractionHorizontal = React.memo(() => {
   const [, dispatch] = useInteraction();

--- a/src/components/charts-generic/overlay/interaction-rows.tsx
+++ b/src/components/charts-generic/overlay/interaction-rows.tsx
@@ -45,7 +45,7 @@ export const InteractionRows = ({ debug = false }: { debug?: boolean }) => {
       </g>
       {debug && (
         <>
-          <g transform={`translate(0, 0)`}>
+          <g>
             <rect
               x={0}
               y={0}

--- a/src/components/charts-generic/overlay/interaction-rows.tsx
+++ b/src/components/charts-generic/overlay/interaction-rows.tsx
@@ -1,8 +1,9 @@
-import * as React from "react";
-
-import { GenericObservation } from "../../../domain/data";
-import { RangePlotState, useChartState } from "../use-chart-state";
-import { useInteraction } from "../use-interaction";
+import {
+  RangePlotState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
+import { useInteraction } from "src/components/charts-generic/use-interaction";
+import { GenericObservation } from "src/domain/data";
 
 export const InteractionRows = ({ debug = false }: { debug?: boolean }) => {
   const [, dispatch] = useInteraction();

--- a/src/components/charts-generic/rangeplot/rangeplot-median.tsx
+++ b/src/components/charts-generic/rangeplot/rangeplot-median.tsx
@@ -7,14 +7,16 @@ import { useFormatCurrency } from "src/domain/helpers";
 import { getLocalizedLabel } from "src/domain/translation";
 
 export const RangeplotMedian = ({ label }: { label: string }) => {
-  const { medianValue, bounds, xScale, yScale } =
-    useChartState() as RangePlotState;
+  const {
+    medianValue: m,
+    bounds,
+    xScale,
+    yScale,
+  } = useChartState() as RangePlotState;
   const { margins } = bounds;
   const { labelColor, domainColor, labelFontSize, fontFamily } =
     useChartTheme();
   const formatCurrency = useFormatCurrency();
-
-  const m = medianValue;
 
   return (
     <>

--- a/src/components/charts-generic/rangeplot/rangeplot-median.tsx
+++ b/src/components/charts-generic/rangeplot/rangeplot-median.tsx
@@ -1,9 +1,10 @@
-import * as React from "react";
-
-import { useFormatCurrency } from "../../../domain/helpers";
-import { getLocalizedLabel } from "../../../domain/translation";
-import { RangePlotState, useChartState } from "../use-chart-state";
-import { useChartTheme } from "../use-chart-theme";
+import {
+  RangePlotState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
+import { useChartTheme } from "src/components/charts-generic/use-chart-theme";
+import { useFormatCurrency } from "src/domain/helpers";
+import { getLocalizedLabel } from "src/domain/translation";
 
 export const RangeplotMedian = ({ label }: { label: string }) => {
   const { medianValue, bounds, xScale, yScale } =

--- a/src/components/charts-generic/rangeplot/rangeplot-state.tsx
+++ b/src/components/charts-generic/rangeplot/rangeplot-state.tsx
@@ -9,29 +9,31 @@ import {
   scaleBand,
   scaleLinear,
 } from "d3";
-import * as React from "react";
 import { ReactNode, useCallback } from "react";
 
-import { minMaxBy } from "src/lib/array";
-import { estimateTextWidth } from "src/lib/estimate-text-width";
-
+import { LEFT_MARGIN_OFFSET } from "src/components/charts-generic/constants";
+import { Tooltip } from "src/components/charts-generic/interaction/tooltip";
+import {
+  ChartContext,
+  ChartProps,
+  RangePlotState,
+} from "src/components/charts-generic/use-chart-state";
+import { useChartTheme } from "src/components/charts-generic/use-chart-theme";
+import { InteractionProvider } from "src/components/charts-generic/use-interaction";
+import { Observer, useWidth } from "src/components/charts-generic/use-width";
 import {
   RangePlotFields,
   SortingOrder,
   SortingType,
-} from "../../../domain/config-types";
-import { GenericObservation } from "../../../domain/data";
+} from "src/domain/config-types";
+import { GenericObservation } from "src/domain/data";
 import {
   getAnnotationSpaces,
   mkNumber,
   useFormatCurrency,
-} from "../../../domain/helpers";
-import { LEFT_MARGIN_OFFSET } from "../constants";
-import { Tooltip } from "../interaction/tooltip";
-import { ChartContext, ChartProps, RangePlotState } from "../use-chart-state";
-import { useChartTheme } from "../use-chart-theme";
-import { InteractionProvider } from "../use-interaction";
-import { Observer, useWidth } from "../use-width";
+} from "src/domain/helpers";
+import { minMaxBy } from "src/lib/array";
+import { estimateTextWidth } from "src/lib/estimate-text-width";
 
 export const DOT_RADIUS = 8;
 export const OUTER_PADDING = 0.2;

--- a/src/components/charts-generic/rangeplot/rangeplot-state.tsx
+++ b/src/components/charts-generic/rangeplot/rangeplot-state.tsx
@@ -53,13 +53,6 @@ const useRangePlotState = ({
     (d: GenericObservation) => d[fields.x.componentIri] as number,
     [fields.x.componentIri]
   );
-  // const getY = useCallback(
-  //   (d: Observation) =>
-  //     fields.y && fields.y.componentIri
-  //       ? (d[fields.y.componentIri] as string)
-  //       : undefined,
-  //   [fields.y]
-  // );
   const getY = useCallback(
     (d: GenericObservation) => d[fields.y.componentIri] as string,
     [fields.y.componentIri]
@@ -75,10 +68,9 @@ const useRangePlotState = ({
   const xDomain = [0, mkNumber(maxValue)];
   const xScale = scaleLinear().domain(xDomain).nice();
 
-  // Sort data
   const sortingType = fields.y.sorting?.sortingType;
   const sortingOrder = fields.y.sorting?.sortingOrder;
-  // Default sorting order by ascending median
+
   const yDomain =
     sortingType && sortingOrder
       ? sortDomain({ sortingType, sortingOrder, data, getX, getY })
@@ -153,7 +145,6 @@ const useRangePlotState = ({
   xScale.range([0, chartWidth]);
   yScale.range([0, chartHeight]);
 
-  // Group
   const rangeGroups = [...group(data, getY)];
 
   const getAnnotationInfo = (d: GenericObservation): Tooltip => {
@@ -163,6 +154,7 @@ const useRangePlotState = ({
     );
 
     const yAnchor = yScale(getY(d));
+
     return {
       xAnchor: xScale(getX(tooltipValues[1])) + 10,
       yAnchor: yAnchor ? yAnchor + margins.top + DOT_RADIUS : 0,
@@ -181,7 +173,6 @@ const useRangePlotState = ({
     };
   };
 
-  // Annotations
   const annotations =
     annotation &&
     annotation
@@ -231,6 +222,7 @@ const RangePlotProvider = ({
     measures,
     medianValue,
   });
+
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
@@ -282,7 +274,6 @@ const sortDomain = ({
       )
       .map((d) => d[0]);
   } else {
-    // by median
     return [
       ...rollup(
         data,

--- a/src/components/charts-generic/rangeplot/rangeplot-state.tsx
+++ b/src/components/charts-generic/rangeplot/rangeplot-state.tsx
@@ -47,7 +47,7 @@ const useRangePlotState = ({
 }): RangePlotState => {
   const width = useWidth();
   const formatCurrency = useFormatCurrency();
-  const { annotationfontSize, palette } = useChartTheme();
+  const { annotationFontSize, palette } = useChartTheme();
 
   const getX = useCallback(
     (d: GenericObservation) => d[fields.x.componentIri] as number,
@@ -123,7 +123,7 @@ const useRangePlotState = ({
         getLabel,
         format: formatCurrency,
         width,
-        annotationfontSize,
+        annotationFontSize,
       })
     : [{ height: 0, nbOfLines: 1 }];
 

--- a/src/components/charts-generic/rangeplot/rangeplot.tsx
+++ b/src/components/charts-generic/rangeplot/rangeplot.tsx
@@ -15,7 +15,6 @@ import { normalize } from "src/lib/array";
 export const Range = ({ id }: { id: string }) => {
   const { bounds, xScale, getX, yScale, colors, rangeGroups } =
     useChartState() as RangePlotState;
-
   const { margins, chartWidth } = bounds;
 
   return (

--- a/src/components/charts-generic/rangeplot/rangeplot.tsx
+++ b/src/components/charts-generic/rangeplot/rangeplot.tsx
@@ -2,14 +2,15 @@ import { useTheme } from "@mui/material";
 import { max, median, min } from "d3-array";
 import * as React from "react";
 
+import { DOT_RADIUS } from "src/components/charts-generic/rangeplot/rangeplot-state";
+import {
+  RangePlotState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
+import { useChartTheme } from "src/components/charts-generic/use-chart-theme";
+import { useInteraction } from "src/components/charts-generic/use-interaction";
+import { isNumber } from "src/domain/helpers";
 import { normalize } from "src/lib/array";
-
-import { isNumber } from "../../../domain/helpers";
-import { RangePlotState, useChartState } from "../use-chart-state";
-import { useChartTheme } from "../use-chart-theme";
-import { useInteraction } from "../use-interaction";
-
-import { DOT_RADIUS } from "./rangeplot-state";
 
 export const Range = ({ id }: { id: string }) => {
   const { bounds, xScale, getX, yScale, colors, rangeGroups } =

--- a/src/components/charts-generic/use-chart-state.tsx
+++ b/src/components/charts-generic/use-chart-state.tsx
@@ -1,22 +1,15 @@
-import {
-  ScaleLinear,
-  ScaleBand,
-  ScaleOrdinal,
-  ScaleTime,
-  Bin,
-} from "d3";
+import { Bin, ScaleBand, ScaleLinear, ScaleOrdinal, ScaleTime } from "d3";
 import { createContext, useContext } from "react";
 
-import { ChartFields } from "../../domain/config-types";
+import { Annotation } from "src/components/charts-generic/annotation/annotation-x";
+import { Tooltip } from "src/components/charts-generic/interaction/tooltip";
+import { Bounds } from "src/components/charts-generic/use-width";
+import { ChartFields } from "src/domain/config-types";
 import {
   ComponentFieldsFragment,
   GenericObservation,
   ObservationValue,
-} from "../../domain/data";
-
-import { Annotation } from "./annotation/annotation-x";
-import { Tooltip } from "./interaction/tooltip";
-import { Bounds } from "./use-width";
+} from "src/domain/data";
 
 export interface ChartProps {
   data: GenericObservation[];

--- a/src/components/charts-generic/use-chart-state.tsx
+++ b/src/components/charts-generic/use-chart-state.tsx
@@ -11,15 +11,15 @@ import {
   ObservationValue,
 } from "src/domain/data";
 
-export interface ChartProps {
+export type ChartProps = {
   data: GenericObservation[];
   fields: ChartFields;
   dimensions: ComponentFieldsFragment[];
   measures: ComponentFieldsFragment[];
   medianValue: number | undefined;
-}
+};
 
-export interface GroupedColumnsState {
+export type GroupedColumnsState = {
   sortedData: GenericObservation[];
   bounds: Bounds;
   getX: (d: GenericObservation) => string;
@@ -34,9 +34,9 @@ export interface GroupedColumnsState {
   yAxisLabel: string;
   grouped: [string, Record<string, ObservationValue>[]][];
   getAnnotationInfo: (d: GenericObservation) => Tooltip;
-}
+};
 
-export interface RangePlotState {
+export type RangePlotState = {
   bounds: Bounds;
   data: GenericObservation[];
   medianValue: number | undefined;
@@ -48,9 +48,9 @@ export interface RangePlotState {
   rangeGroups: [string, Record<string, ObservationValue>[]][];
   annotations?: Annotation[];
   getAnnotationInfo: (d: GenericObservation) => Tooltip;
-}
+};
 
-export interface AreasState {
+export type AreasState = {
   data: GenericObservation[];
   bounds: Bounds;
   getX: (d: GenericObservation) => Date;
@@ -65,23 +65,9 @@ export interface AreasState {
   wide: { [key: string]: number | string }[];
   series: $FixMe[];
   getAnnotationInfo: (d: GenericObservation) => Tooltip;
-}
+};
 
-export interface RangePlotState {
-  bounds: Bounds;
-  data: GenericObservation[];
-  medianValue: number | undefined;
-  getX: (d: GenericObservation) => number;
-  xScale: ScaleLinear<number, number>;
-  getY: (d: GenericObservation) => string;
-  yScale: ScaleBand<string>;
-  colors: ScaleLinear<string, string>;
-  rangeGroups: [string, Record<string, ObservationValue>[]][];
-  annotations?: Annotation[];
-  getAnnotationInfo: (d: GenericObservation) => Tooltip;
-}
-
-export interface GroupedBarsState {
+export type GroupedBarsState = {
   sortedData: GenericObservation[];
   bounds: Bounds;
   getX: (d: GenericObservation) => number;
@@ -94,9 +80,9 @@ export interface GroupedBarsState {
   segments: string[];
   colors: ScaleOrdinal<string, string>;
   opacityScale: ScaleOrdinal<string, number>;
-}
+};
 
-export interface BarsState {
+export type BarsState = {
   bounds: Bounds;
   sortedData: GenericObservation[];
   getX: (d: GenericObservation) => number;
@@ -106,9 +92,9 @@ export interface BarsState {
   getSegment: (d: GenericObservation) => string;
   segments: string[];
   colors: ScaleOrdinal<string, string>;
-}
+};
 
-export interface LinesState {
+export type LinesState = {
   data: GenericObservation[];
   bounds: Bounds;
   segments: string[];
@@ -126,9 +112,9 @@ export interface LinesState {
   wide: ArrayLike<Record<string, ObservationValue>>;
   xKey: string;
   getAnnotationInfo: (d: GenericObservation) => Tooltip;
-}
+};
 
-export interface HistogramState {
+export type HistogramState = {
   bounds: Bounds;
   data: GenericObservation[];
   medianValue: number | undefined;
@@ -142,9 +128,9 @@ export interface HistogramState {
   colors: ScaleLinear<string, string>;
   annotations?: Annotation[];
   getAnnotationInfo: (d: GenericObservation) => Tooltip;
-}
+};
 
-export interface ColumnsState {
+export type ColumnsState = {
   bounds: Bounds;
   sortedData: GenericObservation[];
   getX: (d: GenericObservation) => string;
@@ -157,9 +143,9 @@ export interface ColumnsState {
   colors: ScaleOrdinal<string, string>;
   yAxisLabel: string;
   getAnnotationInfo: (d: GenericObservation) => Tooltip;
-}
+};
 
-export interface StackedColumnsState {
+export type StackedColumnsState = {
   sortedData: GenericObservation[];
   bounds: Bounds;
   getX: (d: GenericObservation) => string;
@@ -178,7 +164,7 @@ export interface StackedColumnsState {
     d: GenericObservation,
     orderedSegments: string[]
   ) => Tooltip;
-}
+};
 
 export type ChartState =
   | ColumnsState
@@ -203,13 +189,3 @@ export const useChartState = () => {
   }
   return ctx;
 };
-
-// export type SharedChartState = {
-//   bounds: Bounds;
-//   data: Observation[];
-//   getX: (d: Observation) => number;
-//   xScale: ScaleLinear<number, number>;
-//   getY: (d: Observation) => string | number;
-//   yScale: ScaleBand<string> | ScaleLinear<number, number>;
-//   colors: ScaleLinear<string, string> | ScaleThreshold<number, string>;
-// };

--- a/src/components/charts-generic/use-chart-theme.ts
+++ b/src/components/charts-generic/use-chart-theme.ts
@@ -11,11 +11,12 @@ export const useChartTheme = () => {
   const axisLabelColor = theme.palette.grey[800];
   const labelFontSize = 12;
   const fontFamily = theme.typography.fontFamily as string;
-  const annotationfontSize = 12;
+  const annotationFontSize = 12;
   const annotationColor = theme.palette.grey[900];
   const annotationLineColor = theme.palette.grey[500];
   const annotationLabelUnderlineColor = theme.palette.grey[700];
   const markBorderColor = theme.palette.grey[100];
+
   return {
     axisLabelFontSize,
     axisLabelColor,
@@ -26,7 +27,7 @@ export const useChartTheme = () => {
     gridColor,
     legendLabelColor,
     fontFamily,
-    annotationfontSize,
+    annotationFontSize,
     annotationColor,
     annotationLineColor,
     annotationLabelUnderlineColor,

--- a/src/components/charts-generic/use-interaction.tsx
+++ b/src/components/charts-generic/use-interaction.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   createContext,
   Dispatch,
   ReactNode,
@@ -6,7 +6,7 @@ import React, {
   useReducer,
 } from "react";
 
-import { GenericObservation } from "../../domain/data";
+import { GenericObservation } from "src/domain/data";
 
 export interface InteractionElement {
   visible: boolean;

--- a/src/components/charts-generic/use-interaction.tsx
+++ b/src/components/charts-generic/use-interaction.tsx
@@ -8,15 +8,13 @@ import {
 
 import { GenericObservation } from "src/domain/data";
 
-export interface InteractionElement {
-  visible: boolean;
-  mouse?: { x: number; y: number } | undefined;
-  d: GenericObservation | undefined;
-}
-
-interface InteractionState {
-  interaction: InteractionElement;
-}
+type InteractionState = {
+  interaction: {
+    visible: boolean;
+    mouse?: { x: number; y: number } | undefined;
+    d: GenericObservation | undefined;
+  };
+};
 
 type InteractionStateAction =
   | {
@@ -35,7 +33,6 @@ const INTERACTION_INITIAL_STATE: InteractionState = {
   },
 };
 
-// Reducer
 const InteractionStateReducer = (
   state: InteractionState,
   action: InteractionStateAction
@@ -71,7 +68,6 @@ const InteractionStateReducer = (
   }
 };
 
-// Provider
 const InteractionStateContext = createContext<
   [InteractionState, Dispatch<InteractionStateAction>] | undefined
 >(undefined);
@@ -86,7 +82,6 @@ export const useInteraction = () => {
   return ctx;
 };
 
-// Component
 export const InteractionProvider = ({ children }: { children: ReactNode }) => {
   const [state, dispatch] = useReducer(
     InteractionStateReducer,

--- a/src/components/charts-generic/use-width.tsx
+++ b/src/components/charts-generic/use-width.tsx
@@ -1,24 +1,24 @@
-import React, { createContext, ReactNode, useContext } from "react";
+import { createContext, ReactNode, useContext } from "react";
 
 import { useResizeObserver } from "src/lib/use-resize-observer";
 
-export interface Margins {
+export type Margins = {
   annotations?: number;
   top: number;
   right: number;
   bottom: number;
   left: number;
-}
-export type Width = number;
-export interface Bounds {
+};
+
+export type Bounds = {
   width: number;
   height: number;
   margins: Margins;
   chartWidth: number;
   chartHeight: number;
-}
+};
 
-const INITIAL_WIDTH: Width = 1;
+const INITIAL_WIDTH = 1;
 
 export const Observer = ({ children }: { children: ReactNode }) => {
   const [resizeRef, width] = useResizeObserver<HTMLDivElement>();
@@ -34,14 +34,16 @@ export const Observer = ({ children }: { children: ReactNode }) => {
   );
 };
 
-const ChartObserverContext = createContext<Width>(INITIAL_WIDTH);
+const ChartObserverContext = createContext(INITIAL_WIDTH);
 
 export const useWidth = () => {
   const ctx = useContext(ChartObserverContext);
+
   if (ctx === undefined) {
     throw Error(
       "You need to wrap your component in <ChartObserverContextProvider /> to useWidth()"
     );
   }
+
   return ctx;
 };

--- a/src/components/combobox.tsx
+++ b/src/components/combobox.tsx
@@ -2,11 +2,11 @@ import { t } from "@lingui/macro";
 import { Box, outlinedInputClasses, Typography } from "@mui/material";
 import Autocomplete, { autocompleteClasses } from "@mui/material/Autocomplete";
 import TextField, { TextFieldProps } from "@mui/material/TextField";
-import { useState, useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-import { Icon } from "../icons";
+import { InfoDialogButton } from "src/components/info-dialog";
+import { Icon } from "src/icons";
 
-import { InfoDialogButton } from "./info-dialog";
 export type ComboboxMultiProps = {
   id: string;
   label: React.ReactNode;

--- a/src/components/combobox.tsx
+++ b/src/components/combobox.tsx
@@ -45,7 +45,7 @@ export const ComboboxMulti = ({
       id={id}
       options={items}
       value={selectedItems}
-      onChange={(event, newValue) => {
+      onChange={(_, newValue) => {
         setSelectedItems(newValue);
       }}
       popupIcon={<Icon name="chevrondown" color="black" />}
@@ -135,18 +135,7 @@ export const ComboboxMulti = ({
   );
 };
 
-interface ComboboxProps {
-  id: string;
-  label: string;
-  items: (string | { type: "header"; title: string })[];
-  selectedItem: string;
-  setSelectedItem: (selectedItem: string) => void;
-  getItemLabel?: (item: string) => string;
-  showLabel?: boolean;
-  infoDialogSlug?: string;
-}
-
-export const Combobox: React.FC<ComboboxProps> = ({
+export const Combobox = ({
   id,
   label,
   items,
@@ -155,6 +144,15 @@ export const Combobox: React.FC<ComboboxProps> = ({
   infoDialogSlug,
   getItemLabel = defaultGetItemLabel,
   showLabel = true,
+}: {
+  id: string;
+  label: string;
+  items: (string | { type: "header"; title: string })[];
+  selectedItem: string;
+  setSelectedItem: (selectedItem: string) => void;
+  getItemLabel?: (item: string) => string;
+  showLabel?: boolean;
+  infoDialogSlug?: string;
 }) => {
   const [inputValue, setInputValue] = useState(getItemLabel(selectedItem));
 
@@ -166,7 +164,7 @@ export const Combobox: React.FC<ComboboxProps> = ({
     return items.filter((item) => typeof item === "string");
   }, [items]);
 
-  const groupsBylabel = useMemo(() => {
+  const groupsByLabel = useMemo(() => {
     const res: Record<string, string> = {};
     let currentGroup = null;
     for (const item of items) {
@@ -206,7 +204,7 @@ export const Combobox: React.FC<ComboboxProps> = ({
         id={`combobox-${id}`}
         options={filteredItems as string[]}
         groupBy={(option) => {
-          return groupsBylabel[option];
+          return groupsByLabel[option];
         }}
         renderGroup={(params) => {
           return (

--- a/src/components/detail-page/banner.tsx
+++ b/src/components/detail-page/banner.tsx
@@ -10,6 +10,7 @@ import { Entity } from "src/domain/data";
 import { Icon } from "src/icons";
 
 const TRUNCATE_COUNT = 5;
+
 const RelationsList = ({
   relations,
   relationPathname,
@@ -71,6 +72,7 @@ export const DetailPageBanner = ({
   municipalities?: { id: string; name: string }[];
 }) => {
   const { query } = useRouter();
+
   return (
     <Box
       sx={{
@@ -99,17 +101,9 @@ export const DetailPageBanner = ({
           ],
           gap: 0,
           alignItems: "center",
-          // flexDirection: ["column", "column", "row"],
-          // justifyContent: "flex-start",
-          // alignItems: ["flex-start", "flex-start", "center"],
-          // width: "100%",
         }}
       >
-        <Box
-          sx={{
-            gridArea: "back",
-          }}
-        >
+        <Box sx={{ gridArea: "back" }}>
           <UILink
             variant="inline"
             component={HomeLink}

--- a/src/components/detail-page/banner.tsx
+++ b/src/components/detail-page/banner.tsx
@@ -1,13 +1,13 @@
 import { Trans } from "@lingui/macro";
-import { Box, Button, Link as UILink, Typography } from "@mui/material";
+import { Box, Button, Typography, Link as UILink } from "@mui/material";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { Fragment, useState } from "react";
 
-import { Entity } from "../../domain/data";
-import { Icon } from "../../icons";
-import { HomeLink } from "../links";
-import { Search } from "../search";
+import { HomeLink } from "src/components/links";
+import { Search } from "src/components/search";
+import { Entity } from "src/domain/data";
+import { Icon } from "src/icons";
 
 const TRUNCATE_COUNT = 5;
 const RelationsList = ({

--- a/src/components/detail-page/cantons-comparison-range.tsx
+++ b/src/components/detail-page/cantons-comparison-range.tsx
@@ -30,7 +30,7 @@ import { Loading, NoDataHint } from "src/components/hint";
 import { InfoDialogButton } from "src/components/info-dialog";
 import { PriceColorLegend } from "src/components/price-color-legend";
 import { RadioTabs } from "src/components/radio-tabs";
-import Stack from "src/components/stack";
+import { Stack } from "src/components/stack";
 import { SortingOrder, SortingType } from "src/domain/config-types";
 import { Entity, GenericObservation, priceComponents } from "src/domain/data";
 import { getLocalizedLabel } from "src/domain/translation";
@@ -46,12 +46,14 @@ import { useQueryState } from "src/lib/use-query-state";
 const DOWNLOAD_ID: Download = "comparison";
 
 type SortingValue = "median-asc" | "median-desc" | "alpha-asc" | "alpha-desc";
+
 const SORTING_VALUES: SortingValue[] = [
   "median-asc",
   "median-desc",
   "alpha-asc",
   "alpha-desc",
 ];
+
 export const CantonsComparisonRangePlots = ({
   id,
   entity,
@@ -127,8 +129,6 @@ export const CantonsComparisonRangePlots = ({
         </Stack>
       }
       downloadId={DOWNLOAD_ID}
-      id={id}
-      entity={entity}
     >
       {!download && (
         <>
@@ -167,7 +167,7 @@ export const CantonsComparisonRangePlots = ({
               id="priceComponents-cantons-comparison"
               label={t({
                 id: "selector.priceComponents",
-                message: `Preiskomponenten`,
+                message: "Preiskomponenten",
               })}
               items={priceComponents}
               getItemLabel={getItemLabel}
@@ -187,7 +187,7 @@ export const CantonsComparisonRangePlots = ({
             <Combobox
               label={t({
                 id: "rangeplot.select.order.hint",
-                message: `Sortieren nach`,
+                message: "Sortieren nach",
               })}
               id={"rangeplot-sorting-select"}
               items={SORTING_VALUES}

--- a/src/components/detail-page/cantons-comparison-range.tsx
+++ b/src/components/detail-page/cantons-comparison-range.tsx
@@ -1,9 +1,39 @@
 import { t, Trans } from "@lingui/macro";
 import { Box } from "@mui/material";
 import { groups } from "d3-array";
-import * as React from "react";
 import { memo, useEffect, useState } from "react";
 
+import {
+  AnnotationX,
+  AnnotationXDataPoint,
+  AnnotationXLabel,
+} from "src/components/charts-generic/annotation/annotation-x";
+import { AxisWidthLinear } from "src/components/charts-generic/axis/axis-width-linear";
+import {
+  ChartContainer,
+  ChartSvg,
+} from "src/components/charts-generic/containers";
+import { Tooltip } from "src/components/charts-generic/interaction/tooltip";
+import { InteractionRows } from "src/components/charts-generic/overlay/interaction-rows";
+import {
+  Range,
+  RangePoints,
+} from "src/components/charts-generic/rangeplot/rangeplot";
+import { RangeplotMedian } from "src/components/charts-generic/rangeplot/rangeplot-median";
+import { RangePlot } from "src/components/charts-generic/rangeplot/rangeplot-state";
+import { Combobox } from "src/components/combobox";
+import { Card } from "src/components/detail-page/card";
+import { Download } from "src/components/detail-page/download-image";
+import { FilterSetDescription } from "src/components/detail-page/filter-set-description";
+import { WithClassName } from "src/components/detail-page/with-classname";
+import { Loading, NoDataHint } from "src/components/hint";
+import { InfoDialogButton } from "src/components/info-dialog";
+import { PriceColorLegend } from "src/components/price-color-legend";
+import { RadioTabs } from "src/components/radio-tabs";
+import Stack from "src/components/stack";
+import { SortingOrder, SortingType } from "src/domain/config-types";
+import { Entity, GenericObservation, priceComponents } from "src/domain/data";
+import { getLocalizedLabel } from "src/domain/translation";
 import {
   ObservationKind,
   PriceComponent,
@@ -12,33 +42,6 @@ import {
 import { EMPTY_ARRAY } from "src/lib/empty-array";
 import { useLocale } from "src/lib/use-locale";
 import { useQueryState } from "src/lib/use-query-state";
-
-import { SortingOrder, SortingType } from "../../domain/config-types";
-import { Entity, GenericObservation, priceComponents } from "../../domain/data";
-import { getLocalizedLabel } from "../../domain/translation";
-import {
-  AnnotationX,
-  AnnotationXDataPoint,
-  AnnotationXLabel,
-} from "../charts-generic/annotation/annotation-x";
-import { AxisWidthLinear } from "../charts-generic/axis/axis-width-linear";
-import { ChartContainer, ChartSvg } from "../charts-generic/containers";
-import { Tooltip } from "../charts-generic/interaction/tooltip";
-import { InteractionRows } from "../charts-generic/overlay/interaction-rows";
-import { Range, RangePoints } from "../charts-generic/rangeplot/rangeplot";
-import { RangeplotMedian } from "../charts-generic/rangeplot/rangeplot-median";
-import { RangePlot } from "../charts-generic/rangeplot/rangeplot-state";
-import { Combobox } from "../combobox";
-import { Loading, NoDataHint } from "../hint";
-import { InfoDialogButton } from "../info-dialog";
-import { PriceColorLegend } from "../price-color-legend";
-import { RadioTabs } from "../radio-tabs";
-import Stack from "../stack";
-
-import { Card } from "./card";
-import { Download } from "./download-image";
-import { FilterSetDescription } from "./filter-set-description";
-import { WithClassName } from "./with-classname";
 
 const DOWNLOAD_ID: Download = "comparison";
 

--- a/src/components/detail-page/card.tsx
+++ b/src/components/detail-page/card.tsx
@@ -1,10 +1,11 @@
 import { Box, Typography } from "@mui/material";
-import * as React from "react";
 import { ReactNode } from "react";
 
-import { Entity } from "../../domain/data";
-
-import { Download, DownloadImage } from "./download-image";
+import { Entity } from "src//domain/data";
+import {
+  Download,
+  DownloadImage,
+} from "src/components/detail-page/download-image";
 
 export const Card = ({
   title,

--- a/src/components/detail-page/card.tsx
+++ b/src/components/detail-page/card.tsx
@@ -1,7 +1,6 @@
 import { Box, Typography } from "@mui/material";
 import { ReactNode } from "react";
 
-import { Entity } from "src//domain/data";
 import {
   Download,
   DownloadImage,
@@ -14,9 +13,6 @@ export const Card = ({
 }: {
   title: string | ReactNode;
   downloadId: Download;
-  id: string;
-  entity: Entity;
-
   children: ReactNode;
 }) => {
   return (

--- a/src/components/detail-page/filter-set-description.tsx
+++ b/src/components/detail-page/filter-set-description.tsx
@@ -2,6 +2,7 @@ import { Box, Typography } from "@mui/material";
 import * as React from "react";
 
 import { getLocalizedLabel } from "src/domain/translation";
+
 type FilterSet = {
   operator: string;
   municipality: string;

--- a/src/components/detail-page/filter-set-description.tsx
+++ b/src/components/detail-page/filter-set-description.tsx
@@ -1,7 +1,7 @@
-import { Typography, Box } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import * as React from "react";
 
-import { getLocalizedLabel } from "../../domain/translation";
+import { getLocalizedLabel } from "src/domain/translation";
 type FilterSet = {
   operator: string;
   municipality: string;

--- a/src/components/detail-page/layout.tsx
+++ b/src/components/detail-page/layout.tsx
@@ -1,9 +1,10 @@
 import { Box } from "@mui/material";
+import { ReactNode } from "react";
 
 type Props = {
-  main: React.ReactNode;
-  selector: React.ReactNode;
-  aside: React.ReactNode;
+  main: ReactNode;
+  selector: ReactNode;
+  aside: ReactNode;
 };
 
 export const DetailPageLayout = ({ main, selector, aside }: Props) => {

--- a/src/components/detail-page/price-components-bars.tsx
+++ b/src/components/detail-page/price-components-bars.tsx
@@ -21,7 +21,7 @@ import { WithClassName } from "src/components/detail-page/with-classname";
 import { Loading, NoDataHint } from "src/components/hint";
 import { InfoDialogButton } from "src/components/info-dialog";
 import { RadioTabs } from "src/components/radio-tabs";
-import Stack from "src/components/stack";
+import { Stack } from "src/components/stack";
 import {
   Entity,
   GenericObservation,
@@ -63,7 +63,6 @@ export const PriceComponentsBarChart = ({
     },
     setQueryState,
   ] = useQueryState();
-  // const [view, setView] = useState("collapsed");
   const comparisonIds =
     entity === "municipality"
       ? municipality
@@ -146,8 +145,6 @@ export const PriceComponentsBarChart = ({
         </Stack>
       }
       downloadId={DOWNLOAD_ID}
-      id={id}
-      entity={entity}
     >
       {!download && entity !== "canton" && (
         <>
@@ -186,7 +183,6 @@ export const PriceComponentsBarChart = ({
               getItemLabel={getItemLabel}
               selectedItem={view[0]}
               setSelectedItem={(view) => setQueryState({ view: [view] })}
-              // setSelectedItem={setView}
               showLabel={false}
             />
           </Box>
@@ -302,7 +298,7 @@ const prepareObservations = ({
       ObservationValue,
       [ObservationValue, Record<string, ObservationValue>[]][]
     ][]
-  ][]; // The output of d3 groups with 3 levels.
+  ][];
   priceComponent: PriceComponent;
   entity: Entity;
   view: string;

--- a/src/components/detail-page/price-components-bars.tsx
+++ b/src/components/detail-page/price-components-bars.tsx
@@ -4,6 +4,33 @@ import { ascending, group, groups, max, min } from "d3-array";
 import * as React from "react";
 
 import {
+  BarsGrouped,
+  BarsGroupedAxis,
+  BarsGroupedLabels,
+} from "src/components/charts-generic/bars/bars-grouped";
+import { GroupedBarsChart } from "src/components/charts-generic/bars/bars-grouped-state";
+import {
+  ChartContainer,
+  ChartSvg,
+} from "src/components/charts-generic/containers";
+import { Combobox } from "src/components/combobox";
+import { Card } from "src/components/detail-page/card";
+import { Download } from "src/components/detail-page/download-image";
+import { FilterSetDescription } from "src/components/detail-page/filter-set-description";
+import { WithClassName } from "src/components/detail-page/with-classname";
+import { Loading, NoDataHint } from "src/components/hint";
+import { InfoDialogButton } from "src/components/info-dialog";
+import { RadioTabs } from "src/components/radio-tabs";
+import Stack from "src/components/stack";
+import {
+  Entity,
+  GenericObservation,
+  ObservationValue,
+  priceComponents,
+} from "src/domain/data";
+import { mkNumber, pivot_longer } from "src/domain/helpers";
+import { getLocalizedLabel } from "src/domain/translation";
+import {
   ObservationKind,
   PriceComponent,
   useObservationsWithAllPriceComponentsQuery,
@@ -11,32 +38,6 @@ import {
 import { EMPTY_ARRAY } from "src/lib/empty-array";
 import { useLocale } from "src/lib/use-locale";
 import { useQueryState } from "src/lib/use-query-state";
-
-import {
-  Entity,
-  GenericObservation,
-  ObservationValue,
-  priceComponents,
-} from "../../domain/data";
-import { mkNumber, pivot_longer } from "../../domain/helpers";
-import { getLocalizedLabel } from "../../domain/translation";
-import {
-  BarsGrouped,
-  BarsGroupedAxis,
-  BarsGroupedLabels,
-} from "../charts-generic/bars/bars-grouped";
-import { GroupedBarsChart } from "../charts-generic/bars/bars-grouped-state";
-import { ChartContainer, ChartSvg } from "../charts-generic/containers";
-import { Combobox } from "../combobox";
-import { Loading, NoDataHint } from "../hint";
-import { InfoDialogButton } from "../info-dialog";
-import { RadioTabs } from "../radio-tabs";
-import Stack from "../stack";
-
-import { Card } from "./card";
-import { Download } from "./download-image";
-import { FilterSetDescription } from "./filter-set-description";
-import { WithClassName } from "./with-classname";
 
 const DOWNLOAD_ID: Download = "components";
 export const EXPANDED_TAG = "expanded";

--- a/src/components/detail-page/price-distribution-histogram.tsx
+++ b/src/components/detail-page/price-distribution-histogram.tsx
@@ -32,7 +32,7 @@ import { Loading, NoDataHint } from "src/components/hint";
 import { InfoDialogButton } from "src/components/info-dialog";
 import { PriceColorLegend } from "src/components/price-color-legend";
 import { RadioTabs } from "src/components/radio-tabs";
-import Stack from "src/components/stack";
+import { Stack } from "src/components/stack";
 import { Entity, GenericObservation, priceComponents } from "src/domain/data";
 import { getLocalizedLabel } from "src/domain/translation";
 import { EMPTY_ARRAY } from "src/lib/empty-array";
@@ -87,8 +87,6 @@ export const PriceDistributionHistograms = ({
         </Stack>
       }
       downloadId={DOWNLOAD_ID}
-      id={id}
-      entity={entity}
     >
       {!download && (
         <>
@@ -147,9 +145,6 @@ export const PriceDistributionHistograms = ({
           entity={entity}
         />
       ))}
-      {/* <Box sx={{ color: "grey.700", fontSize: 2 }}>
-        <Trans id="chart.unit.cent.kWh">Preise in Rp./kWh</Trans>
-      </Box> */}
     </Card>
   );
 };
@@ -309,7 +304,6 @@ export const PriceDistributionHistogram = ({
             <ChartContainer>
               <ChartSvg>
                 <AxisHeightLinear />
-                {/* <AxisWidthHistogram /> */}
                 <HistogramMinMaxValues />
                 <AxisWidthHistogramDomain />
                 <AnnotationX />

--- a/src/components/detail-page/price-distribution-histogram.tsx
+++ b/src/components/detail-page/price-distribution-histogram.tsx
@@ -1,46 +1,43 @@
 import { t, Trans } from "@lingui/macro";
 import { Box } from "@mui/material";
 import { groups } from "d3-array";
-import * as React from "react";
-
-import { EMPTY_ARRAY } from "src/lib/empty-array";
-import { useLocale } from "src/lib/use-locale";
-import { useQueryState } from "src/lib/use-query-state";
-
-import { Entity, GenericObservation, priceComponents } from "../../domain/data";
-import { getLocalizedLabel } from "../../domain/translation";
-import {
-  AnnotationX,
-  AnnotationXLabel,
-} from "../charts-generic/annotation/annotation-x";
-import { AxisHeightLinear } from "../charts-generic/axis/axis-height-linear";
-import { AxisWidthHistogramDomain } from "../charts-generic/axis/axis-width-histogram";
-import { HistogramColumns } from "../charts-generic/histogram/histogram";
-import { HistogramMinMaxValues } from "../charts-generic/histogram/histogram-min-max-values";
-import { Histogram } from "../charts-generic/histogram/histogram-state";
-import { HistogramMedian } from "../charts-generic/histogram/median";
-import { Tooltip } from "../charts-generic/interaction/tooltip";
-import { InteractionHistogram } from "../charts-generic/overlay/interaction-histogram";
-import { Combobox } from "../combobox";
-import { Loading, NoDataHint } from "../hint";
-import { InfoDialogButton } from "../info-dialog";
-import { PriceColorLegend } from "../price-color-legend";
-import { RadioTabs } from "../radio-tabs";
-import Stack from "../stack";
 
 import {
   ChartContainer,
   ChartSvg,
-} from "./../../components/charts-generic/containers";
-import { Card } from "./../../components/detail-page/card";
+} from "src//components/charts-generic/containers";
+import { Card } from "src//components/detail-page/card";
 import {
   ObservationKind,
   PriceComponent,
   useObservationsQuery,
-} from "./../../graphql/queries";
-import { Download } from "./download-image";
-import { FilterSetDescription } from "./filter-set-description";
-import { WithClassName } from "./with-classname";
+} from "src//graphql/queries";
+import {
+  AnnotationX,
+  AnnotationXLabel,
+} from "src/components/charts-generic/annotation/annotation-x";
+import { AxisHeightLinear } from "src/components/charts-generic/axis/axis-height-linear";
+import { AxisWidthHistogramDomain } from "src/components/charts-generic/axis/axis-width-histogram";
+import { HistogramColumns } from "src/components/charts-generic/histogram/histogram";
+import { HistogramMinMaxValues } from "src/components/charts-generic/histogram/histogram-min-max-values";
+import { Histogram } from "src/components/charts-generic/histogram/histogram-state";
+import { HistogramMedian } from "src/components/charts-generic/histogram/median";
+import { Tooltip } from "src/components/charts-generic/interaction/tooltip";
+import { InteractionHistogram } from "src/components/charts-generic/overlay/interaction-histogram";
+import { Combobox } from "src/components/combobox";
+import { Download } from "src/components/detail-page/download-image";
+import { FilterSetDescription } from "src/components/detail-page/filter-set-description";
+import { WithClassName } from "src/components/detail-page/with-classname";
+import { Loading, NoDataHint } from "src/components/hint";
+import { InfoDialogButton } from "src/components/info-dialog";
+import { PriceColorLegend } from "src/components/price-color-legend";
+import { RadioTabs } from "src/components/radio-tabs";
+import Stack from "src/components/stack";
+import { Entity, GenericObservation, priceComponents } from "src/domain/data";
+import { getLocalizedLabel } from "src/domain/translation";
+import { EMPTY_ARRAY } from "src/lib/empty-array";
+import { useLocale } from "src/lib/use-locale";
+import { useQueryState } from "src/lib/use-query-state";
 
 const DOWNLOAD_ID: Download = "distribution";
 

--- a/src/components/detail-page/price-evolution-line-chart.tsx
+++ b/src/components/detail-page/price-evolution-line-chart.tsx
@@ -1,39 +1,36 @@
 import { t, Trans } from "@lingui/macro";
 import { Box } from "@mui/material";
-import * as React from "react";
 import { memo } from "react";
 
-import { EMPTY_ARRAY } from "src/lib/empty-array";
-import { useLocale } from "src/lib/use-locale";
-import { useQueryState } from "src/lib/use-query-state";
-
-import { Entity, GenericObservation, priceComponents } from "../../domain/data";
-import { getLocalizedLabel } from "../../domain/translation";
-import { AxisHeightLinear } from "../charts-generic/axis/axis-height-linear";
-import { AxisTime } from "../charts-generic/axis/axis-width-time";
-import { HoverDotMultiple } from "../charts-generic/interaction/hover-dots-multiple";
-import { Ruler } from "../charts-generic/interaction/ruler";
-import { Tooltip } from "../charts-generic/interaction/tooltip";
-import { LegendColor } from "../charts-generic/legends/color";
-import { Lines } from "../charts-generic/lines/lines";
-import { LineChart } from "../charts-generic/lines/lines-state";
-import { InteractionHorizontal } from "../charts-generic/overlay/interaction-horizontal";
-import { Loading, NoDataHint } from "../hint";
-import { InfoDialogButton } from "../info-dialog";
-import Stack from "../stack";
-
+import { AxisHeightLinear } from "src/components/charts-generic/axis/axis-height-linear";
+import { AxisTime } from "src/components/charts-generic/axis/axis-width-time";
 import {
   ChartContainer,
   ChartSvg,
-} from "./../../components/charts-generic/containers";
-import { Card } from "./../../components/detail-page/card";
+} from "src/components/charts-generic/containers";
+import { HoverDotMultiple } from "src/components/charts-generic/interaction/hover-dots-multiple";
+import { Ruler } from "src/components/charts-generic/interaction/ruler";
+import { Tooltip } from "src/components/charts-generic/interaction/tooltip";
+import { LegendColor } from "src/components/charts-generic/legends/color";
+import { Lines } from "src/components/charts-generic/lines/lines";
+import { LineChart } from "src/components/charts-generic/lines/lines-state";
+import { InteractionHorizontal } from "src/components/charts-generic/overlay/interaction-horizontal";
+import { Card } from "src/components/detail-page/card";
+import { Download } from "src/components/detail-page/download-image";
+import { FilterSetDescription } from "src/components/detail-page/filter-set-description";
+import { WithClassName } from "src/components/detail-page/with-classname";
+import { Loading, NoDataHint } from "src/components/hint";
+import { InfoDialogButton } from "src/components/info-dialog";
+import Stack from "src/components/stack";
+import { Entity, GenericObservation, priceComponents } from "src/domain/data";
+import { getLocalizedLabel } from "src/domain/translation";
 import {
   ObservationKind,
   useObservationsWithAllPriceComponentsQuery,
-} from "./../../graphql/queries";
-import { Download } from "./download-image";
-import { FilterSetDescription } from "./filter-set-description";
-import { WithClassName } from "./with-classname";
+} from "src/graphql/queries";
+import { EMPTY_ARRAY } from "src/lib/empty-array";
+import { useLocale } from "src/lib/use-locale";
+import { useQueryState } from "src/lib/use-query-state";
 
 const DOWNLOAD_ID: Download = "evolution";
 

--- a/src/components/detail-page/price-evolution-line-chart.tsx
+++ b/src/components/detail-page/price-evolution-line-chart.tsx
@@ -21,7 +21,7 @@ import { FilterSetDescription } from "src/components/detail-page/filter-set-desc
 import { WithClassName } from "src/components/detail-page/with-classname";
 import { Loading, NoDataHint } from "src/components/hint";
 import { InfoDialogButton } from "src/components/info-dialog";
-import Stack from "src/components/stack";
+import { Stack } from "src/components/stack";
 import { Entity, GenericObservation, priceComponents } from "src/domain/data";
 import { getLocalizedLabel } from "src/domain/translation";
 import {
@@ -100,8 +100,6 @@ export const PriceEvolution = ({
         </Stack>
       }
       downloadId={DOWNLOAD_ID}
-      id={id}
-      entity={entity}
     >
       <FilterSetDescription
         filters={{

--- a/src/components/detail-page/selector-multi.tsx
+++ b/src/components/detail-page/selector-multi.tsx
@@ -1,17 +1,16 @@
-import { Trans, t } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
 import { Box, Typography } from "@mui/material";
 import { useMemo } from "react";
 
-import { useQueryState } from "src/lib/use-query-state";
-
-import { Combobox, ComboboxMulti } from "../../components/combobox";
-import { categories, Entity, periods, products } from "../../domain/data";
-import { getLocalizedLabel } from "../../domain/translation";
+import { Combobox, ComboboxMulti } from "src/components/combobox";
 import {
   CantonsCombobox,
   MunicipalitiesCombobox,
   OperatorsCombobox,
-} from "../query-combobox";
+} from "src/components/query-combobox";
+import { categories, Entity, periods, products } from "src/domain/data";
+import { getLocalizedLabel } from "src/domain/translation";
+import { useQueryState } from "src/lib/use-query-state";
 
 export const SelectorMulti = ({
   entity = "municipality",

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,17 +1,15 @@
 import { Trans, t } from "@lingui/macro";
-import { Box, Link, Typography, IconButton, LinkProps } from "@mui/material";
+import { Box, IconButton, Link, LinkProps, Typography } from "@mui/material";
 import { PropsWithChildren } from "react";
 
+import { HelpDialog } from "src/components/info-dialog";
+import { LogoDesktop } from "src/components/logo";
+import { useDisclosure } from "src/components/useDisclosure";
+import { IconDownload } from "src/icons/ic-download";
+import { IconInfo } from "src/icons/ic-info";
+import { IconShare } from "src/icons/ic-share";
 import { useLocale } from "src/lib/use-locale";
 import { useQueryStateSingle } from "src/lib/use-query-state";
-
-import { IconDownload } from "../icons/ic-download";
-import { IconInfo } from "../icons/ic-info";
-import { IconShare } from "../icons/ic-share";
-
-import { HelpDialog } from "./info-dialog";
-import { LogoDesktop } from "./logo";
-import { useDisclosure } from "./useDisclosure";
 
 const FooterLink = ({
   children,

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -4,7 +4,7 @@ import { PropsWithChildren } from "react";
 
 import { HelpDialog } from "src/components/info-dialog";
 import { LogoDesktop } from "src/components/logo";
-import { useDisclosure } from "src/components/useDisclosure";
+import { useDisclosure } from "src/components/use-disclosure";
 import { IconDownload } from "src/icons/ic-download";
 import { IconInfo } from "src/icons/ic-info";
 import { IconShare } from "src/icons/ic-share";

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -2,24 +2,23 @@ import { Trans } from "@lingui/macro";
 import {
   Box,
   BoxProps,
+  FormControlLabel,
+  IconButton,
+  InputAdornment,
+  InputBase,
   Checkbox as MuiCheckbox,
   Radio as MuiRadio,
   Select as MuiSelect,
-  IconButton,
-  SelectProps,
-  Typography,
-  InputAdornment,
-  OutlinedInput,
   NativeSelect,
   NativeSelectProps,
-  FormControlLabel,
-  InputBase,
+  OutlinedInput,
+  SelectProps,
+  Typography,
 } from "@mui/material";
 import * as React from "react";
 
 import VisuallyHidden from "src/components/VisuallyHidden";
-
-import { Icon } from "../icons";
+import { Icon } from "src/icons";
 
 export type Option = {
   value: string | $FixMe;

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -16,22 +16,23 @@ import {
   Typography,
 } from "@mui/material";
 import * as React from "react";
+import { ReactNode } from "react";
 
-import VisuallyHidden from "src/components/VisuallyHidden";
+import { VisuallyHidden } from "src/components/visually-hidden";
 import { Icon } from "src/icons";
 
-export type Option = {
+type Option = {
   value: string | $FixMe;
   label: string | $FixMe;
   disabled?: boolean;
 };
 
-export type FieldProps = Pick<
+type FieldProps = Pick<
   React.InputHTMLAttributes<HTMLInputElement>,
   "onChange" | "id" | "name" | "value" | "checked" | "type"
 >;
 
-export const Label = ({
+const Label = ({
   label,
   htmlFor,
   disabled,
@@ -39,11 +40,11 @@ export const Label = ({
   children,
   showLabel = true,
 }: {
-  label?: string | React.ReactNode;
+  label?: string | ReactNode;
   htmlFor: string;
   disabled?: boolean;
   smaller?: boolean;
-  children: React.ReactNode;
+  children: ReactNode;
   showLabel?: boolean;
 }) => (
   <Typography
@@ -85,7 +86,7 @@ export const Radio = ({
   checked,
   disabled,
   onChange,
-}: { label: string | React.ReactNode; disabled?: boolean } & FieldProps) => {
+}: { label: string | ReactNode; disabled?: boolean } & FieldProps) => {
   return (
     <Box mb={2}>
       <FormControlLabel
@@ -116,7 +117,7 @@ export const Checkbox = ({
   checked,
   disabled,
   onChange,
-}: { label: React.ReactNode; disabled?: boolean } & FieldProps) => (
+}: { label: ReactNode; disabled?: boolean } & FieldProps) => (
   <FormControlLabel
     label={label}
     htmlFor={`${name}-${label}`}
@@ -147,7 +148,7 @@ export const Select = ({
 }: {
   id: string;
   options: Option[];
-  label?: React.ReactNode;
+  label?: ReactNode;
   disabled?: boolean;
 } & SelectProps) => (
   <Box sx={{ color: "grey.700", pb: 2 }}>
@@ -197,7 +198,7 @@ export const MiniSelect = ({
 }: {
   id: string;
   options: Option[];
-  label?: React.ReactNode;
+  label?: ReactNode;
   disabled?: boolean;
 } & NativeSelectProps) => (
   <Box sx={{ color: "grey.800" }}>
@@ -243,7 +244,7 @@ export const Input = ({
   value,
   onChange,
 }: {
-  label?: string | React.ReactNode;
+  label?: string | ReactNode;
   disabled?: boolean;
 } & FieldProps) => (
   <Box sx={{ color: "grey.700", fontSize: "1rem" }}>
@@ -272,7 +273,7 @@ export const SearchField = ({
   sx,
 }: {
   id: string;
-  label?: string | React.ReactNode;
+  label?: string | ReactNode;
   disabled?: boolean;
   value?: string;
   placeholder?: string;
@@ -316,7 +317,7 @@ export const SearchField = ({
 export const FieldSetLegend = ({
   legendTitle,
 }: {
-  legendTitle: string | React.ReactNode;
+  legendTitle: string | ReactNode;
 }) => (
   <Box
     sx={{

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,11 +1,10 @@
 import { Trans } from "@lingui/macro";
 import { Box, Typography } from "@mui/material";
 
+import { LanguageMenu } from "src/components/language-menu";
+import { HomeLink } from "src/components/links";
+import { LogoDesktop, LogoMobile } from "src/components/logo";
 import buildEnv from "src/env/build";
-
-import { LanguageMenu } from "./language-menu";
-import { HomeLink } from "./links";
-import { LogoDesktop, LogoMobile } from "./logo";
 
 export const Header = ({
   pageType = "app",

--- a/src/components/highlight-context.tsx
+++ b/src/components/highlight-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, Dispatch, SetStateAction } from "react";
 
-import { Entity } from "../domain/data";
+import { Entity } from "src/domain/data";
 
 export type HighlightValue = {
   entity: Entity;

--- a/src/components/hint.tsx
+++ b/src/components/hint.tsx
@@ -1,11 +1,11 @@
 import { keyframes } from "@emotion/react";
 import { Trans } from "@lingui/macro";
 import { Box, BoxProps, Typography } from "@mui/material";
-import * as React from "react";
+import { ReactNode } from "react";
 
 import { Icon, IconName } from "src/icons";
 
-export const Error = ({ children }: { children: React.ReactNode }) => (
+export const Error = ({ children }: { children: ReactNode }) => (
   <Box
     sx={{
       justifyContent: "center",
@@ -19,7 +19,7 @@ export const Error = ({ children }: { children: React.ReactNode }) => (
   </Box>
 );
 
-export const Hint = ({ children }: { children: React.ReactNode }) => (
+export const Hint = ({ children }: { children: ReactNode }) => (
   <Box
     sx={{
       width: "100%",
@@ -245,7 +245,7 @@ export const HintBlue = ({
   children,
 }: {
   iconName: IconName;
-  children: React.ReactNode;
+  children: ReactNode;
 }) => (
   <Box
     sx={{
@@ -273,7 +273,7 @@ export const HintRed = ({
   children,
 }: {
   iconName: IconName;
-  children: React.ReactNode;
+  children: ReactNode;
 }) => (
   <Box
     sx={{

--- a/src/components/hint.tsx
+++ b/src/components/hint.tsx
@@ -3,7 +3,7 @@ import { Trans } from "@lingui/macro";
 import { Box, BoxProps, Typography } from "@mui/material";
 import * as React from "react";
 
-import { Icon, IconName } from "../icons";
+import { Icon, IconName } from "src/icons";
 
 export const Error = ({ children }: { children: React.ReactNode }) => (
   <Box

--- a/src/components/info-banner.tsx
+++ b/src/components/info-banner.tsx
@@ -1,9 +1,8 @@
 import { Box } from "@mui/material";
 
+import { HintBlue } from "src/components/hint";
 import { useWikiContentQuery } from "src/graphql/queries";
 import { useLocale } from "src/lib/use-locale";
-
-import { HintBlue } from "./hint";
 
 export const InfoBanner = ({
   bypassBannerEnabled,
@@ -25,6 +24,7 @@ export const InfoBanner = ({
   }
 
   const wikiContent = contentQuery.data?.wikiContent;
+
   if (!wikiContent.info.bannerEnabled && !bypassBannerEnabled) {
     return null;
   }

--- a/src/components/info-dialog.tsx
+++ b/src/components/info-dialog.tsx
@@ -1,24 +1,22 @@
 import { Trans } from "@lingui/macro";
 import {
+  Backdrop,
   Box,
-  Typography,
   Dialog,
+  IconButton,
   DialogContent as MuiDialogContent,
   DialogTitle as MuiDialogTitle,
-  IconButton,
-  Backdrop,
+  Typography,
 } from "@mui/material";
 import { createPortal } from "react-dom";
 
 import VisuallyHidden from "src/components/VisuallyHidden";
+import { LoadingIcon, NoContentHint } from "src/components/hint";
+import { useDisclosure } from "src/components/useDisclosure";
 import { useWikiContentQuery } from "src/graphql/queries";
+import { Icon } from "src/icons";
 import { useLocale } from "src/lib/use-locale";
 import { theme } from "src/themes/elcom";
-
-import { Icon } from "../icons";
-
-import { LoadingIcon, NoContentHint } from "./hint";
-import { useDisclosure } from "./useDisclosure";
 
 const DialogContent = ({
   contentQuery,

--- a/src/components/info-dialog.tsx
+++ b/src/components/info-dialog.tsx
@@ -10,9 +10,9 @@ import {
 } from "@mui/material";
 import { createPortal } from "react-dom";
 
-import VisuallyHidden from "src/components/VisuallyHidden";
 import { LoadingIcon, NoContentHint } from "src/components/hint";
-import { useDisclosure } from "src/components/useDisclosure";
+import { useDisclosure } from "src/components/use-disclosure";
+import { VisuallyHidden } from "src/components/visually-hidden";
 import { useWikiContentQuery } from "src/graphql/queries";
 import { Icon } from "src/icons";
 import { useLocale } from "src/lib/use-locale";

--- a/src/components/links.tsx
+++ b/src/components/links.tsx
@@ -36,7 +36,6 @@ export const IconLink = ({
 }) => (
   <UILink
     title={title}
-    // disabled={disabled}
     href={href}
     target="_blank"
     rel="noopener noreferrer"

--- a/src/components/links.tsx
+++ b/src/components/links.tsx
@@ -3,7 +3,7 @@ import NextLink, { LinkProps } from "next/link";
 import { useRouter } from "next/router";
 import React from "react";
 
-import { Icon, IconName } from "../icons";
+import { Icon, IconName } from "src/icons";
 
 export const HomeLink = (
   props: Omit<LinkProps, "href" | "as"> & {

--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -10,7 +10,7 @@ import { MiniSelect, SearchField } from "src/components/form";
 import { HighlightContext } from "src/components/highlight-context";
 import { InfoDialogButton } from "src/components/info-dialog";
 import { RadioTabs } from "src/components/radio-tabs";
-import Stack from "src/components/stack";
+import { Stack } from "src/components/stack";
 import { Entity } from "src/domain/data";
 import { useFormatCurrency } from "src/domain/helpers";
 import {
@@ -42,6 +42,7 @@ const ListItem = ({
       : listState === "PROVIDERS"
       ? "operator"
       : ("canton" as Entity);
+
   return (
     <Link
       underline="none"
@@ -99,13 +100,6 @@ const ListItem = ({
     </Link>
   );
 };
-
-interface Props {
-  observations: OperatorObservationFieldsFragment[];
-  cantonObservations: CantonMedianObservationFieldsFragment[];
-  colorScale: ScaleThreshold<number, string>;
-  observationsQueryFetching: boolean;
-}
 
 const TRUNCATION_INCREMENT = 20;
 
@@ -230,7 +224,12 @@ export const List = ({
   cantonObservations,
   colorScale,
   observationsQueryFetching,
-}: Props) => {
+}: {
+  observations: OperatorObservationFieldsFragment[];
+  cantonObservations: CantonMedianObservationFieldsFragment[];
+  colorScale: ScaleThreshold<number, string>;
+  observationsQueryFetching: boolean;
+}) => {
   const [listState, setListState] = useState<ListState>("MUNICIPALITIES");
   const [sortState, setSortState] = useState<SortState>("ASC");
   const [searchQuery, setSearchQuery] = useState<string>("");

--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -6,20 +6,18 @@ import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { useContext, useMemo, useState } from "react";
 
+import { MiniSelect, SearchField } from "src/components/form";
+import { HighlightContext } from "src/components/highlight-context";
+import { InfoDialogButton } from "src/components/info-dialog";
+import { RadioTabs } from "src/components/radio-tabs";
+import Stack from "src/components/stack";
+import { Entity } from "src/domain/data";
+import { useFormatCurrency } from "src/domain/helpers";
 import {
   CantonMedianObservationFieldsFragment,
   OperatorObservationFieldsFragment,
 } from "src/graphql/queries";
-
-import { Entity } from "../domain/data";
-import { useFormatCurrency } from "../domain/helpers";
-import { Icon } from "../icons";
-
-import { MiniSelect, SearchField } from "./form";
-import { HighlightContext } from "./highlight-context";
-import { InfoDialogButton } from "./info-dialog";
-import { RadioTabs } from "./radio-tabs";
-import Stack from "./stack";
+import { Icon } from "src/icons";
 
 const ListItem = ({
   id,

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -29,16 +29,14 @@ import {
   mesh as topojsonMesh,
 } from "topojson-client";
 
+import { TooltipBoxWithoutChartState } from "src/components/charts-generic/interaction/tooltip-box";
+import { WithClassName } from "src/components/detail-page/with-classname";
+import { HighlightContext } from "src/components/highlight-context";
+import { Loading, NoDataHint, NoGeoDataHint } from "src/components/hint";
+import { MapPriceColorLegend } from "src/components/price-color-legend";
+import { useFormatCurrency } from "src/domain/helpers";
 import { OperatorObservationFieldsFragment } from "src/graphql/queries";
 import { maxBy } from "src/lib/array";
-
-import { useFormatCurrency } from "../domain/helpers";
-
-import { TooltipBoxWithoutChartState } from "./charts-generic/interaction/tooltip-box";
-import { WithClassName } from "./detail-page/with-classname";
-import { HighlightContext } from "./highlight-context";
-import { Loading, NoDataHint, NoGeoDataHint } from "./hint";
-import { MapPriceColorLegend } from "./price-color-legend";
 
 import type { Feature, FeatureCollection, MultiLineString } from "geojson";
 

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -237,11 +237,7 @@ const fetchGeoData = async (year: string) => {
     topo.objects.municipalities,
     (a, b) => a !== b
   );
-  const cantonMesh = topojsonMesh(
-    topo,
-    topo.objects.cantons
-    // (a, b) => a !== b
-  );
+  const cantonMesh = topojsonMesh(topo, topo.objects.cantons);
   const lakes = topojsonFeature(topo, topo.objects.lakes);
   return {
     municipalities: municipalities as Extract<
@@ -306,7 +302,7 @@ const SCREENSHOT_CANVAS_SIZE = {
 };
 
 /**
- * Get the map as an image, using the deckgl canvas and html2canvas to get
+ * Get the map as an image, using the Deck.gl canvas and html2canvas to get
  * the legend as an image.
  */
 const getImageData = async (deck: Deck, legend: HTMLElement) => {

--- a/src/components/operator-documents.tsx
+++ b/src/components/operator-documents.tsx
@@ -9,10 +9,9 @@ import {
   OperatorDocumentCategory,
   useOperatorDocumentsQuery,
 } from "src/graphql/queries";
+import { Icon } from "src/icons";
 import { EMPTY_ARRAY } from "src/lib/empty-array";
 import { useLocale } from "src/lib/use-locale";
-
-import { Icon } from "../icons";
 
 const CATEGORIES = [
   {

--- a/src/components/price-color-legend.tsx
+++ b/src/components/price-color-legend.tsx
@@ -1,14 +1,12 @@
 import styled from "@emotion/styled";
 import { Trans, t } from "@lingui/macro";
-import { Box } from "@mui/material";
-import { useTheme, Typography } from "@mui/material";
-import React, { useState } from "react";
+import { Box, Typography, useTheme } from "@mui/material";
+import { useState } from "react";
 
-import { useFormatCurrency } from "../domain/helpers";
-import { IconClear } from "../icons/ic-clear";
-import { IconInfo } from "../icons/ic-info";
-
-import { InfoDialogButton } from "./info-dialog";
+import { InfoDialogButton } from "src/components/info-dialog";
+import { useFormatCurrency } from "src/domain/helpers";
+import { IconClear } from "src/icons/ic-clear";
+import { IconInfo } from "src/icons/ic-info";
 
 const LEGEND_WIDTH = 215;
 const TOP_LABEL_HEIGHT = 14;

--- a/src/components/price-color-legend.tsx
+++ b/src/components/price-color-legend.tsx
@@ -49,6 +49,7 @@ export const MapPriceColorLegend = ({
       </LegendBox>
     );
   }
+
   return (
     <LegendBox id={id}>
       <Box sx={{ alignItems: "center", width: "100%", mb: -1 }} display="flex">
@@ -196,6 +197,7 @@ export const PriceColorLegend = () => {
 
 export const ColorsLine = () => {
   const { palette } = useTheme();
+
   return (
     <Box
       sx={{ height: COLOR_HEIGHT + BOTTOM_LABEL_HEIGHT, position: "relative" }}
@@ -281,4 +283,5 @@ export const ColorsLine = () => {
     </Box>
   );
 };
+
 const PRICE_THRESHOLDS = ["-15%", "-5%", "+5%", "+15%"];

--- a/src/components/query-combobox.tsx
+++ b/src/components/query-combobox.tsx
@@ -1,14 +1,13 @@
 import { rollup } from "d3-array";
 import { useMemo, useState } from "react";
 
+import { ComboboxMulti, ComboboxMultiProps } from "src/components/combobox";
 import {
+  useCantonsQuery,
   useMunicipalitiesQuery,
   useOperatorsQuery,
-  useCantonsQuery,
 } from "src/graphql/queries";
 import { useLocale } from "src/lib/use-locale";
-
-import { ComboboxMulti, ComboboxMultiProps } from "./combobox";
 
 export const MunicipalitiesCombobox = (
   comboboxMultiProps: Pick<

--- a/src/components/radio-tabs.tsx
+++ b/src/components/radio-tabs.tsx
@@ -1,17 +1,17 @@
 import { Box } from "@mui/material";
-import { ChangeEventHandler, useCallback } from "react";
+import { ChangeEventHandler, ReactNode, useCallback } from "react";
 
-import VisuallyHidden from "src/components/VisuallyHidden";
+import { VisuallyHidden } from "src/components/visually-hidden";
 
 type RadioTabsVariants = "tabs" | "borderlessTabs" | "segmented";
 
-interface RadioTabsProps<T> {
+type RadioTabsProps<T> = {
   name: string;
-  options: { value: T; label: React.ReactNode }[];
+  options: { value: T; label: ReactNode }[];
   value: T;
   setValue: (value: T) => void;
   variant?: RadioTabsVariants;
-}
+};
 
 const STYLES = {
   tabs: {

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -16,7 +16,7 @@ import { sortBy } from "lodash";
 import { useRouter } from "next/router";
 import React, { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 
-import VisuallyHidden from "src/components/VisuallyHidden";
+import { VisuallyHidden } from "src/components/visually-hidden";
 import { analyticsSiteSearch } from "src/domain/analytics";
 import { getLocalizedLabel } from "src/domain/translation";
 import { useSearchQuery } from "src/graphql/queries";
@@ -87,6 +87,7 @@ export const Search = () => {
 };
 
 type ResultType = "OperatorResult" | "MunicipalityResult" | "CantonResult";
+
 type Item = {
   id: string;
   __typename: ResultType;
@@ -142,6 +143,7 @@ export const SearchField = ({
   const inputRef = useRef<HTMLInputElement>(null);
 
   debugger;
+
   return (
     <Box sx={{ width: "100%", maxWidth: "44rem", mx: "auto", my: 1 }}>
       <VisuallyHidden>
@@ -291,9 +293,6 @@ export const SearchField = ({
                   textDecoration: "none",
                   px: 6,
                   py: 3,
-                },
-                "& > svg": {
-                  // visibility: "hidden",
                 },
                 "&:hover > svg, .Mui-focusVisible & > svg": {
                   visibility: "visible",

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -1,29 +1,28 @@
 import { t, Trans } from "@lingui/macro";
 import {
+  Autocomplete,
   AutocompleteProps,
   Box,
   Divider,
   IconButton,
   InputAdornment,
   outlinedInputClasses,
+  TextField,
   Typography,
+  useTheme,
 } from "@mui/material";
-import { useTheme } from "@mui/material";
-import { Autocomplete, TextField } from "@mui/material";
 import { rollup } from "d3-array";
 import { sortBy } from "lodash";
 import { useRouter } from "next/router";
-import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
-import React from "react";
+import React, { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 
 import VisuallyHidden from "src/components/VisuallyHidden";
+import { analyticsSiteSearch } from "src/domain/analytics";
 import { getLocalizedLabel } from "src/domain/translation";
 import { useSearchQuery } from "src/graphql/queries";
+import { Icon } from "src/icons";
 import { EMPTY_ARRAY } from "src/lib/empty-array";
 import { useLocale } from "src/lib/use-locale";
-
-import { analyticsSiteSearch } from "../domain/analytics";
-import { Icon } from "../icons";
 
 export const Search = () => {
   const locale = useLocale();

--- a/src/components/selector.tsx
+++ b/src/components/selector.tsx
@@ -1,6 +1,6 @@
 import { Trans, t } from "@lingui/macro";
 import { Box, Typography } from "@mui/material";
-import { useMemo } from "react";
+import { ComponentProps, useMemo } from "react";
 
 import { Combobox } from "src/components/combobox";
 import {
@@ -21,8 +21,9 @@ export const Selector = () => {
       ...categories.filter((x) => x.startsWith("H")),
       { type: "header", title: getItemLabel("C-group") },
       ...categories.filter((x) => x.startsWith("C")),
-    ] as React.ComponentProps<typeof Combobox>["items"];
+    ] as ComponentProps<typeof Combobox>["items"];
   }, []);
+
   return (
     <Box
       component="fieldset"

--- a/src/components/selector.tsx
+++ b/src/components/selector.tsx
@@ -1,13 +1,16 @@
 import { Trans, t } from "@lingui/macro";
-import { Typography, Box } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { useMemo } from "react";
 
+import { Combobox } from "src/components/combobox";
+import {
+  categories,
+  periods,
+  priceComponents,
+  products,
+} from "src/domain/data";
+import { getLocalizedLabel } from "src/domain/translation";
 import { useQueryStateSingle } from "src/lib/use-query-state";
-
-import { categories, periods, priceComponents, products } from "../domain/data";
-import { getLocalizedLabel } from "../domain/translation";
-
-import { Combobox } from "./../components/combobox";
 
 export const Selector = () => {
   const [queryState, setQueryState] = useQueryStateSingle();

--- a/src/components/stack.tsx
+++ b/src/components/stack.tsx
@@ -1,6 +1,6 @@
 import { Box, BoxProps } from "@mui/material";
 
-const Stack = ({
+export const Stack = ({
   direction = "column",
   spacing = 1,
   children,
@@ -27,5 +27,3 @@ const Stack = ({
     </Box>
   );
 };
-
-export default Stack;

--- a/src/components/use-disclosure.tsx
+++ b/src/components/use-disclosure.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 
 export const useDisclosure = () => {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isOpen, setIsOpen] = useState(false);
   const close = () => setIsOpen(false);
   const open = () => setIsOpen(true);
+
   return { isOpen, open, close, setIsOpen };
 };

--- a/src/components/use-outside-click.tsx
+++ b/src/components/use-outside-click.tsx
@@ -1,7 +1,7 @@
-import { useEffect } from "react";
+import { RefObject, useEffect } from "react";
 
-const useOutsideClick = (
-  ref: React.RefObject<HTMLElement | null>,
+export const useOutsideClick = (
+  ref: RefObject<HTMLElement | null>,
   callback: () => void
 ): void => {
   useEffect(() => {
@@ -17,5 +17,3 @@ const useOutsideClick = (
     };
   }, [ref, callback]);
 };
-
-export default useOutsideClick;

--- a/src/components/visually-hidden.tsx
+++ b/src/components/visually-hidden.tsx
@@ -1,0 +1,6 @@
+import { visuallyHidden } from "@mui/utils";
+import { ReactNode } from "react";
+
+export const VisuallyHidden = ({ children }: { children: ReactNode }) => (
+  <div style={visuallyHidden}>{children}</div>
+);

--- a/src/domain/config-types.ts
+++ b/src/domain/config-types.ts
@@ -1,6 +1,5 @@
 import * as t from "io-ts";
 
-// Chart Config
 const SortingOrder = t.union([t.literal("asc"), t.literal("desc")]);
 export type SortingOrder = t.TypeOf<typeof SortingOrder>;
 
@@ -45,8 +44,6 @@ const SegmentField = t.intersection([
 
 export type SegmentField = t.TypeOf<typeof SegmentField>;
 export type SegmentFields = Record<string, SegmentField | undefined>;
-
-// ----
 
 const BarFields = t.intersection([
   t.type({

--- a/src/domain/gever/encrypt.ts
+++ b/src/domain/gever/encrypt.ts
@@ -1,5 +1,5 @@
 /**
- * The docuemnt reference coming from GEVER must be kept secret so
+ * The document reference coming from GEVER must be kept secret so
  * we encrypt it before passing it to the client.
  * We decrypt it when the we receive the download request for a
  * document.

--- a/src/domain/gitlab-wiki-api.ts
+++ b/src/domain/gitlab-wiki-api.ts
@@ -4,10 +4,9 @@ import path from "path";
 
 import fs from "fs-extra";
 
+import { getWikiPage as getStaticWikiPage } from "src/domain/gitlab-wiki-static";
 import serverEnv from "src/env/server";
 import { setupUndiciHttpAgent } from "src/pages/api/http-agent";
-
-import { getWikiPage as getStaticWikiPage } from "./gitlab-wiki-static";
 
 type WikiPage = {
   format: string;
@@ -32,7 +31,7 @@ const fetchWithTimeout = async (
   const { timeout } = options;
 
   let id;
-  const aborter = new Promise((resolve, reject) =>
+  const aborter = new Promise((_, reject) =>
     timeout !== undefined
       ? (id = setTimeout(() => reject(new Error("Timeout")), timeout))
       : undefined

--- a/src/domain/helpers.tsx
+++ b/src/domain/helpers.tsx
@@ -224,7 +224,7 @@ export const getAnnotationSpaces = ({
             estimateTextWidth(format(getX(datum)), annotationFontSize) +
             labelLength;
 
-          // On smaller screens, anotations may break on several lines
+          // On smaller screens, annotations may break on several lines
           const nbOfLines = Math.ceil(oneFullLine / width);
 
           acc.push({

--- a/src/domain/helpers.tsx
+++ b/src/domain/helpers.tsx
@@ -198,14 +198,14 @@ export const getAnnotationSpaces = ({
   getLabel,
   format,
   width,
-  annotationfontSize,
+  annotationFontSize,
 }: {
   annotation: { [x: string]: string | number | boolean }[];
   getX: (x: GenericObservation) => number;
   getLabel: (x: GenericObservation) => string | undefined;
   format: (n: number) => string;
   width: number;
-  annotationfontSize: number;
+  annotationFontSize: number;
 }) => {
   return annotation
     ? annotation.reduce(
@@ -215,13 +215,13 @@ export const getAnnotationSpaces = ({
           const nbOfSpaces = splitLabel.length + 1;
           const labelLength =
             splitLabel.reduce(
-              (acc, cur) => acc + estimateTextWidth(cur, annotationfontSize),
+              (acc, cur) => acc + estimateTextWidth(cur, annotationFontSize),
               0
             ) +
-            nbOfSpaces * estimateTextWidth(" ", annotationfontSize);
+            nbOfSpaces * estimateTextWidth(" ", annotationFontSize);
 
           const oneFullLine =
-            estimateTextWidth(format(getX(datum)), annotationfontSize) +
+            estimateTextWidth(format(getX(datum)), annotationFontSize) +
             labelLength;
 
           // On smaller screens, anotations may break on several lines
@@ -231,7 +231,7 @@ export const getAnnotationSpaces = ({
             height:
               acc[i].height +
               // annotation height
-              nbOfLines * annotationfontSize +
+              nbOfLines * annotationFontSize +
               // size of annotation indicator (triangle below label)
               ANNOTATION_TRIANGLE_HEIGHT +
               // + margin between annotations

--- a/src/domain/helpers.tsx
+++ b/src/domain/helpers.tsx
@@ -18,13 +18,11 @@ import {
 } from "d3";
 import React from "react";
 
+import { ANNOTATION_TRIANGLE_HEIGHT } from "src/components/charts-generic/annotation/annotation-x";
+import { GenericObservation } from "src/domain/data";
 import { estimateTextWidth } from "src/lib/estimate-text-width";
 import { useLocale } from "src/lib/use-locale";
 import { d3FormatLocales, d3TimeFormatLocales } from "src/locales/locales";
-
-import { ANNOTATION_TRIANGLE_HEIGHT } from "../components/charts-generic/annotation/annotation-x";
-
-import { GenericObservation } from "./data";
 
 export const isNumber = (x: $IntentionalAny): boolean =>
   typeof x === "number" && !isNaN(x);

--- a/src/graphql/context.tsx
+++ b/src/graphql/context.tsx
@@ -1,13 +1,10 @@
+import { ReactNode } from "react";
 import { createClient, Provider } from "urql";
 
 const client = createClient({
   url: "/api/graphql",
 });
 
-export const GraphqlProvider = ({
-  children,
-}: {
-  children: React.ReactNode;
-}) => {
+export const GraphqlProvider = ({ children }: { children: ReactNode }) => {
   return <Provider value={client}>{children}</Provider>;
 };

--- a/src/graphql/queries.graphql
+++ b/src/graphql/queries.graphql
@@ -88,24 +88,6 @@ query Observations(
   }
 }
 
-# query CantonMedianObservations(
-#   $locale: String!
-#   $priceComponent: PriceComponent!
-#   $filters: ObservationFilters!
-# ) {
-#   cantonMedianObservations(locale: $locale, filters: $filters) {
-#     ...cantonMedianObservationFields
-#   }
-# }
-
-# query SwissMedianObservations(
-#   $locale: String!
-#   $priceComponent: PriceComponent!
-#   $filters: ObservationFilters!
-# ) {
-
-# }
-
 fragment operatorObservationWithAllPriceComponentsFields on OperatorObservation {
   period
   municipality
@@ -130,11 +112,9 @@ fragment cantonMedianObservationWithAllPriceComponentsFields on CantonMedianObse
   category
 
   aidfee: value(priceComponent: aidfee)
-  # fixcosts: value(priceComponent: fixcosts)
   charge: value(priceComponent: charge)
   gridusage: value(priceComponent: gridusage)
   energy: value(priceComponent: energy)
-  # fixcostspercent: value(priceComponent: fixcostspercent)
   total: value(priceComponent: total)
 }
 

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -3,43 +3,38 @@ import { GraphQLError, GraphQLResolveInfo } from "graphql";
 import { parseResolveInfo, ResolveTree } from "graphql-parse-resolve-info";
 import micromark from "micromark";
 
-import { defaultLocale } from "src/locales/locales";
-
-import { searchGeverDocuments } from "../domain/gever";
-import { getWikiPage } from "../domain/gitlab-wiki-api";
-import {
-  getDimensionValuesAndLabels,
-  getObservations,
-  getOperatorDocuments,
-  getObservationsCube,
-  getCantonMedianCube,
-  getView,
-  getSwissMedianCube,
-} from "../rdf/queries";
-import { fetchOperatorInfo, search } from "../rdf/search-queries";
-
+import { searchGeverDocuments } from "src/domain/gever";
+import { getWikiPage } from "src/domain/gitlab-wiki-api";
 import {
   ResolvedCantonMedianObservation,
   ResolvedOperatorObservation,
   ResolvedSwissMedianObservation,
-} from "./resolver-mapped-types";
+} from "src/graphql/resolver-mapped-types";
 import {
   CantonMedianObservationResolvers,
   MunicipalityResolvers,
+  ObservationKind,
   ObservationResolvers,
   OperatorObservationResolvers,
   OperatorResolvers,
   QueryResolvers,
   Resolvers,
-  ObservationKind,
   SwissMedianObservationResolvers,
-} from "./resolver-types";
-
+} from "src/graphql/resolver-types";
+import { defaultLocale } from "src/locales/locales";
+import {
+  getCantonMedianCube,
+  getDimensionValuesAndLabels,
+  getObservations,
+  getObservationsCube,
+  getOperatorDocuments,
+  getSwissMedianCube,
+  getView,
+} from "src/rdf/queries";
+import { fetchOperatorInfo, search } from "src/rdf/search-queries";
 
 const gfmSyntax = require("micromark-extension-gfm");
 const gfmHtml = require("micromark-extension-gfm/html");
-
-
 
 const expectedCubeDimensions = [
   "https://energy.ld.admin.ch/elcom/electricityprice/dimension/category",

--- a/src/lib/copy-to-clipboard.ts
+++ b/src/lib/copy-to-clipboard.ts
@@ -1,0 +1,7 @@
+export const copyToClipboard = async (text: string) => {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (error) {
+    console.error("Failed to copy text to clipboard:", error);
+  }
+};

--- a/src/lib/observations.ts
+++ b/src/lib/observations.ts
@@ -1,6 +1,6 @@
 import { Literal, NamedNode } from "rdf-js";
 
-import * as ns from "../rdf/namespace";
+import * as ns from "src/rdf/namespace";
 
 export type RawObservationValue = {
   value: Literal | NamedNode;

--- a/src/lib/observations.ts
+++ b/src/lib/observations.ts
@@ -52,7 +52,7 @@ const parseRDFLiteral = (value: Literal): ObservationValue => {
 };
 
 /**
- * Parse observation values (values returnd from query.execute()) to native JS types
+ * Parse observation values (values returned from query.execute()) to native JS types
  *
  * @param observationValue
  */
@@ -72,7 +72,8 @@ export const parseObservation = (
   d: Record<string, Literal | NamedNode<string>>
 ) => {
   const parsed: { [k: string]: string | number | boolean } = {};
-  const electricityPriceDimensionPrefix = ns.electricitypriceDimension().value;
+  const electricityPriceDimensionPrefix = ns.electricityPriceDimension().value;
+
   for (const [k, v] of Object.entries(d)) {
     const key = k.replace(electricityPriceDimensionPrefix, "");
 
@@ -83,5 +84,6 @@ export const parseObservation = (
         ? ns.stripNamespaceFromIri({ iri: parsedValue })
         : parsedValue;
   }
+
   return parsed;
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,14 +6,14 @@ import { useRouter } from "next/router";
 import Script from "next/script";
 import { useEffect, useState } from "react";
 
+import { analyticsPageView } from "src/domain/analytics";
 import { GraphqlProvider } from "src/graphql/context";
 import { LocaleProvider } from "src/lib/use-locale";
 import { useNProgress } from "src/lib/use-nprogress";
 import { i18n, parseLocaleString } from "src/locales/locales";
+import { fonts, theme } from "src/themes/elcom";
 
-import { analyticsPageView } from "../domain/analytics";
 import "src/styles/nprogress.css";
-import { fonts, theme } from "../themes/elcom";
 
 const useMatomo = () => {
   const [matomoId, setMatomoId] = useState<string | undefined>(undefined);

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,14 +1,11 @@
-import Document, { Html, Head, Main, NextScript } from "next/document";
+import Document, { Head, Html, Main, NextScript } from "next/document";
 
 import buildEnv from "src/env/build";
 
 class MyDocument extends Document {
   render() {
     return (
-      <Html
-        data-app-version={`${buildEnv.VERSION}`}
-        // lang={this.props.locale}
-      >
+      <Html data-app-version={`${buildEnv.VERSION}`}>
         <Head></Head>
         <body>
           <Main />

--- a/src/pages/_system/api-status.tsx
+++ b/src/pages/_system/api-status.tsx
@@ -22,6 +22,7 @@ const IndicatorFail = () => (
     FAIL
   </Box>
 );
+
 const IndicatorSuccess = () => (
   <Box
     sx={{
@@ -203,6 +204,7 @@ const CantonMedianStatus = () => {
       },
     },
   });
+
   return (
     <Status
       title="Canton Median Observations (All Price Components)"
@@ -409,7 +411,7 @@ DESCRIBE <https://ld.admin.ch/municipality/${formData.municipalityId}>
           <details>{data && data ? <pre>{data}</pre> : null}</details>
           {query.error ? (
             <div>
-              Erreur:{" "}
+              Error:{" "}
               {query.error instanceof Error
                 ? query.error.message
                 : `${query.error}`}

--- a/src/pages/_system/api-status.tsx
+++ b/src/pages/_system/api-status.tsx
@@ -1,11 +1,10 @@
-import { Box, Typography, TypographyProps, BoxProps } from "@mui/material";
+import { Box, BoxProps, Typography, TypographyProps } from "@mui/material";
 import { FormEvent, useCallback, useMemo, useState } from "react";
 import { UseQueryState } from "urql";
 
+import { LoadingIconInline } from "src/components/hint";
 import * as Queries from "src/graphql/queries";
-
-import { LoadingIconInline } from "../../components/hint";
-import { DebugDownloadGetResponse } from "../api/debug-download";
+import { DebugDownloadGetResponse } from "src/pages/api/debug-download";
 
 const IndicatorFail = () => (
   <Box

--- a/src/pages/api/data-export.ts
+++ b/src/pages/api/data-export.ts
@@ -3,12 +3,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import buildEnv from "src/env/build";
 import { parseLocaleString } from "src/locales/locales";
-
-import {
-  getObservations,
-  getObservationsCube,
-  getView,
-} from "../../rdf/queries";
+import { getObservations, getObservationsCube, getView } from "src/rdf/queries";
 
 const formatters: Record<string, ReturnType<typeof format>> = {
   // See if this is needed later

--- a/src/pages/api/debug-download.ts
+++ b/src/pages/api/debug-download.ts
@@ -1,12 +1,11 @@
 import { InferAPIResponse } from "nextkit";
 
+import { searchGeverDocuments } from "src/domain/gever";
 import serverEnv from "src/env/server";
 import assert from "src/lib/assert";
-
-import { searchGeverDocuments } from "../../domain/gever";
-import { fetchOperatorInfo } from "../../rdf/search-queries";
-import { endpointUrl } from "../../rdf/sparql-client";
-import { api } from "../../server/nextkit";
+import { fetchOperatorInfo } from "src/rdf/search-queries";
+import { endpointUrl } from "src/rdf/sparql-client";
+import { api } from "src/server/nextkit";
 
 assert(!!serverEnv, "serverEnv is not defined");
 

--- a/src/pages/api/download-operator-document/[reference].ts
+++ b/src/pages/api/download-operator-document/[reference].ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
-import { downloadGeverDocument } from "../../../domain/gever";
+import { downloadGeverDocument } from "src/domain/gever";
 
 // Taken from node.js source code
 // @see https://github.com/nodejs/node/blob/main/lib/_http_common.js#L216C1-L216C51

--- a/src/pages/api/graphql.ts
+++ b/src/pages/api/graphql.ts
@@ -1,8 +1,10 @@
+/* eslint-disable import/order */
+
 import { ApolloServer } from "@apollo/server";
+import responseCachePlugin from "@apollo/server-plugin-response-cache";
 import { ApolloServerPluginCacheControl } from "@apollo/server/plugin/cacheControl";
 import { ApolloServerPluginLandingPageDisabled } from "@apollo/server/plugin/disabled";
 import { ApolloServerPluginLandingPageLocalDefault } from "@apollo/server/plugin/landingPage/default";
-import responseCachePlugin from "@apollo/server-plugin-response-cache";
 import { startServerAndCreateNextHandler } from "@as-integrations/next";
 import { NextApiHandler } from "next";
 
@@ -11,8 +13,7 @@ import { resolvers } from "src/graphql/resolvers";
 import typeDefs from "src/graphql/schema.graphql";
 import { context } from "src/graphql/server-context";
 import assert from "src/lib/assert";
-
-import { metricsPlugin } from "./metricsPlugin";
+import { metricsPlugin } from "src/pages/api/metricsPlugin";
 
 assert(!!serverEnv, "serverEnv is not defined");
 

--- a/src/pages/canton/[id].tsx
+++ b/src/pages/canton/[id].tsx
@@ -6,16 +6,16 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import basicAuthMiddleware from "nextjs-basic-auth-middleware";
 
-import { DetailPageBanner } from "../../components/detail-page/banner";
-import { CantonsComparisonRangePlots } from "../../components/detail-page/cantons-comparison-range";
-import { DetailPageLayout } from "../../components/detail-page/layout";
-import { PriceComponentsBarChart } from "../../components/detail-page/price-components-bars";
-import { PriceDistributionHistograms } from "../../components/detail-page/price-distribution-histogram";
-import { PriceEvolution } from "../../components/detail-page/price-evolution-line-chart";
-import { SelectorMulti } from "../../components/detail-page/selector-multi";
-import { Footer } from "../../components/footer";
-import { Header } from "../../components/header";
-import { getCanton } from "../../rdf/queries";
+import { DetailPageBanner } from "src/components/detail-page/banner";
+import { CantonsComparisonRangePlots } from "src/components/detail-page/cantons-comparison-range";
+import { DetailPageLayout } from "src/components/detail-page/layout";
+import { PriceComponentsBarChart } from "src/components/detail-page/price-components-bars";
+import { PriceDistributionHistograms } from "src/components/detail-page/price-distribution-histogram";
+import { PriceEvolution } from "src/components/detail-page/price-evolution-line-chart";
+import { SelectorMulti } from "src/components/detail-page/selector-multi";
+import { Footer } from "src/components/footer";
+import { Header } from "src/components/header";
+import { getCanton } from "src/rdf/queries";
 
 type Props =
   | {

--- a/src/pages/canton/[id].tsx
+++ b/src/pages/canton/[id].tsx
@@ -22,9 +22,11 @@ type Props =
       status: "found";
       id: string;
       name: string;
-      // operators: { id: string; name: string }[];
     }
-  | { status: "notfound" };
+  | {
+      status: "notfound";
+    };
+
 export const getServerSideProps: GetServerSideProps<
   Props,
   { locale: string; id: string }
@@ -51,6 +53,7 @@ const CantonPage = (props: Props) => {
   }
 
   const { id, name } = props;
+
   return (
     <>
       <Head>

--- a/src/pages/embed.tsx
+++ b/src/pages/embed.tsx
@@ -38,9 +38,11 @@ export const getServerSideProps: GetServerSideProps<
 
 const assertBaseDomainOK = (baseDomain: string) => {
   const url = new URL(baseDomain);
+
   if (url.hostname.endsWith("elcom.admin.ch") || url.hostname === "localhost") {
     return true;
   }
+
   throw new Error("Bad baseDomain, baseDomain should end with elcom.admin.ch");
 };
 

--- a/src/pages/embed.tsx
+++ b/src/pages/embed.tsx
@@ -5,6 +5,12 @@ import basicAuthMiddleware from "nextjs-basic-auth-middleware";
 import { useCallback, useMemo, useState } from "react";
 
 import {
+  HighlightContext,
+  HighlightValue,
+} from "src/components/highlight-context";
+import { ChoroplethMap } from "src/components/map";
+import { useColorScale } from "src/domain/data";
+import {
   PriceComponent,
   useAllMunicipalitiesQuery,
   useObservationsQuery,
@@ -13,27 +19,22 @@ import { EMPTY_ARRAY } from "src/lib/empty-array";
 import { useQueryStateSingle } from "src/lib/use-query-state";
 import { defaultLocale } from "src/locales/locales";
 
-import {
-  HighlightContext,
-  HighlightValue,
-} from "../components/highlight-context";
-import { ChoroplethMap } from "../components/map";
-import { useColorScale } from "../domain/data";
-
 type Props = {
   locale: string;
 };
 
-export const getServerSideProps: GetServerSideProps<Props, { locale: string }> =
-  async ({ locale, req, res }) => {
-    await basicAuthMiddleware(req, res);
+export const getServerSideProps: GetServerSideProps<
+  Props,
+  { locale: string }
+> = async ({ locale, req, res }) => {
+  await basicAuthMiddleware(req, res);
 
-    return {
-      props: {
-        locale: locale ?? defaultLocale,
-      },
-    };
+  return {
+    props: {
+      locale: locale ?? defaultLocale,
+    },
   };
+};
 
 const assertBaseDomainOK = (baseDomain: string) => {
   const url = new URL(baseDomain);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,8 +20,8 @@ import { List } from "src/components/list";
 import { ChoroplethMap, ChoroplethMapProps } from "src/components/map";
 import { Search } from "src/components/search";
 import { Selector } from "src/components/selector";
-import { useDisclosure } from "src/components/useDisclosure";
-import useOutsideClick from "src/components/useOutsideClick";
+import { useDisclosure } from "src/components/use-disclosure";
+import { useOutsideClick } from "src/components/use-outside-click";
 import { useColorScale } from "src/domain/data";
 import {
   PriceComponent,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,6 +12,7 @@ import {
   useAllMunicipalitiesQuery,
   useObservationsQuery,
 } from "src/graphql/queries";
+import { copyToClipboard } from "src/lib/copy-to-clipboard";
 import { EMPTY_ARRAY } from "src/lib/empty-array";
 import { useQueryStateSingle } from "src/lib/use-query-state";
 import { defaultLocale } from "src/locales/locales";
@@ -55,14 +56,6 @@ export const getServerSideProps: GetServerSideProps<
 
 const HEADER_HEIGHT_S = "107px";
 const HEADER_HEIGHT_M_UP = "96px";
-
-const copyToClipboard = async function (text: string) {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch (error) {
-    console.error("Failed to copy text to clipboard:", error);
-  }
-};
 
 const ShareButton = () => {
   const { isOpen, open, close } = useDisclosure();

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,33 +7,32 @@ import { useRouter } from "next/router";
 import basicAuthMiddleware from "nextjs-basic-auth-middleware";
 import { useCallback, useRef, useState } from "react";
 
+import { TooltipBox } from "src/components/charts-generic/interaction/tooltip-box";
+import { DownloadImage } from "src/components/detail-page/download-image";
+import { Footer } from "src/components/footer";
+import { Header } from "src/components/header";
+import {
+  HighlightContext,
+  HighlightValue,
+} from "src/components/highlight-context";
+import { InfoBanner } from "src/components/info-banner";
+import { List } from "src/components/list";
+import { ChoroplethMap, ChoroplethMapProps } from "src/components/map";
+import { Search } from "src/components/search";
+import { Selector } from "src/components/selector";
+import { useDisclosure } from "src/components/useDisclosure";
+import useOutsideClick from "src/components/useOutsideClick";
+import { useColorScale } from "src/domain/data";
 import {
   PriceComponent,
   useAllMunicipalitiesQuery,
   useObservationsQuery,
 } from "src/graphql/queries";
+import { IconCopy } from "src/icons/ic-copy";
 import { copyToClipboard } from "src/lib/copy-to-clipboard";
 import { EMPTY_ARRAY } from "src/lib/empty-array";
 import { useQueryStateSingle } from "src/lib/use-query-state";
 import { defaultLocale } from "src/locales/locales";
-
-import { TooltipBox } from "../components/charts-generic/interaction/tooltip-box";
-import { DownloadImage } from "../components/detail-page/download-image";
-import { Footer } from "../components/footer";
-import { Header } from "../components/header";
-import {
-  HighlightContext,
-  HighlightValue,
-} from "../components/highlight-context";
-import { InfoBanner } from "../components/info-banner";
-import { List } from "../components/list";
-import { ChoroplethMap, ChoroplethMapProps } from "../components/map";
-import { Search } from "../components/search";
-import { Selector } from "../components/selector";
-import { useDisclosure } from "../components/useDisclosure";
-import useOutsideClick from "../components/useOutsideClick";
-import { useColorScale } from "../domain/data";
-import { IconCopy } from "../icons/ic-copy";
 
 const DOWNLOAD_ID = "map";
 

--- a/src/pages/municipality/[id].tsx
+++ b/src/pages/municipality/[id].tsx
@@ -5,22 +5,21 @@ import ErrorPage from "next/error";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import basicAuthMiddleware from "nextjs-basic-auth-middleware";
-import * as React from "react";
 
-import { DetailPageBanner } from "../../components/detail-page/banner";
-import { CantonsComparisonRangePlots } from "../../components/detail-page/cantons-comparison-range";
-import { DetailPageLayout } from "../../components/detail-page/layout";
-import { PriceComponentsBarChart } from "../../components/detail-page/price-components-bars";
-import { PriceDistributionHistograms } from "../../components/detail-page/price-distribution-histogram";
-import { PriceEvolution } from "../../components/detail-page/price-evolution-line-chart";
-import { SelectorMulti } from "../../components/detail-page/selector-multi";
-import { Footer } from "../../components/footer";
-import { Header } from "../../components/header";
+import { DetailPageBanner } from "src/components/detail-page/banner";
+import { CantonsComparisonRangePlots } from "src/components/detail-page/cantons-comparison-range";
+import { DetailPageLayout } from "src/components/detail-page/layout";
+import { PriceComponentsBarChart } from "src/components/detail-page/price-components-bars";
+import { PriceDistributionHistograms } from "src/components/detail-page/price-distribution-histogram";
+import { PriceEvolution } from "src/components/detail-page/price-evolution-line-chart";
+import { SelectorMulti } from "src/components/detail-page/selector-multi";
+import { Footer } from "src/components/footer";
+import { Header } from "src/components/header";
 import {
   getDimensionValuesAndLabels,
   getMunicipality,
   getObservationsCube,
-} from "../../rdf/queries";
+} from "src/rdf/queries";
 
 type Props =
   | {
@@ -31,38 +30,40 @@ type Props =
     }
   | { status: "notfound" };
 
-export const getServerSideProps: GetServerSideProps<Props, { id: string }> =
-  async ({ params, req, res, locale }) => {
-    await basicAuthMiddleware(req, res);
+export const getServerSideProps: GetServerSideProps<
+  Props,
+  { id: string }
+> = async ({ params, req, res, locale }) => {
+  await basicAuthMiddleware(req, res);
 
-    const { id } = params!;
+  const { id } = params!;
 
-    const municipality = await getMunicipality({ id });
+  const municipality = await getMunicipality({ id });
 
-    if (!municipality) {
-      res.statusCode = 404;
-      return { props: { status: "notfound" } };
-    }
+  if (!municipality) {
+    res.statusCode = 404;
+    return { props: { status: "notfound" } };
+  }
 
-    const cube = await getObservationsCube();
+  const cube = await getObservationsCube();
 
-    const operators = await getDimensionValuesAndLabels({
-      cube,
-      dimensionKey: "operator",
-      filters: { municipality: [id] },
-    });
+  const operators = await getDimensionValuesAndLabels({
+    cube,
+    dimensionKey: "operator",
+    filters: { municipality: [id] },
+  });
 
-    return {
-      props: {
-        status: "found",
-        id,
-        name: municipality.name,
-        operators: operators
-          .sort((a, b) => a.name.localeCompare(b.name, locale))
-          .map(({ id, name }) => ({ id, name })),
-      },
-    };
+  return {
+    props: {
+      status: "found",
+      id,
+      name: municipality.name,
+      operators: operators
+        .sort((a, b) => a.name.localeCompare(b.name, locale))
+        .map(({ id, name }) => ({ id, name })),
+    },
   };
+};
 
 const MunicipalityPage = (props: Props) => {
   const { query } = useRouter();

--- a/src/pages/municipality/[id].tsx
+++ b/src/pages/municipality/[id].tsx
@@ -28,7 +28,9 @@ type Props =
       name: string;
       operators: { id: string; name: string }[];
     }
-  | { status: "notfound" };
+  | {
+      status: "notfound";
+    };
 
 export const getServerSideProps: GetServerSideProps<
   Props,

--- a/src/pages/operator/[id].tsx
+++ b/src/pages/operator/[id].tsx
@@ -6,21 +6,21 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import basicAuthMiddleware from "nextjs-basic-auth-middleware";
 
-import { DetailPageBanner } from "../../components/detail-page/banner";
-import { CantonsComparisonRangePlots } from "../../components/detail-page/cantons-comparison-range";
-import { DetailPageLayout } from "../../components/detail-page/layout";
-import { PriceComponentsBarChart } from "../../components/detail-page/price-components-bars";
-import { PriceDistributionHistograms } from "../../components/detail-page/price-distribution-histogram";
-import { PriceEvolution } from "../../components/detail-page/price-evolution-line-chart";
-import { SelectorMulti } from "../../components/detail-page/selector-multi";
-import { Footer } from "../../components/footer";
-import { Header } from "../../components/header";
-import { OperatorDocuments } from "../../components/operator-documents";
+import { DetailPageBanner } from "src/components/detail-page/banner";
+import { CantonsComparisonRangePlots } from "src/components/detail-page/cantons-comparison-range";
+import { DetailPageLayout } from "src/components/detail-page/layout";
+import { PriceComponentsBarChart } from "src/components/detail-page/price-components-bars";
+import { PriceDistributionHistograms } from "src/components/detail-page/price-distribution-histogram";
+import { PriceEvolution } from "src/components/detail-page/price-evolution-line-chart";
+import { SelectorMulti } from "src/components/detail-page/selector-multi";
+import { Footer } from "src/components/footer";
+import { Header } from "src/components/header";
+import { OperatorDocuments } from "src/components/operator-documents";
 import {
   getDimensionValuesAndLabels,
   getObservationsCube,
   getOperator,
-} from "../../rdf/queries";
+} from "src/rdf/queries";
 
 type Props =
   | {
@@ -30,38 +30,40 @@ type Props =
       municipalities: { id: string; name: string }[];
     }
   | { status: "notfound" };
-export const getServerSideProps: GetServerSideProps<Props, { id: string }> =
-  async ({ params, req, res, locale }) => {
-    await basicAuthMiddleware(req, res);
+export const getServerSideProps: GetServerSideProps<
+  Props,
+  { id: string }
+> = async ({ params, req, res, locale }) => {
+  await basicAuthMiddleware(req, res);
 
-    const { id } = params!;
+  const { id } = params!;
 
-    const operator = await getOperator({ id });
+  const operator = await getOperator({ id });
 
-    if (!operator) {
-      res.statusCode = 404;
-      return { props: { status: "notfound" } };
-    }
+  if (!operator) {
+    res.statusCode = 404;
+    return { props: { status: "notfound" } };
+  }
 
-    const cube = await getObservationsCube();
+  const cube = await getObservationsCube();
 
-    const municipalities = await getDimensionValuesAndLabels({
-      cube,
-      dimensionKey: "municipality",
-      filters: { operator: [id] },
-    });
+  const municipalities = await getDimensionValuesAndLabels({
+    cube,
+    dimensionKey: "municipality",
+    filters: { operator: [id] },
+  });
 
-    return {
-      props: {
-        status: "found",
-        id,
-        name: operator.name,
-        municipalities: municipalities
-          .sort((a, b) => a.name.localeCompare(b.name, locale))
-          .map(({ id, name }) => ({ id, name })),
-      },
-    };
+  return {
+    props: {
+      status: "found",
+      id,
+      name: operator.name,
+      municipalities: municipalities
+        .sort((a, b) => a.name.localeCompare(b.name, locale))
+        .map(({ id, name }) => ({ id, name })),
+    },
   };
+};
 
 const OperatorPage = (props: Props) => {
   const { query } = useRouter();

--- a/src/pages/operator/[id].tsx
+++ b/src/pages/operator/[id].tsx
@@ -29,7 +29,10 @@ type Props =
       name: string;
       municipalities: { id: string; name: string }[];
     }
-  | { status: "notfound" };
+  | {
+      status: "notfound";
+    };
+
 export const getServerSideProps: GetServerSideProps<
   Props,
   { id: string }
@@ -67,11 +70,13 @@ export const getServerSideProps: GetServerSideProps<
 
 const OperatorPage = (props: Props) => {
   const { query } = useRouter();
+
   if (props.status === "notfound") {
     return <ErrorPage statusCode={404} />;
   }
 
   const { id, name, municipalities } = props;
+
   return (
     <>
       <Head>

--- a/src/rdf/namespace.ts
+++ b/src/rdf/namespace.ts
@@ -3,21 +3,13 @@ import namespace from "@rdfjs/namespace";
 export { rdf, schema, sh } from "@tpluscode/rdf-ns-builders";
 
 export const schemaAdmin = namespace("https://schema.ld.admin.ch/");
-// export const adminTerm = namespace("https://ld.admin.ch/definedTerm/");
-
-// export const cube = namespace("https://cube.link/");
-// export const cubeView = namespace("https://cube.link/view/");
-// export const cubeMeta = namespace("https://cube.link/meta/");
-
 export const visualizeAdmin = namespace("https://visualize.admin.ch/");
-
-export const electricityprice = namespace(
+export const electricityPrice = namespace(
   "https://energy.ld.admin.ch/elcom/electricityprice/"
 );
-export const electricitypriceDimension = namespace(
+export const electricityPriceDimension = namespace(
   "https://energy.ld.admin.ch/elcom/electricityprice/dimension/"
 );
-
 export const municipality = namespace("https://ld.admin.ch/municipality/");
 export const canton = namespace("https://ld.admin.ch/canton/");
 
@@ -31,7 +23,6 @@ export const stripNamespaceFromIri = ({ iri }: { iri: string }): string => {
   const matches = iri.match(/\/([a-zA-Z0-9]+)$/);
 
   if (!matches) {
-    // Warn?
     return iri;
   }
 
@@ -55,11 +46,14 @@ export const addNamespaceToID = ({
   if (id.match(/^http(s)?:\/\//)) {
     return id;
   }
+
   if (dimension === "municipality") {
     return municipality(`${id}`).value;
   }
+
   if (dimension === "canton" || dimension === "region") {
     return canton(`${id}`).value;
   }
-  return electricityprice(`${dimension}/${id}`).value;
+
+  return electricityPrice(`${dimension}/${id}`).value;
 };

--- a/src/rdf/parse.ts
+++ b/src/rdf/parse.ts
@@ -1,1 +1,0 @@
-export const parseOperatorDocument = () => {};

--- a/src/rdf/queries.ts
+++ b/src/rdf/queries.ts
@@ -148,28 +148,28 @@ const getRegionDimensionsAndFilter = ({
   locale: string;
 }) => {
   const muniDimension = view.dimension({
-    cubeDimension: ns.electricitypriceDimension("municipality"),
+    cubeDimension: ns.electricityPriceDimension("municipality"),
   });
 
   const regionDimension = view.createDimension({
     source: lookupSource,
     path: ns.schema("containedInPlace"),
     join: muniDimension,
-    as: ns.electricitypriceDimension("region"),
+    as: ns.electricityPriceDimension("region"),
   });
 
   const regionLabelDimension = view.createDimension({
     source: lookupSource,
     path: ns.schema.name,
     join: regionDimension,
-    as: ns.electricitypriceDimension("regionLabel"),
+    as: ns.electricityPriceDimension("regionLabel"),
   });
 
   const regionTypeDimension = view.createDimension({
     source: lookupSource,
     path: ns.rdf.type,
     join: regionDimension,
-    as: ns.electricitypriceDimension("regionType"),
+    as: ns.electricityPriceDimension("regionType"),
   });
 
   const regionTypeFilter = regionTypeDimension.filter.eq(
@@ -213,12 +213,7 @@ export const getObservations = async (
   const queryFilters = filters
     ? Object.entries(filters).flatMap(([dimensionKey, filterValues]) =>
         filterValues
-          ? buildDimensionFilter(
-              view,
-              dimensionKey,
-              // dimensionKey.replace(/^canton/, "region"),
-              filterValues
-            ) ?? []
+          ? buildDimensionFilter(view, dimensionKey, filterValues) ?? []
           : []
       )
     : [];
@@ -238,14 +233,14 @@ export const getObservations = async (
         if (labelMatches) {
           const dimensionKey = labelMatches ? labelMatches[1] : d;
           const dimension = view.dimension({
-            cubeDimension: ns.electricitypriceDimension(dimensionKey),
+            cubeDimension: ns.electricityPriceDimension(dimensionKey),
           });
 
           const labelDimension = view.createDimension({
             source: lookupSource,
             path: ns.schema.name,
             join: dimension,
-            as: ns.electricitypriceDimension(`${dimensionKey}Label`),
+            as: ns.electricityPriceDimension(`${dimensionKey}Label`),
           });
 
           // FIXME: we only add the language filter on region labels because we can't use it on strings without language tag (yet?!)
@@ -262,24 +257,23 @@ export const getObservations = async (
         if (idMatches) {
           const dimensionKey = idMatches ? idMatches[1] : d;
           const dimension = view.dimension({
-            cubeDimension: ns.electricitypriceDimension(dimensionKey),
+            cubeDimension: ns.electricityPriceDimension(dimensionKey),
           });
 
           const idDimension = view.createDimension({
             source: lookupSource,
             path: ns.schema.identifier,
             join: dimension,
-            as: ns.electricitypriceDimension(`${dimensionKey}Identifier`),
+            as: ns.electricityPriceDimension(`${dimensionKey}Identifier`),
           });
 
           return dimension ? [dimension, idDimension] : [];
         }
 
         const dimension = view.dimension({
-          cubeDimension: ns.electricitypriceDimension(d),
+          cubeDimension: ns.electricityPriceDimension(d),
         });
 
-        // console.log(ns.energyPricing(d).value, dimension);
         return dimension ? [dimension] : [];
       })
     : view.dimensions;
@@ -350,21 +344,14 @@ export const getDimensionValuesAndLabels = async ({
 
   const queryFilters = filters
     ? Object.entries(filters).flatMap(([dim, filterValues]) =>
-        filterValues
-          ? buildDimensionFilter(
-              view,
-              // dim.replace(/^canton/, "region"),
-              dim,
-              filterValues
-            ) ?? []
-          : []
+        filterValues ? buildDimensionFilter(view, dim, filterValues) ?? [] : []
       )
     : [];
 
   const lookupView = new View({ parent: source, filters: queryFilters });
 
   const dimension = view.dimension({
-    cubeDimension: ns.electricitypriceDimension(dimensionKey),
+    cubeDimension: ns.electricityPriceDimension(dimensionKey),
   });
 
   if (!dimension) {
@@ -377,7 +364,7 @@ export const getDimensionValuesAndLabels = async ({
     source: lookup,
     path: dimensionKey === "region" ? ns.schema.alternateName : ns.schema.name,
     join: dimension,
-    as: ns.electricitypriceDimension(`${dimensionKey}Label`),
+    as: ns.electricityPriceDimension(`${dimensionKey}Label`),
   });
   lookupView.addDimension(dimension).addDimension(labelDimension);
 
@@ -392,15 +379,15 @@ export const getDimensionValuesAndLabels = async ({
 
   return observations.flatMap((obs) => {
     // Filter out "empty" observations
-    return obs[ns.electricitypriceDimension(dimensionKey).value]
+    return obs[ns.electricityPriceDimension(dimensionKey).value]
       ? [
           {
             id: ns.stripNamespaceFromIri({
-              iri: obs[ns.electricitypriceDimension(dimensionKey).value]
+              iri: obs[ns.electricityPriceDimension(dimensionKey).value]
                 .value as string,
             }),
             name: obs[
-              ns.electricitypriceDimension(`${dimensionKey}Label`).value
+              ns.electricityPriceDimension(`${dimensionKey}Label`).value
             ].value as string,
             view,
             source,
@@ -410,15 +397,13 @@ export const getDimensionValuesAndLabels = async ({
   });
 };
 
-// export const getOperatorMunicipalities()
-
 export const getCubeDimension = (
   view: View,
   dimensionKey: string,
   { locale }: { locale: string }
 ) => {
   const viewDimension = view.dimension({
-    cubeDimension: ns.electricitypriceDimension(dimensionKey),
+    cubeDimension: ns.electricityPriceDimension(dimensionKey),
   });
 
   const cubeDimension = viewDimension?.cubeDimensions[0];
@@ -448,7 +433,7 @@ export const buildDimensionFilter = (
   filters: string[]
 ) => {
   const viewDimension = view.dimension({
-    cubeDimension: ns.electricitypriceDimension(dimensionKey),
+    cubeDimension: ns.electricityPriceDimension(dimensionKey),
   });
 
   const cubeDimension = viewDimension?.cubeDimensions[0];
@@ -496,7 +481,7 @@ export const getMunicipality = async ({
 
   const sparql = `
 SELECT DISTINCT ?name {
-  <${iri}> <http://schema.org/name> ?name.
+  <${iri}> <http://schema.org/name> ?name .
 }
   `;
 
@@ -593,13 +578,13 @@ export const getOperatorDocuments = async ({
   return results.map((d) => {
     const id = d.download.value;
     const year = d.year.value;
-    const category = ns.electricityprice`documenttype/tariffs_provider`.equals(
+    const category = ns.electricityPrice`documenttype/tariffs_provider`.equals(
       d.category
     )
       ? OperatorDocumentCategory.Tariffs
-      : ns.electricityprice`documenttype/annual_report`.equals(d.category)
+      : ns.electricityPrice`documenttype/annual_report`.equals(d.category)
       ? OperatorDocumentCategory.AnnualReport
-      : ns.electricityprice`documenttype/financial_statement`.equals(d.category)
+      : ns.electricityPrice`documenttype/financial_statement`.equals(d.category)
       ? OperatorDocumentCategory.FinancialStatement
       : null;
     const name = d.name.value;

--- a/src/rdf/search-queries.ts
+++ b/src/rdf/search-queries.ts
@@ -21,7 +21,7 @@ const vars = {
 };
 
 const graphs = {
-  electricityprice: rdf.namedNode(
+  electricityPrice: rdf.namedNode(
     "https://lindas.admin.ch/elcom/electricityprice"
   ),
 };
@@ -30,7 +30,7 @@ const searchQueryBuilders = {
   zipCode: ({ query }: { query: string }) => {
     return sparql`{
     SELECT DISTINCT ("municipality" AS ${vars.type}) (?municipality AS ${vars.iri}) (?municipalityLabel AS ${vars.name})
-      WHERE { GRAPH ${graphs.electricityprice} {
+      WHERE { GRAPH ${graphs.electricityPrice} {
         ?offer a ${ns.schema.Offer} ;
           ${ns.schema.areaServed} ?municipality;
           ${ns.schema.postalCode} "${query}" .
@@ -54,7 +54,7 @@ const searchQueryBuilders = {
     operator: ({ query, limit }: { query: string; limit: number }) => {
       return sparql`{
       SELECT DISTINCT ("operator" AS ${vars.type}) (?operator AS ${vars.iri}) (?operatorLabel AS ${vars.name}) WHERE {
-        GRAPH ${graphs.electricityprice} {
+        GRAPH ${graphs.electricityPrice} {
           ?operator a ${ns.schema.Organization} .
           ?operator ${ns.schema.name} ?operatorLabel.    
         }
@@ -115,12 +115,12 @@ const searchQueryBuilders = {
         SELECT DISTINCT ("operator" AS ${vars.type}) (?operator AS ${
         vars.iri
       }) (?operatorLabel AS ${vars.name}) WHERE {
-          GRAPH ${graphs.electricityprice} {
+          GRAPH ${graphs.electricityPrice} {
             ?operator a ${ns.schema.Organization} .
             ?operator ${ns.schema.name} ?operatorLabel.    
           }
           FILTER (?operator IN (${ids
-            .map((id) => `<${ns.electricityprice(`operator/${id}`).value}>`)
+            .map((id) => `<${ns.electricityPrice(`operator/${id}`).value}>`)
             .join(",")}))
         }
       }`;


### PR DESCRIPTION
This PR:
- consolidates imports to use the `src` alias,
- extracts some components out,
- renames some variables,
- corrects typos,
- cleans up 5-years old comments, unused code and some other patterns (e.g. `interface` -> `type`).

Hope it makes sense @ptbrowne, I was going through every file in the project to understand how it's structured and was correcting smaller things, mostly for consistency :)

Failed checks did so already on `main`, so I don't think it's a regression from this PR. We already had the same issue with GitLab mirroring in Visualize and fixed it by changing our GitHub Action library, I can take a look at this. For unit tests things, I can also take a look unless you have a suspicion @ptbrowne?