### PR TITLE
fix: Fixed tooltip positioning w/ increased offset

### DIFF
--- a/src/components/charts-generic/constants.ts
+++ b/src/components/charts-generic/constants.ts
@@ -3,3 +3,7 @@ export const BOTTOM_MARGIN_OFFSET = 10;
 
 // Horizontal chart
 export const BAR_HEIGHT = 24;
+
+// Histogram chart
+export const TOOLTIP_ARROW_HEIGHT = 8;
+export const VERTICAL_TICK_OFFSET = 19;

--- a/src/components/charts-generic/histogram/histogram-state.tsx
+++ b/src/components/charts-generic/histogram/histogram-state.tsx
@@ -1,6 +1,12 @@
 import { Box, Typography } from "@mui/material";
-import { ascending, histogram, max, min, scaleLinear } from "d3";
-import { interpolateHsl } from "d3";
+import {
+  ascending,
+  histogram,
+  interpolateHsl,
+  max,
+  min,
+  scaleLinear,
+} from "d3";
 import { ReactNode, useCallback } from "react";
 
 import { LEFT_MARGIN_OFFSET } from "src/components/charts-generic/constants";
@@ -115,7 +121,7 @@ const useHistogramState = ({
       datum: undefined,
       placement: { x: "center", y: "top" },
       xAnchor: xScale((d.x1! + d.x0!) / 2),
-      yAnchor: yScale(getY(d)) + margins.top - 10,
+      yAnchor: yScale(getY(d)) + margins.top - 30,
       xValue: "",
       tooltipContent: (
         <>

--- a/src/components/charts-generic/histogram/histogram-state.tsx
+++ b/src/components/charts-generic/histogram/histogram-state.tsx
@@ -1,15 +1,12 @@
 import { Box, Typography } from "@mui/material";
-import {
-  ascending,
-  histogram,
-  interpolateHsl,
-  max,
-  min,
-  scaleLinear,
-} from "d3";
+import { ascending, bin, interpolateHsl, max, min, scaleLinear } from "d3";
 import { ReactNode, useCallback } from "react";
 
-import { LEFT_MARGIN_OFFSET } from "src/components/charts-generic/constants";
+import {
+  LEFT_MARGIN_OFFSET,
+  TOOLTIP_ARROW_HEIGHT,
+  VERTICAL_TICK_OFFSET,
+} from "src/components/charts-generic/constants";
 import { Tooltip } from "src/components/charts-generic/interaction/tooltip";
 import { LegendSymbol } from "src/components/charts-generic/legends/color";
 import {
@@ -78,7 +75,7 @@ const useHistogramState = ({
     .range(palette.diverging)
     .interpolate(interpolateHsl);
   // y
-  const bins = histogram<GenericObservation, number>()
+  const bins = bin<GenericObservation, number>()
     .value((x) => getX(x))
     .domain([mkNumber(minValue), mkNumber(maxValue)])
     .thresholds(xScale.ticks(25))(data);
@@ -117,11 +114,15 @@ const useHistogramState = ({
     : [{ height: 0, nbOfLines: 1 }];
 
   const getAnnotationInfo = (d: (typeof bins)[number]): Tooltip => {
+    console.log(yScale(getY(d)));
     return {
-      datum: undefined,
       placement: { x: "center", y: "top" },
       xAnchor: xScale((d.x1! + d.x0!) / 2),
-      yAnchor: yScale(getY(d)) + margins.top - 30,
+      yAnchor:
+        yScale(getY(d)) +
+        margins.top -
+        TOOLTIP_ARROW_HEIGHT -
+        VERTICAL_TICK_OFFSET,
       xValue: "",
       tooltipContent: (
         <>
@@ -133,7 +134,7 @@ const useHistogramState = ({
             </Typography>
           </Box>
           <Typography variant="meta">
-            {yAxisLabel}:{d.length}
+            {yAxisLabel}: {d.length}
           </Typography>
         </>
       ),


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #63 

<!--- Describe the changes -->

This PR improves the tooltip positioning for the histogram Chart by increasing the offset from `10 -> 30`

<!--- Test instructions -->

## How to test

1. Go to this [link](https://elcom-electricity-price-website-git-fix-tooltip-ori-ed2b7e-ixt1.vercel.app/municipality/1402).
2. Scroll down to histograms
3. Hover over the chart
4. See how tooltip is overlapping the smaller bars and is aligned to the top of them ✅ 

## How to reproduce

1. Go to this [link](https://www.strompreis.elcom.admin.ch/municipality/1406)
2. Scroll down to histograms
5. Hover over the chart
6. See how tooltip is overlapping the smaller bars and is not aligned to the top of them ❌ 


---

- [x] I made a self-review of my own code

---

cc: @sosiology 