### PR TITLE
fix: flagged sunshine stuff that is causing crash

### DIFF
--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -32,6 +32,7 @@ import { copyToClipboard } from "src/lib/copy-to-clipboard";
 import { EMPTY_ARRAY } from "src/lib/empty-array";
 import { useQueryStateSingle } from "src/lib/use-query-state";
 import { defaultLocale } from "src/locales/locales";
+import { useFlag } from "src/utils/flags";
 
 const ApplicationLayout = dynamic(
   () =>
@@ -206,15 +207,19 @@ const IndexPage = ({ locale }: Props) => {
     accessor: colorAccessor,
   });
 
+  const isSunshine = useFlag("sunshine");
+
   const controlsRef: NonNullable<ChoroplethMapProps["controls"]> = useRef(null);
 
   useEffect(() => {
-    if (activeId) {
-      controlsRef.current?.zoomOn(activeId);
-    } else {
-      controlsRef.current?.zoomOut();
+    if (isSunshine) {
+      if (activeId) {
+        controlsRef.current?.zoomOn(activeId);
+      } else {
+        controlsRef.current?.zoomOut();
+      }
     }
-  }, [activeId]);
+  }, [activeId, isSunshine]);
 
   return (
     <MapProvider activeId={activeId} setActiveId={setActiveId}>
@@ -360,7 +365,6 @@ const IndexPage = ({ locale }: Props) => {
               position: "relative",
             }}
           >
-            
             <ElectricitySelectors />
             <List
               observations={observations}


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR is a hotfix preventing the page to crash on navigation back from the details page to the map view.

## Related Issues
<!-- Link any related issues using #issue_number format -->

## Testing Performed
<!-- Describe the testing you've done -->

- [x] Tested with the following Browsers: Chrome, Safari <!-- [Chrome, Firefox, Safari, etc] -->
- [x] Tested on the following devices: MacBook Pro, Large Monitor <!-- [MacBook Pro, iPhone 13, iPad, etc] -->
- [x] Verified functionality: Manually <!-- [Tested this functionality manually, automated, etc] -->
- [ ] Storybook updated
- [ ] Automated tests added

<!--
### Testing or Reproduction Steps

### Testing/Reproduction Steps
1. Navigate to [specific page]
2. Click on [specific element]
3. Observe [expected behavior]
-->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [x] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [x] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog

## Notes for Reviewers
<!-- Add any notes that might help reviewers understand your changes. -->

<!--
### Configuration Required
- Environment variables:
- Feature flags:
- Database changes:

### Known Limitations
-

### Performance Considerations
-

### Alternative Approaches Considered
-

### Future Improvements
-
-->


cc: @ptbrowne I will merge to ref as soon as we merge this 