### PR TITLE
Display map

### DIFF
--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -434,7 +434,7 @@ export const ChoroplethMap = ({
       new GeoJsonLayer({
         id: "municipalities-base",
         /** @ts-expect-error bad types */
-        data: geoData.municipalities,
+        data: geoData.data.municipalities,
         pickable: true,
         stroked: false,
         filled: true,
@@ -474,7 +474,7 @@ export const ChoroplethMap = ({
       new GeoJsonLayer({
         id: "municipality-mesh",
         /** @ts-expect-error GeoJsonLayer type seems bad */
-        data: geoData.municipalityMesh,
+        data: geoData.data.municipalityMesh,
         pickable: false,
         stroked: true,
         filled: false,
@@ -488,7 +488,7 @@ export const ChoroplethMap = ({
       new GeoJsonLayer({
         id: "lakes",
         /** @ts-expect-error GeoJsonLayer type seems bad */
-        data: geoData.lakes,
+        data: geoData.data.lakes,
         pickable: false,
         stroked: true,
         filled: true,
@@ -503,7 +503,7 @@ export const ChoroplethMap = ({
         id: "cantons",
 
         /** @ts-expect-error GeoJsonLayer type seems bad */
-        data: geoData.cantonMesh,
+        data: geoData.data.cantonMesh,
         pickable: false,
         stroked: true,
         filled: false,
@@ -521,7 +521,7 @@ export const ChoroplethMap = ({
       new GeoJsonLayer({
         id: "municipalities-overlay",
         /** @ts-expect-error bad types */
-        data: geoData.municipalities,
+        data: geoData.data.municipalities,
         pickable: false,
         stroked: true,
         filled: true,

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -1,5 +1,4 @@
 import {
-  Deck,
   MapController,
   PickingInfo,
   WebMercatorViewport,
@@ -11,7 +10,6 @@ import { Trans } from "@lingui/macro";
 import { Box, Typography } from "@mui/material";
 import centroid from "@turf/centroid";
 import { extent, group, mean, rollup, ScaleThreshold } from "d3";
-import html2canvas from "html2canvas";
 import React, {
   ComponentProps,
   Fragment,
@@ -32,6 +30,7 @@ import { constrainZoom, getFillColor } from "src/components/map-helpers";
 import { MapPriceColorLegend } from "src/components/price-color-legend";
 import { useGeoData } from "src/data/geo";
 import { useFormatCurrency } from "src/domain/helpers";
+import { getImageData, SCREENSHOT_CANVAS_SIZE } from "src/domain/screenshot";
 import { OperatorObservationFieldsFragment } from "src/graphql/queries";
 import { maxBy } from "src/lib/array";
 import { useIsMobile } from "src/lib/use-mobile";
@@ -167,102 +166,6 @@ type HoverState =
       value: number;
       label: string;
     };
-
-const toBlob = (canvas: HTMLCanvasElement, type: string) =>
-  new Promise<Blob | null>((resolve) => {
-    canvas.toBlob((blob) => resolve(blob), type);
-  });
-
-const SCREENSHOT_IMAGE_SIZE = {
-  width: 1120,
-  height: 928,
-};
-
-const SCREENSHOT_CANVAS_SIZE = {
-  width: 1120,
-  height: 730,
-};
-
-/**
- * Get the map as an image, using the Deck.gl canvas and html2canvas to get
- * the legend as an image.
- */
-const getImageData = async (deck: Deck, legend: HTMLElement) => {
-  if (!deck || "canvas" in deck === false) {
-    return;
-  }
-
-  // @ts-expect-error canvas is private
-  const canvas = deck.canvas;
-  if (!canvas) {
-    return;
-  }
-
-  const initialSize = {
-    width: canvas.width,
-    height: canvas.height,
-  };
-
-  const imageSize = {
-    width: SCREENSHOT_IMAGE_SIZE.width * 2,
-    height: SCREENSHOT_IMAGE_SIZE.height * 2,
-  };
-  const canvasSize = {
-    width: SCREENSHOT_CANVAS_SIZE.width * 2,
-    height: SCREENSHOT_CANVAS_SIZE.height * 2,
-  };
-
-  Object.assign(canvas, canvasSize);
-  deck.redraw("New size");
-
-  const newCanvas = document.createElement("canvas");
-  newCanvas.width = imageSize.width;
-  newCanvas.height = imageSize.height;
-  const context = newCanvas.getContext("2d");
-  if (!context) {
-    return;
-  }
-
-  // Using html2canvas, take the legend element, and draw it on the new canvas
-  // Make a new canvas element to convert the image to a png
-  // We need a new canvas since we will draw the legend onto it
-  context.fillStyle = "white";
-  context.fillRect(0, 0, newCanvas.width, newCanvas.height);
-
-  const ratio = window.devicePixelRatio;
-  context.drawImage(
-    canvas,
-    (newCanvas.width - canvas.width) / 2,
-    (newCanvas.height - canvas.height) / 2,
-    canvas.width,
-    canvas.height
-  );
-
-  const legendCanvas = await html2canvas(legend);
-
-  // We need to draw the legend using the device pixel ratio otherwise we get
-  // difference between different browsers (Safari legend would be bigger somehow)
-  const { width, height } = legend.getBoundingClientRect();
-
-  const legendPadding = 24;
-  context.drawImage(
-    legendCanvas,
-    legendPadding,
-    legendPadding,
-    width * ratio,
-    height * ratio
-  );
-
-  // Returns the canvas as a png
-  const res = await toBlob(newCanvas, "image/png").then((blob) =>
-    blob ? URL.createObjectURL(blob) : undefined
-  );
-
-  Object.assign(canvas, initialSize);
-  deck.redraw("Initial size");
-
-  return res;
-};
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 const frame = () => new Promise((resolve) => requestAnimationFrame(resolve));

--- a/src/domain/screenshot.ts
+++ b/src/domain/screenshot.ts
@@ -1,0 +1,98 @@
+import { Deck } from "@deck.gl/core/typed";
+import html2canvas from "html2canvas";
+
+const toBlob = (canvas: HTMLCanvasElement, type: string) =>
+  new Promise<Blob | null>((resolve) => {
+    canvas.toBlob((blob) => resolve(blob), type);
+  });
+
+const SCREENSHOT_IMAGE_SIZE = {
+  width: 1120,
+  height: 928,
+};
+
+export const SCREENSHOT_CANVAS_SIZE = {
+  width: 1120,
+  height: 730,
+};
+
+/**
+ * Get the map as an image, using the Deck.gl canvas and html2canvas to get
+ * the legend as an image.
+ */
+export const getImageData = async (deck: Deck, legend: HTMLElement) => {
+  if (!deck || "canvas" in deck === false) {
+    return;
+  }
+
+  // @ts-expect-error canvas is private
+  const canvas = deck.canvas;
+  if (!canvas) {
+    return;
+  }
+
+  const initialSize = {
+    width: canvas.width,
+    height: canvas.height,
+  };
+
+  const imageSize = {
+    width: SCREENSHOT_IMAGE_SIZE.width * 2,
+    height: SCREENSHOT_IMAGE_SIZE.height * 2,
+  };
+  const canvasSize = {
+    width: SCREENSHOT_CANVAS_SIZE.width * 2,
+    height: SCREENSHOT_CANVAS_SIZE.height * 2,
+  };
+
+  Object.assign(canvas, canvasSize);
+  deck.redraw("New size");
+
+  const newCanvas = document.createElement("canvas");
+  newCanvas.width = imageSize.width;
+  newCanvas.height = imageSize.height;
+  const context = newCanvas.getContext("2d");
+  if (!context) {
+    return;
+  }
+
+  // Using html2canvas, take the legend element, and draw it on the new canvas
+  // Make a new canvas element to convert the image to a png
+  // We need a new canvas since we will draw the legend onto it
+  context.fillStyle = "white";
+  context.fillRect(0, 0, newCanvas.width, newCanvas.height);
+
+  const ratio = window.devicePixelRatio;
+  context.drawImage(
+    canvas,
+    (newCanvas.width - canvas.width) / 2,
+    (newCanvas.height - canvas.height) / 2,
+    canvas.width,
+    canvas.height
+  );
+
+  const legendCanvas = await html2canvas(legend);
+
+  // We need to draw the legend using the device pixel ratio otherwise we get
+  // difference between different browsers (Safari legend would be bigger somehow)
+  const { width, height } = legend.getBoundingClientRect();
+
+  const legendPadding = 24;
+  context.drawImage(
+    legendCanvas,
+    legendPadding,
+    legendPadding,
+    width * ratio,
+    height * ratio
+  );
+
+  // Returns the canvas as a png
+  const res = await toBlob(newCanvas, "image/png").then((blob) =>
+    blob ? URL.createObjectURL(blob) : undefined
+  );
+
+  Object.assign(canvas, initialSize);
+  deck.redraw("Initial size");
+
+  return res;
+};

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -286,6 +286,7 @@ const IndexPage = ({ locale }: Props) => {
               bgcolor: "background.paper",
             }}
           >
+            
             <ElectricitySelectors />
             <List
               observations={observations}


### PR DESCRIPTION
Map display bug

After the refactor of useFetch/useGeoData, the map was not displayed since the data
has moved under the "data" attribute. Typescript did not warn about that since
there is an expect-error directive because it seems the DeckGL types / GeoJSON types
are incompatible (while the functionality works perfectly).

I fixed the immediate problem by using the "data" property, but I will take some time
to see how to remove the expect-error directive.

Sorry about that @noahonyejese :scream:.

