### PR TITLE
fix: GitLab mirror

### DIFF
--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -2,14 +2,26 @@ name: GitLab Mirror
 
 on: [push, delete]
 
+# Ensures that only one mirror task will run at a time.
+concurrency:
+  group: to_gitlab
+
 jobs:
   to_gitlab:
     runs-on: ubuntu-latest
-    steps:                                              # <-- must use actions/checkout@v1 before mirroring!
-    - uses: actions/checkout@v1
-    - uses: pixta-dev/repository-mirroring-action@v1
-      with:
-        target_repo_url:
-          git@gitlab.ldbar.ch:interactivethings/elcom-electricity-price-website.git
-        ssh_private_key:                                # <-- use 'secrets' to pass credential information.
-          ${{ secrets.GITLAB_SSH_PRIVATE_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Logging
+        run: |
+          git remote show origin
+          git for-each-ref
+      - name: Mirror to GitLab
+        uses: wearerequired/git-mirror-action@v1
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.GITLAB_SSH_PRIVATE_KEY }}
+        with:
+          source-repo: "git@github.com:visualize-admin/electricity-prices-switzerland.git"
+          destination-repo: "git@gitlab.ldbar.ch:interactivethings/elcom-electricity-price-website.git"


### PR DESCRIPTION
This PR fixes broken GitLab mirroring by changing the action we use and updating deploy tokens.