### PR TITLE
Refactor details page

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,13 +3,17 @@ import type { Decorator, Preview } from "@storybook/react";
 import React from "react";
 import { theme } from "../src/themes/elcom";
 import "./preview.css";
+import { i18n } from "../src/locales/locales";
+import { I18nProvider } from "@lingui/react";
 
 const withAppProviders: Decorator = (Story: any) => {
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <Story />
-    </ThemeProvider>
+    <I18nProvider i18n={i18n}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Story />
+      </ThemeProvider>
+    </I18nProvider>
   );
 };
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -40,6 +40,9 @@ const config: KnipConfig = {
 
     // Used through webpack loaders
     "raw-loader",
+
+    // Used when debugging
+    "react-inspector",
   ],
 };
 export default config;

--- a/src/components/combobox.stories.tsx
+++ b/src/components/combobox.stories.tsx
@@ -1,0 +1,230 @@
+import { useState } from "react";
+
+import { Combobox, ComboboxItem, ComboboxMulti } from "./combobox";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Combobox> = {
+  title: "Components/Combobox",
+  component: Combobox,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Combobox>;
+
+// Year Selection Story
+export const YearSelection: Story = {
+  render: () => {
+    const [selectedYear, setSelectedYear] = useState("2023");
+    const years = ["2019", "2020", "2021", "2022", "2023", "2024"];
+
+    return (
+      <div style={{ width: "300px" }}>
+        <Combobox
+          id="year-selection"
+          label="Select Year"
+          items={years}
+          selectedItem={selectedYear}
+          setSelectedItem={setSelectedYear}
+        />
+      </div>
+    );
+  },
+};
+
+// Municipality Selection Story
+export const MunicipalitySelection: Story = {
+  render: () => {
+    const [selectedMunicipality, setSelectedMunicipality] = useState("zurich");
+    const municipalities = [
+      { type: "header", title: "Popular Cities" },
+      "zurich",
+      "geneva",
+      "basel",
+      { type: "header", title: "Other Cities" },
+      "bern",
+      "lausanne",
+      "winterthur",
+      "lucerne",
+      "st-gallen",
+    ] satisfies ComboboxItem[];
+
+    const getLabel = (id: string) => {
+      const labels: Record<string, string> = {
+        zurich: "Zürich",
+        geneva: "Geneva",
+        basel: "Basel",
+        bern: "Bern",
+        lausanne: "Lausanne",
+        winterthur: "Winterthur",
+        lucerne: "Lucerne",
+        "st-gallen": "St. Gallen",
+      };
+      return labels[id] || id;
+    };
+
+    return (
+      <div style={{ width: "300px" }}>
+        <Combobox
+          id="municipality-selection"
+          label="Select Municipality"
+          items={municipalities}
+          selectedItem={selectedMunicipality}
+          setSelectedItem={setSelectedMunicipality}
+          getItemLabel={getLabel}
+          infoDialogSlug="municipality-info"
+        />
+      </div>
+    );
+  },
+};
+
+// Usage Category Selection Story
+export const UsageCategorySelection: Story = {
+  render: () => {
+    const [selectedCategory, setSelectedCategory] = useState("H1");
+    const categories = [
+      { type: "header", title: "Household Categories" },
+      "H1",
+      "H2",
+      "H3",
+      "H4",
+      "H5",
+      "H6",
+      "H7",
+      { type: "header", title: "Business Categories" },
+      "C1",
+      "C2",
+      "C3",
+      "C4",
+      "C5",
+      "C6",
+    ] satisfies ComboboxItem[];
+
+    const getCategoryLabel = (category: string) => {
+      const descriptions: Record<string, string> = {
+        H1: "H1 - Single apartment with 2 rooms",
+        H2: "H2 - Apartment with 4 rooms",
+        H3: "H3 - Single family house",
+        H4: "H4 - Large family house",
+        H5: "H5 - Small business",
+        H6: "H6 - Medium business",
+        H7: "H7 - Large business",
+        C1: "C1 - Small commercial",
+        C2: "C2 - Medium commercial",
+        C3: "C3 - Large commercial",
+        C4: "C4 - Small industrial",
+        C5: "C5 - Medium industrial",
+        C6: "C6 - Large industrial",
+      };
+      return descriptions[category] || category;
+    };
+
+    return (
+      <div style={{ width: "400px" }}>
+        <Combobox
+          id="usage-category-selection"
+          label="Select Usage Category"
+          items={categories}
+          selectedItem={selectedCategory}
+          setSelectedItem={setSelectedCategory}
+          getItemLabel={getCategoryLabel}
+        />
+      </div>
+    );
+  },
+};
+
+// Multi-Selection Example
+export const MultiSelection: StoryObj<typeof ComboboxMulti> = {
+  render: () => {
+    const [selectedMunicipalities, setSelectedMunicipalities] = useState([
+      "zurich",
+      "bern",
+    ]);
+    const municipalities = [
+      "zurich",
+      "geneva",
+      "basel",
+      "bern",
+      "lausanne",
+      "winterthur",
+      "lucerne",
+      "st-gallen",
+    ];
+
+    const getLabel = (id: string) => {
+      const labels: Record<string, string> = {
+        zurich: "Zürich",
+        geneva: "Geneva",
+        basel: "Basel",
+        bern: "Bern",
+        lausanne: "Lausanne",
+        winterthur: "Winterthur",
+        lucerne: "Lucerne",
+        "st-gallen": "St. Gallen",
+      };
+      return labels[id] || id;
+    };
+
+    return (
+      <div style={{ width: "400px" }}>
+        <ComboboxMulti
+          id="municipality-multi-selection"
+          label="Select Municipalities for Comparison"
+          items={municipalities}
+          selectedItems={selectedMunicipalities}
+          setSelectedItems={setSelectedMunicipalities}
+          getItemLabel={getLabel}
+          minSelectedItems={1}
+        />
+      </div>
+    );
+  },
+};
+
+// Disabled state example
+export const DisabledCombobox: Story = {
+  render: () => {
+    const [selectedYear, setSelectedYear] = useState("2023");
+    const years = ["2019", "2020", "2021", "2022", "2023", "2024"];
+
+    return (
+      <div style={{ width: "300px" }}>
+        <Combobox
+          id="disabled-year-selection"
+          label="Select Year (Disabled)"
+          items={years}
+          selectedItem={selectedYear}
+          setSelectedItem={setSelectedYear}
+          disabled={true}
+        />
+      </div>
+    );
+  },
+};
+
+// Error state example
+export const ErrorCombobox: Story = {
+  render: () => {
+    const [selectedYear, setSelectedYear] = useState("2023");
+    const years = ["2019", "2020", "2021", "2022", "2023", "2024"];
+
+    return (
+      <div style={{ width: "300px" }}>
+        <Combobox
+          id="error-year-selection"
+          label="Select Year (Error State)"
+          items={years}
+          selectedItem={selectedYear}
+          setSelectedItem={setSelectedYear}
+          error={true}
+        />
+      </div>
+    );
+  },
+};

--- a/src/components/combobox.tsx
+++ b/src/components/combobox.tsx
@@ -135,6 +135,8 @@ export const ComboboxMulti = ({
   );
 };
 
+export type ComboboxItem = string | { type: "header"; title: string };
+
 export const Combobox = ({
   id,
   label,
@@ -149,7 +151,7 @@ export const Combobox = ({
 }: {
   id: string;
   label: string;
-  items: (string | { type: "header"; title: string })[];
+  items: ComboboxItem[];
   selectedItem: string;
   setSelectedItem: (selectedItem: string) => void;
   getItemLabel?: (item: string) => string;

--- a/src/components/detail-page/layout.tsx
+++ b/src/components/detail-page/layout.tsx
@@ -30,11 +30,7 @@ type Props = {
   download?: string | string[];
 } & DetailsPageBaseProps;
 
-export const DetailPageContentLayout = ({
-  children,
-  selector,
-  download,
-}: Props) => {
+const DetailPageContentLayout = ({ children, selector, download }: Props) => {
   const renderedChildren = download
     ? Children.map(children, (child) => {
         if (

--- a/src/components/detail-page/layout.tsx
+++ b/src/components/detail-page/layout.tsx
@@ -1,7 +1,25 @@
 import { Box, Typography } from "@mui/material";
+import dynamic from "next/dynamic";
+import Head from "next/head";
 import { Children, isValidElement, ReactNode } from "react";
 
+import { useIsMobile } from "src/lib/use-mobile";
+
 import { SectionProps } from "./card";
+
+const ContentWrapper = dynamic(
+  () =>
+    import("@interactivethings/swiss-federal-ci/dist/components").then(
+      (mod) => mod.ContentWrapper
+    ),
+  { ssr: false }
+);
+
+const ApplicationLayout = dynamic(
+  () =>
+    import("src/components/app-layout").then((mod) => mod.ApplicationLayout),
+  { ssr: false }
+);
 
 type DetailsPageBaseProps = {
   children: ReactNode;
@@ -12,7 +30,11 @@ type Props = {
   download?: string | string[];
 } & DetailsPageBaseProps;
 
-export const DetailPageLayout = ({ children, selector, download }: Props) => {
+export const DetailPageContentLayout = ({
+  children,
+  selector,
+  download,
+}: Props) => {
   const renderedChildren = download
     ? Children.map(children, (child) => {
         if (
@@ -109,5 +131,75 @@ export const DetailsPageSubtitle = ({ children }: DetailsPageBaseProps) => {
     <Typography variant="body2" component={"h2"}>
       {children}
     </Typography>
+  );
+};
+
+// Generic DetailsPage component
+interface DetailsPageProps {
+  title: string;
+  BannerContent: React.ReactNode;
+  SidebarContent?: React.ReactNode;
+  MainContent: React.ReactNode;
+  download?: string | string[];
+}
+
+export const DetailsPageLayout = ({
+  title,
+  BannerContent,
+  SidebarContent,
+  MainContent,
+  download,
+}: DetailsPageProps) => {
+  const isMobile = useIsMobile();
+
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+      </Head>
+      <ApplicationLayout>
+        <Box
+          sx={{
+            borderBottomWidth: "1px",
+            borderBottomStyle: "solid",
+            borderBottomColor: "monochrome.300",
+          }}
+        >
+          <ContentWrapper
+            sx={{
+              flexGrow: 1,
+              backgroundColor: "background.paper",
+            }}
+          >
+            {BannerContent}
+          </ContentWrapper>
+        </Box>
+        <Box
+          sx={{
+            backgroundColor: "secondary.50",
+          }}
+        >
+          <ContentWrapper
+            sx={{
+              backgroundColor: "secondary.50",
+            }}
+          >
+            <Box
+              sx={{
+                flexGrow: 1,
+                bgcolor: "background.paper",
+              }}
+            >
+              <DetailPageContentLayout
+                download={download}
+                selector={!isMobile && SidebarContent ? SidebarContent : null}
+              >
+                {MainContent}
+              </DetailPageContentLayout>
+            </Box>
+          </ContentWrapper>
+        </Box>
+      </ApplicationLayout>
+    </>
   );
 };

--- a/src/components/map.stories.tsx
+++ b/src/components/map.stories.tsx
@@ -24,7 +24,7 @@ import { SunshineDataRow } from "src/graphql/resolver-types";
 import { truthy } from "src/lib/truthy";
 import {
   ElectricityCategory,
-  getOperatorMunicipalities,
+  getOperatorsMunicipalities,
 } from "src/rdf/queries";
 
 import { props } from "./map.mock";
@@ -112,7 +112,7 @@ export const Operators = () => {
     sunshineAttributeToElectricityCategory[attribute] ?? "all";
   const { data: operatorMunicipalities } = useFetch({
     key: `operator-municipalities-${period}-${electricityCategory}`,
-    queryFn: () => getOperatorMunicipalities(period, electricityCategory),
+    queryFn: () => getOperatorsMunicipalities(period, electricityCategory),
   });
   const { data: geoData } = useGeoData(period);
   const [sunshineTarriffs] = useSunshineTariffQuery({

--- a/src/components/map.stories.tsx
+++ b/src/components/map.stories.tsx
@@ -1,7 +1,5 @@
 import { GeoJsonLayer } from "@deck.gl/layers/typed";
 import DeckGL, { DeckGLRef } from "@deck.gl/react/typed";
-import { I18n } from "@lingui/core";
-import { I18nProvider } from "@lingui/react";
 import { Box, List, ListItemButton } from "@mui/material";
 import { Decorator } from "@storybook/react";
 import * as turf from "@turf/turf";
@@ -9,7 +7,6 @@ import { easeExpIn, mean, median } from "d3";
 import { Feature, Geometry, MultiPolygon, Polygon } from "geojson";
 import { keyBy } from "lodash";
 import { useCallback, useMemo, useRef, useState } from "react";
-import { ObjectInspector } from "react-inspector";
 import { createClient, Provider } from "urql";
 
 import { ChoroplethMap } from "src/components/map";
@@ -34,10 +31,6 @@ import { props } from "./map.mock";
 
 const TRANSPARENT = [255, 255, 255, 0] as [number, number, number, number];
 
-const i18n = new I18n({
-  locale: "en",
-});
-
 const colorAccessor = (d: { value: number }) => d.value;
 
 export const Example = () => {
@@ -47,25 +40,23 @@ export const Example = () => {
     accessor: colorAccessor,
   });
   return (
-    <I18nProvider i18n={i18n}>
-      <Box
-        width="800px"
-        height="800px"
-        position="relative"
-        sx={{
-          "& #deckgl-wrapper": {
-            width: "100%",
-            height: "100%",
-          },
-        }}
-      >
-        <ChoroplethMap
-          {...props}
-          colorScale={colorScale}
-          onMunicipalityLayerClick={() => {}}
-        />
-      </Box>
-    </I18nProvider>
+    <Box
+      width="800px"
+      height="800px"
+      position="relative"
+      sx={{
+        "& #deckgl-wrapper": {
+          width: "100%",
+          height: "100%",
+        },
+      }}
+    >
+      <ChoroplethMap
+        {...props}
+        colorScale={colorScale}
+        onMunicipalityLayerClick={() => {}}
+      />
+    </Box>
   );
 };
 
@@ -186,8 +177,7 @@ export const Operators = () => {
 
   const deckglRef = useRef<DeckGLRef>(null);
   return (
-    <I18nProvider i18n={i18n}>
-      <ObjectInspector data={sunshineTarriffs} />
+    <>
       Attribute selection
       <Box
         width="800px"
@@ -321,7 +311,7 @@ export const Operators = () => {
           ) : null}
         </Box>
       </Box>
-    </I18nProvider>
+    </>
   );
 };
 

--- a/src/data/shared-page-props.tsx
+++ b/src/data/shared-page-props.tsx
@@ -1,0 +1,106 @@
+import { ServerResponse, IncomingMessage } from "http";
+
+import { Entity } from "src/domain/data";
+import { defaultLocale } from "src/locales/locales";
+import {
+  getMunicipality,
+  getObservationsCube,
+  getDimensionValuesAndLabels,
+  getOperator,
+  getOperatorMunicipalities,
+  getCanton,
+} from "src/rdf/queries";
+
+export type PageParams = { locale: string; id: string; entity: Entity };
+
+export type Props =
+  | {
+      entity: "canton";
+      status: "found";
+      id: string;
+      name: string;
+    }
+  | {
+      entity: "municipality";
+      status: "found";
+      id: string;
+      name: string;
+      operators: { id: string; name: string }[];
+      locale: string;
+    }
+  | {
+      entity: "operator";
+      status: "found";
+      id: string;
+      name: string;
+      municipalities: { id: string; name: string }[];
+    }
+  | {
+      status: "notfound";
+    };
+
+export const handleMunicipalityEntity = async (
+  params: Omit<PageParams, "entity"> & { res: ServerResponse<IncomingMessage> }
+): Promise<Props> => {
+  const { id, locale, res } = params!;
+  const municipality = await getMunicipality({ id });
+
+  if (!municipality) {
+    res.statusCode = 404;
+    return { status: "notfound" };
+  }
+
+  const cube = await getObservationsCube();
+
+  const operators = await getDimensionValuesAndLabels({
+    cube,
+    dimensionKey: "operator",
+    filters: { municipality: [id] },
+  });
+
+  return {
+    entity: "municipality",
+    status: "found",
+    id,
+    name: municipality.name,
+    operators: operators
+      .sort((a, b) => a.name.localeCompare(b.name, locale))
+      .map(({ id, name }) => ({ id, name })),
+    locale: locale ?? defaultLocale,
+  };
+};
+export const handleOperatorsEntity = async (
+  params: Omit<PageParams, "entity"> & { res: ServerResponse<IncomingMessage> }
+): Promise<Props> => {
+  const { id, locale, res } = params!;
+  const operator = await getOperator({ id });
+
+  if (!operator) {
+    res.statusCode = 404;
+    return { status: "notfound" };
+  }
+
+  const municipalities = await getOperatorMunicipalities(id, locale);
+
+  return {
+    entity: "operator",
+    status: "found",
+    id,
+    name: operator.name,
+    municipalities: municipalities,
+  };
+};
+
+export const handleCantonEntity = async (
+  params: Omit<PageParams, "entity"> & { res: ServerResponse<IncomingMessage> }
+): Promise<Props> => {
+  const { id, locale, res } = params!;
+  const canton = await getCanton({ id, locale: locale! });
+
+  if (!canton) {
+    res.statusCode = 404;
+    return { status: "notfound" };
+  }
+
+  return { status: "found", id, name: canton.name, entity: "canton" };
+};

--- a/src/pages/[entity]/[id]/index.tsx
+++ b/src/pages/[entity]/[id]/index.tsx
@@ -1,23 +1,12 @@
 import { t, Trans } from "@lingui/macro";
-import { Box } from "@mui/material";
 import { GetServerSideProps } from "next";
-import dynamic from "next/dynamic";
 import ErrorPage from "next/error";
-import Head from "next/head";
 import { useRouter } from "next/router";
-
-const ContentWrapper = dynamic(
-  () =>
-    import("@interactivethings/swiss-federal-ci/dist/components").then(
-      (mod) => mod.ContentWrapper
-    ),
-  { ssr: false }
-);
 
 import { DetailPageBanner } from "src/components/detail-page/banner";
 import { CantonsComparisonRangePlots } from "src/components/detail-page/cantons-comparison-range";
 import {
-  DetailPageLayout,
+  DetailsPageLayout,
   DetailsPageHeader,
   DetailsPageSubtitle,
   DetailsPageTitle,
@@ -35,14 +24,7 @@ import {
   Props,
 } from "src/data/shared-page-props";
 import { getLocalizedLabel } from "src/domain/translation";
-import { useIsMobile } from "src/lib/use-mobile";
 import { defaultLocale } from "src/locales/locales";
-
-const ApplicationLayout = dynamic(
-  () =>
-    import("src/components/app-layout").then((mod) => mod.ApplicationLayout),
-  { ssr: false }
-);
 
 export const getServerSideProps: GetServerSideProps<
   Props,
@@ -87,6 +69,7 @@ export const getServerSideProps: GetServerSideProps<
   };
 };
 
+// Main page using the generic component
 const ElectricityTariffsPage = (props: Props) => {
   const { query } = useRouter();
 
@@ -96,97 +79,57 @@ const ElectricityTariffsPage = (props: Props) => {
 
   const { id, name, entity } = props;
 
-  const isMobile = useIsMobile();
+  const pageTitle = `${getLocalizedLabel({ id: entity })} ${name} – ${t({
+    id: "site.title",
+    message: "Stromtarife und Vorschriften",
+  })}`;
+
+  const bannerContent = (
+    <DetailPageBanner
+      id={id}
+      name={name}
+      operators={entity === "municipality" ? props.operators : undefined}
+      municipalities={entity === "operator" ? props.municipalities : undefined}
+      entity={entity}
+    />
+  );
+
+  const sidebarContent = <DetailsPageSidebar id={id} entity={entity} />;
+
+  const mainContent = (
+    <>
+      <DetailsPageHeader>
+        <DetailsPageTitle>
+          <Trans id="page.electricity-tariffs.title">Stromtarife</Trans>
+        </DetailsPageTitle>
+        <DetailsPageSubtitle>
+          <Trans id="page.electricity-tariffs.description">
+            Auf der Detailseite des Netzbetreibers finden Sie aktuelle
+            Informationen zu den Stromtarifen, die einen Preisvergleich
+            ermöglichen. Sie können die Aufschlüsselung der Energie-, Netz- und
+            Zusatzkosten einsehen und unter historische Trends abrufen, um ein
+            besseres Verständnis der Stromkosten von zu erhalten.
+          </Trans>
+        </DetailsPageSubtitle>
+      </DetailsPageHeader>
+
+      <SelectorMulti entity={entity} />
+
+      <PriceComponentsBarChart id={id} entity={entity} />
+      <PriceEvolution id={id} entity={entity} />
+      <PriceDistributionHistograms id={id} entity={entity} />
+      <CantonsComparisonRangePlots id={id} entity={entity} />
+    </>
+  );
 
   return (
-    <>
-      <Head>
-        <title>{`${getLocalizedLabel({ id: entity })} ${name} – ${t({
-          id: "site.title",
-          message: "Stromtarife und Vorschriften",
-        })}`}</title>
-      </Head>
-      <ApplicationLayout>
-        <Box
-          sx={{
-            borderBottomWidth: "1px",
-            borderBottomStyle: "solid",
-            borderBottomColor: "monochrome.300",
-          }}
-        >
-          <ContentWrapper
-            sx={{
-              flexGrow: 1,
-              backgroundColor: "background.paper",
-            }}
-          >
-            <DetailPageBanner
-              id={id}
-              name={name}
-              operators={
-                entity === "municipality" ? props.operators : undefined
-              }
-              municipalities={
-                entity === "operator" ? props.municipalities : undefined
-              }
-              entity={entity}
-            />
-          </ContentWrapper>
-        </Box>
-        <Box
-          sx={{
-            backgroundColor: "secondary.50",
-          }}
-        >
-          <ContentWrapper
-            sx={{
-              backgroundColor: "secondary.50",
-            }}
-          >
-            <Box
-              sx={{
-                flexGrow: 1,
-                bgcolor: "background.paper",
-              }}
-            >
-              <DetailPageLayout
-                download={query.download}
-                selector={
-                  !isMobile ? (
-                    <DetailsPageSidebar id={id} entity={entity} />
-                  ) : null
-                }
-              >
-                <DetailsPageHeader>
-                  <DetailsPageTitle>
-                    <Trans id="page.electricity-tariffs.title">
-                      Stromtarife
-                    </Trans>
-                  </DetailsPageTitle>
-                  <DetailsPageSubtitle>
-                    <Trans id="page.electricity-tariffs.description">
-                      Auf der Detailseite des Netzbetreibers finden Sie aktuelle
-                      Informationen zu den Stromtarifen, die einen
-                      Preisvergleich ermöglichen. Sie können die Aufschlüsselung
-                      der Energie-, Netz- und Zusatzkosten einsehen und unter
-                      historische Trends abrufen, um ein besseres Verständnis
-                      der Stromkosten von zu erhalten.
-                    </Trans>
-                  </DetailsPageSubtitle>
-                </DetailsPageHeader>
-
-                <SelectorMulti entity={entity} />
-
-                <PriceComponentsBarChart id={id} entity={entity} />
-                <PriceEvolution id={id} entity={entity} />
-                <PriceDistributionHistograms id={id} entity={entity} />
-                <CantonsComparisonRangePlots id={id} entity={entity} />
-              </DetailPageLayout>
-            </Box>
-          </ContentWrapper>
-        </Box>
-      </ApplicationLayout>
-    </>
+    <DetailsPageLayout
+      title={pageTitle}
+      BannerContent={bannerContent}
+      SidebarContent={sidebarContent}
+      MainContent={mainContent}
+      download={query.download}
+    />
   );
 };
 

--- a/src/rdf/queries.ts
+++ b/src/rdf/queries.ts
@@ -532,7 +532,7 @@ export type ElectricityCategory =
   | "H7"
   | "H8";
 
-export const getOperatorMunicipalities = async (
+export const getOperatorsMunicipalities = async (
   year: string,
   category: ElectricityCategory | "all",
   client = sparqlClient
@@ -580,8 +580,22 @@ export const getOperatorMunicipalities = async (
 };
 
 export type OperatorMunicipalityRecord = Awaited<
-  ReturnType<typeof getOperatorMunicipalities>
+  ReturnType<typeof getOperatorsMunicipalities>
 >[number];
+
+export const getOperatorMunicipalities = async (id: string, locale: string) => {
+  const cube = await getObservationsCube();
+
+  const municipalities = await getDimensionValuesAndLabels({
+    cube,
+    dimensionKey: "municipality",
+    filters: { operator: [id] },
+  });
+
+  return municipalities
+    .sort((a, b) => a.name.localeCompare(b.name, locale))
+    .map(({ id, name }) => ({ id, name }));
+};
 
 export const getSparqlEditorUrl = (query: string): string | null => {
   assert(!!serverEnv, "serverEnv is not defined");


### PR DESCRIPTION
Refactor the electricity tariffs page

Make the layout & props easier to reuse.
The electricity tariffs page reuses the details page layout components.
The sunshine pages will be able to use this details page layout.

