### PR TITLE
Add costs and tariffs page

### DIFF
--- a/src/components/button-group.stories.tsx
+++ b/src/components/button-group.stories.tsx
@@ -1,0 +1,163 @@
+import React, { useState } from "react";
+
+import { StoryGrid } from "src/components/storybook/story-grid";
+
+import { ButtonGroup } from "./button-group";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof ButtonGroup> = {
+  title: "Components/ButtonGroup",
+  component: ButtonGroup,
+  parameters: {
+    layout: "centered",
+    docs: {
+      page: () => <StoryGrid cols={2} title="Button group" />,
+    },
+  },
+  tags: ["autodocs", "e2e:autodocs-screenshot"],
+};
+
+export default meta;
+type Story = StoryObj<typeof ButtonGroup>;
+
+// Basic button group with string options
+export const Basic: Story = {
+  render: () => {
+    const [selected, setSelected] = useState("option1");
+
+    return (
+      <ButtonGroup
+        id="basic-button-group"
+        label="Select an option"
+        options={[
+          { value: "option1", label: "Option 1" },
+          { value: "option2", label: "Option 2" },
+          { value: "option3", label: "Option 3" },
+        ]}
+        value={selected}
+        setValue={setSelected}
+      />
+    );
+  },
+};
+
+// Button group with long labels to demonstrate overflow handling
+export const LongLabels: Story = {
+  render: () => {
+    const [selected, setSelected] = useState("option1");
+
+    return (
+      <div style={{ width: "300px" }}>
+        <ButtonGroup
+          id="long-labels-button-group"
+          label="Select an option with long labels"
+          options={[
+            {
+              value: "option1",
+              label: "This is a very long option label that will overflow",
+            },
+            {
+              value: "option2",
+              label:
+                "Another extremely long option that demonstrates text overflow handling",
+            },
+            { value: "option3", label: "Short option" },
+          ]}
+          value={selected}
+          setValue={setSelected}
+        />
+      </div>
+    );
+  },
+};
+
+// Button group with hidden label
+export const HiddenLabel: Story = {
+  render: () => {
+    const [selected, setSelected] = useState("option1");
+
+    return (
+      <ButtonGroup
+        id="hidden-label-button-group"
+        label="This label is hidden"
+        showLabel={false}
+        options={[
+          { value: "option1", label: "Option 1" },
+          { value: "option2", label: "Option 2" },
+          { value: "option3", label: "Option 3" },
+        ]}
+        value={selected}
+        setValue={setSelected}
+      />
+    );
+  },
+};
+// Button group with many options
+export const ManyOptions: Story = {
+  render: () => {
+    const [selected, setSelected] = useState("option1");
+
+    return (
+      <div style={{ width: "600px" }}>
+        <ButtonGroup
+          id="many-options-button-group"
+          label="Many options"
+          options={[
+            { value: "option1", label: "Option 1" },
+            { value: "option2", label: "Option 2" },
+            { value: "option3", label: "Option 3" },
+            { value: "option4", label: "Option 4" },
+            { value: "option5", label: "Option 5" },
+            { value: "option6", label: "Option 6" },
+            { value: "option7", label: "Option 7" },
+          ]}
+          value={selected}
+          setValue={setSelected}
+        />
+      </div>
+    );
+  },
+};
+
+// Controlled demo with external state management
+export const ControlledDemo: Story = {
+  render: () => {
+    const [selected, setSelected] = useState("winter");
+    const [message, setMessage] = useState("Winter is selected");
+
+    const handleSeasonChange = (value: string) => {
+      setSelected(value);
+      setMessage(
+        `${value.charAt(0).toUpperCase() + value.slice(1)} is selected`
+      );
+    };
+
+    return (
+      <div>
+        <ButtonGroup
+          id="controlled-button-group"
+          label="Select a season"
+          options={[
+            { value: "winter", label: "Winter" },
+            { value: "spring", label: "Spring" },
+            { value: "summer", label: "Summer" },
+            { value: "autumn", label: "Autumn" },
+          ]}
+          value={selected}
+          setValue={handleSeasonChange}
+        />
+        <div
+          style={{
+            marginTop: "20px",
+            padding: "10px",
+            backgroundColor: "#f0f0f0",
+            borderRadius: "4px",
+          }}
+        >
+          {message}
+        </div>
+      </div>
+    );
+  },
+};

--- a/src/components/card-grid.stories.tsx
+++ b/src/components/card-grid.stories.tsx
@@ -1,0 +1,188 @@
+import {
+  Card,
+  CardContent,
+  Typography,
+  useTheme,
+  useMediaQuery,
+} from "@mui/material";
+
+import CardGrid from "./card-grid";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof CardGrid> = {
+  title: "Components/CardGrid",
+  component: CardGrid,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof CardGrid>;
+
+// Simple card component for demonstration
+const DemoCard = ({
+  title,
+  color = "#f0f0f0",
+}: {
+  title: string;
+  color?: string;
+}) => (
+  <Card
+    sx={{
+      bgcolor: color,
+      height: "100%",
+      display: "flex",
+      minHeight: "100px",
+    }}
+  >
+    <CardContent>
+      <Typography variant="h6">{title}</Typography>
+    </CardContent>
+  </Card>
+);
+
+// Basic 3-column grid
+export const Basic: Story = {
+  render: () => (
+    <CardGrid
+      sx={{
+        gridTemplateColumns: "repeat(3, 1fr)",
+        gridAutoRows: "minmax(100px, auto)",
+      }}
+    >
+      <DemoCard title="Card 1" color="#e3f2fd" />
+      <DemoCard title="Card 2" color="#e8f5e9" />
+      <DemoCard title="Card 3" color="#fff3e0" />
+      <DemoCard title="Card 4" color="#f3e5f5" />
+      <DemoCard title="Card 5" color="#e0f7fa" />
+      <DemoCard title="Card 6" color="#fff8e1" />
+    </CardGrid>
+  ),
+};
+
+// Responsive grid with different column counts based on screen size
+export const ResponsiveColumns: Story = {
+  render: () => {
+    const theme = useTheme();
+    const isXs = useMediaQuery(theme.breakpoints.only("xs"));
+    const isSm = useMediaQuery(theme.breakpoints.only("sm"));
+    const isMd = useMediaQuery(theme.breakpoints.only("md"));
+
+    // Determine current breakpoint for display
+    let currentBreakpoint = "lg or xl";
+    if (isXs) currentBreakpoint = "xs";
+    else if (isSm) currentBreakpoint = "sm";
+    else if (isMd) currentBreakpoint = "md";
+
+    return (
+      <>
+        <Typography variant="body2" sx={{ mb: 2, fontStyle: "italic" }}>
+          Current breakpoint: {currentBreakpoint} - Resize window to see
+          responsive behavior
+        </Typography>
+
+        <CardGrid
+          sx={{
+            gridTemplateColumns: {
+              xs: "1fr", // 1 column on mobile
+              sm: "repeat(2, 1fr)", // 2 columns on tablet
+              md: "repeat(3, 1fr)", // 3 columns on desktop
+              lg: "repeat(4, 1fr)", // 4 columns on large screens
+            },
+            gridAutoRows: "minmax(100px, auto)",
+          }}
+        >
+          <DemoCard title="Card 1" color="#e3f2fd" />
+          <DemoCard title="Card 2" color="#e8f5e9" />
+          <DemoCard title="Card 3" color="#fff3e0" />
+          <DemoCard title="Card 4" color="#f3e5f5" />
+          <DemoCard title="Card 5" color="#e0f7fa" />
+          <DemoCard title="Card 6" color="#fff8e1" />
+          <DemoCard title="Card 7" color="#fce4ec" />
+          <DemoCard title="Card 8" color="#f1f8e9" />
+        </CardGrid>
+      </>
+    );
+  },
+};
+
+// Dashboard-like layout with different card sizes
+export const DashboardLayout: Story = {
+  render: () => (
+    <CardGrid
+      sx={{
+        gridTemplateColumns: "repeat(12, 1fr)",
+        gridAutoRows: "minmax(100px, auto)",
+      }}
+    >
+      <Card sx={{ gridColumn: "span 12", bgcolor: "#e3f2fd" }}>
+        <CardContent>
+          <Typography variant="h5">Header - Full Width (12 columns)</Typography>
+        </CardContent>
+      </Card>
+
+      <Card
+        sx={{ gridColumn: { xs: "span 12", md: "span 8" }, bgcolor: "#e8f5e9" }}
+      >
+        <CardContent>
+          <Typography variant="h5">Main Content</Typography>
+          <Typography variant="body2">
+            8 columns on desktop, 12 on mobile
+          </Typography>
+        </CardContent>
+      </Card>
+
+      <Card
+        sx={{
+          gridColumn: { xs: "span 12", md: "span 4" },
+          bgcolor: "#fff3e0",
+          gridRow: { md: "span 2" },
+        }}
+      >
+        <CardContent>
+          <Typography variant="h5">Sidebar</Typography>
+          <Typography variant="body2">
+            4 columns on desktop, spans 2 rows, 12 columns on mobile
+          </Typography>
+        </CardContent>
+      </Card>
+
+      <Card
+        sx={{
+          gridColumn: { xs: "span 12", sm: "span 6", md: "span 4" },
+          bgcolor: "#f3e5f5",
+        }}
+      >
+        <CardContent>
+          <Typography variant="h5">Card 1</Typography>
+          <Typography variant="body2">
+            4 columns on desktop, 6 on tablet, 12 on mobile
+          </Typography>
+        </CardContent>
+      </Card>
+
+      <Card
+        sx={{
+          gridColumn: { xs: "span 12", sm: "span 6", md: "span 4" },
+          bgcolor: "#e0f7fa",
+        }}
+      >
+        <CardContent>
+          <Typography variant="h5">Card 2</Typography>
+          <Typography variant="body2">
+            4 columns on desktop, 6 on tablet, 12 on mobile
+          </Typography>
+        </CardContent>
+      </Card>
+
+      <Card sx={{ gridColumn: "span 12", bgcolor: "#fff8e1" }}>
+        <CardContent>
+          <Typography variant="h5">Footer - Full Width (12 columns)</Typography>
+        </CardContent>
+      </Card>
+    </CardGrid>
+  ),
+};

--- a/src/components/card-grid.tsx
+++ b/src/components/card-grid.tsx
@@ -1,0 +1,21 @@
+import { Box, cardClasses, cardContentClasses, styled } from "@mui/material";
+
+const CardGrid = styled(Box)(({ theme }) => ({
+  display: "grid",
+  gap: theme.spacing(4),
+  [`& .${cardClasses.root}`]: {
+    boxShadow: theme.shadows[2],
+  },
+  [`& .${cardContentClasses.root}`]: {
+    padding: theme.spacing(8),
+  },
+
+  [theme.breakpoints.down("sm")]: {
+    gap: theme.spacing(2),
+    [`& .${cardContentClasses.root}`]: {
+      padding: theme.spacing(2),
+    },
+  },
+}));
+
+export default CardGrid;

--- a/src/components/card-source.tsx
+++ b/src/components/card-source.tsx
@@ -1,0 +1,21 @@
+import { Trans } from "@lingui/react";
+import { Box } from "@mui/material";
+
+const CardSource = ({ date, source }: { date: string; source: string }) => (
+  <Box
+    sx={{
+      mt: 4,
+      color: "text.secondary",
+      typography: "caption",
+    }}
+  >
+    <div>
+      <Trans id="sunshine.costs-and-tariffs.date">Date: {date}</Trans>
+    </div>
+    <div>
+      <Trans id="sunshine.costs-and-tariffs.source">Source: {source}</Trans>
+    </div>
+  </Box>
+);
+
+export default CardSource;

--- a/src/components/combobox.stories.tsx
+++ b/src/components/combobox.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 const meta: Meta<typeof Combobox> = {
   title: "Components/Combobox",
   component: Combobox,
+  tags: ["autodocs", "e2e:autodocs-screenshot"],
   parameters: {
     layout: "centered",
   },

--- a/src/components/comparison-table.stories.tsx
+++ b/src/components/comparison-table.stories.tsx
@@ -1,0 +1,54 @@
+import { TableBody, TableRow, TableCell, Typography } from "@mui/material";
+
+import ComparisonTable from "src/components/comparison-table";
+import UnitValueWithTrend from "src/components/unit-value-with-trend";
+
+export const Example = () => {
+  const operatorLabel = "Operator XYZ";
+  const operatorRate = 1500;
+  const peerGroupMedianRate = 1200;
+  return (
+    <ComparisonTable size="small">
+      <TableBody>
+        <TableRow>
+          <TableCell>
+            <Typography variant="body3" color="text.secondary">
+              {operatorLabel}
+            </Typography>
+          </TableCell>
+          <TableCell>
+            <UnitValueWithTrend
+              value={operatorRate}
+              unit="Rp./km"
+              trend="stable"
+            />
+          </TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>
+            <Typography variant="body3" color="text.secondary">
+              Median Peer Group
+            </Typography>
+          </TableCell>
+          <TableCell>
+            <UnitValueWithTrend
+              value={peerGroupMedianRate}
+              unit="Rp./km"
+              trend="stable"
+            />
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </ComparisonTable>
+  );
+};
+
+const meta = {
+  title: "Components/ComparisonTable",
+  component: ComparisonTable,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;

--- a/src/components/comparison-table.tsx
+++ b/src/components/comparison-table.tsx
@@ -1,0 +1,22 @@
+import { styled, Table, tableCellClasses, tableClasses } from "@mui/material";
+
+const ComparisonTable = styled(Table)(({ theme }) => ({
+  mb: theme.spacing(2),
+  width: "100%",
+
+  [`& .${tableClasses.root}`]: {
+    tableLayout: "fixed", // Ensures the table takes full width
+    width: "100%",
+  },
+
+  // Make sure the 1st column takes 50% of the width
+  [`& .${tableCellClasses.root}:first-child`]: {
+    paddingLeft: 0,
+    width: "50%", // Ensures the first column takes 50% of the width
+  },
+  [`& .${tableCellClasses.root}:last-child`]: {
+    textAlign: "right", // Ensures the first column takes 50% of the width
+  },
+}));
+
+export default ComparisonTable;

--- a/src/components/detail-page/sidebar.tsx
+++ b/src/components/detail-page/sidebar.tsx
@@ -7,8 +7,12 @@ import { Icon } from "src/icons";
 
 import { SectionProps } from "./card";
 
+const useFlag = (flag: string) => true;
+
 export const DetailsPageSidebar = (props: SectionProps) => {
   const { id, entity } = props;
+
+  const sunshineFlag = useFlag("sunshine");
 
   return (
     <Box
@@ -29,31 +33,35 @@ export const DetailsPageSidebar = (props: SectionProps) => {
       </SidebarItem>
 
       {/* FIXME: Make this only a preview and add a coming soon label */}
-      {/* <SidebarSectionTitle>
-        <Trans id="details.page.navigation.sunshine-indicators-title">
-          Sunshine Indikatoren
-        </Trans>
-      </SidebarSectionTitle>
-      <SidebarItem href={`/${entity}/${id}/overview`}>
-        <Trans id="details.page.navigation.sunshine-overview-item">
-          Übersicht
-        </Trans>
-      </SidebarItem>
-      <SidebarItem href={`/${entity}/${id}/costs-and-tariffs`}>
-        <Trans id="details.page.navigation.costs-and-tariffs-item">
-          Kosten und Tariffe
-        </Trans>
-      </SidebarItem>
-      <SidebarItem href={`/${entity}/${id}/power-stability`}>
-        <Trans id="details.page.navigation.power-stability-item">
-          Leistungsstabilität
-        </Trans>
-      </SidebarItem>
-      <SidebarItem href={`/${entity}/${id}/operational-standards`}>
-        <Trans id="details.page.navigation.operational-standards-item">
-          Operationelle Standards
-        </Trans>
-      </SidebarItem> */}
+      {sunshineFlag && entity === "operator" ? (
+        <>
+          <SidebarSectionTitle>
+            <Trans id="details.page.navigation.sunshine-indicators-title">
+              Sunshine Indikatoren
+            </Trans>
+          </SidebarSectionTitle>
+          <SidebarItem href={`/sunshine/${entity}/${id}/overview`}>
+            <Trans id="details.page.navigation.sunshine-overview-item">
+              Übersicht
+            </Trans>
+          </SidebarItem>
+          <SidebarItem href={`/sunshine/${entity}/${id}/costs-and-tariffs`}>
+            <Trans id="details.page.navigation.costs-and-tariffs-item">
+              Kosten und Tariffe
+            </Trans>
+          </SidebarItem>
+          <SidebarItem href={`/sunshine/${entity}/${id}/power-stability`}>
+            <Trans id="details.page.navigation.power-stability-item">
+              Leistungsstabilität
+            </Trans>
+          </SidebarItem>
+          <SidebarItem href={`/sunshine/${entity}/${id}/operational-standards`}>
+            <Trans id="details.page.navigation.operational-standards-item">
+              Operationelle Standards
+            </Trans>
+          </SidebarItem>
+        </>
+      ) : null}
     </Box>
   );
 };

--- a/src/components/kitchen-sink.stories.tsx
+++ b/src/components/kitchen-sink.stories.tsx
@@ -716,7 +716,9 @@ export default {
   parameters: {
     layout: "centered",
     docs: {
-      page: () => <StoryGrid cols={2} />,
+      page: () => (
+        <StoryGrid cols={2} title="Kitchen Sink" reference="Bund Library" />
+      ),
     },
   },
 };

--- a/src/components/net-tariffs-trend-card.tsx
+++ b/src/components/net-tariffs-trend-card.tsx
@@ -1,0 +1,119 @@
+import { Trans, t } from "@lingui/macro";
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Grid,
+  CardProps,
+} from "@mui/material";
+import React, { useState } from "react";
+
+import { ButtonGroup } from "src/components/button-group";
+import CardSource from "src/components/card-source";
+import { Combobox } from "src/components/combobox";
+import { PeerGroup } from "src/domain/data";
+import { getLocalizedLabel, getPeerGroupLabels } from "src/domain/translation";
+
+const NetTariffsTrendCard: React.FC<
+  {
+    peerGroup: PeerGroup;
+    updateDate: string;
+  } & CardProps
+> = (props) => {
+  const [compareWith, setCompareWith] = useState(
+    "sunshine.costs-and-tariffs.all-peer-group"
+  );
+  const [viewBy, setViewBy] = useState("latest");
+
+  const { peerGroup, updateDate } = props;
+  const { peerGroupLabel } = getPeerGroupLabels(peerGroup);
+  return (
+    <Card {...props}>
+      <CardContent>
+        <Typography variant="h3" gutterBottom>
+          <Trans id="sunshine.costs-and-tariffs.net-tariffs-trend">
+            Net Tariffs Trend
+          </Trans>
+        </Typography>
+        <Typography variant="body2" color="text.secondary" gutterBottom mb={8}>
+          <Trans id="sunshine.costs-and-tariffs.benchmarking-peer-group">
+            Benchmarking within the Peer Group: {peerGroupLabel}
+          </Trans>
+        </Typography>
+
+        {/* Dropdown Controls */}
+        <Grid container spacing={3} sx={{ mb: 3 }}>
+          <Grid item xs={12} sm={6}>
+            <ButtonGroup
+              id="view-by-button-group"
+              label={t({
+                id: "sunshine.costs-and-tariffs.view-by",
+                message: "View By",
+              })}
+              options={[
+                {
+                  value: "latest",
+                  label: (
+                    <Trans id="sunshine.costs-and-tariffs.latest-year-option">
+                      Latest year
+                    </Trans>
+                  ),
+                },
+                {
+                  value: "progress",
+                  label: (
+                    <Trans id="sunshine.costs-and-tariffs.progress-over-time">
+                      Progress over time
+                    </Trans>
+                  ),
+                },
+              ]}
+              value={viewBy}
+              setValue={setViewBy}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <Combobox
+              id="compare-with-selection"
+              label={t({
+                id: "sunshine.costs-and-tariffs.compare-with",
+                message: "Compare With",
+              })}
+              items={[
+                "sunshine.costs-and-tariffs.all-peer-group",
+                "sunshine.costs-and-tariffs.selected-operators",
+              ]}
+              selectedItem={compareWith}
+              setSelectedItem={setCompareWith}
+              getItemLabel={(item) =>
+                getLocalizedLabel({
+                  id: item,
+                })
+              }
+            />
+          </Grid>
+        </Grid>
+
+        {/* Scatter Plot */}
+        <Box sx={{ height: 400, width: "100%" }}>
+          {/* This is a placeholder for the ScatterPlot component */}
+          <Typography color="text.secondary" sx={{ pt: 10 }}>
+            <Trans id="sunshine.costs-and-tariffs.scatter-plot-description">
+              Scatter Plot visualization showing net tariffs costs across
+              different levels (End Consumer Level, Low Voltage Distribution,
+              Medium Voltage Distribution)
+            </Trans>
+          </Typography>
+
+          {/* Implement your ScatterPlot component here */}
+          {/* <ScatterPlot /> */}
+        </Box>
+        {/* Footer Info */}
+        <CardSource date={`${updateDate}`} source={"Lindas"} />
+      </CardContent>
+    </Card>
+  );
+};
+
+export default NetTariffsTrendCard;

--- a/src/components/network-costs-trend-card.tsx
+++ b/src/components/network-costs-trend-card.tsx
@@ -1,0 +1,119 @@
+import { Trans, t } from "@lingui/macro";
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Grid,
+  CardProps,
+} from "@mui/material";
+import React, { useState } from "react";
+
+import { ButtonGroup } from "src/components/button-group";
+import CardSource from "src/components/card-source";
+import { Combobox } from "src/components/combobox";
+import { PeerGroup } from "src/domain/data";
+import { getLocalizedLabel, getPeerGroupLabels } from "src/domain/translation";
+
+const NetworkCostsTrendCard: React.FC<
+  {
+    peerGroup: PeerGroup;
+    updateDate: string;
+  } & CardProps
+> = (props) => {
+  const [compareWith, setCompareWith] = useState(
+    "sunshine.costs-and-tariffs.all-peer-group"
+  );
+  const [viewBy, setViewBy] = useState("latest");
+
+  const { peerGroup, updateDate } = props;
+  const { peerGroupLabel } = getPeerGroupLabels(peerGroup);
+  return (
+    <Card {...props}>
+      <CardContent>
+        <Typography variant="h3" gutterBottom>
+          <Trans id="sunshine.costs-and-tariffs.network-cost-trend">
+            Network Cost Trend
+          </Trans>
+        </Typography>
+        <Typography variant="body2" color="text.secondary" gutterBottom mb={8}>
+          <Trans id="sunshine.costs-and-tariffs.benchmarking-peer-group">
+            Benchmarking within the Peer Group: {peerGroupLabel}
+          </Trans>
+        </Typography>
+
+        {/* Dropdown Controls */}
+        <Grid container spacing={3} sx={{ mb: 3 }}>
+          <Grid item xs={12} sm={6}>
+            <ButtonGroup
+              id="view-by-button-group"
+              label={t({
+                id: "sunshine.costs-and-tariffs.view-by",
+                message: "View By",
+              })}
+              options={[
+                {
+                  value: "latest",
+                  label: (
+                    <Trans id="sunshine.costs-and-tariffs.latest-year-option">
+                      Latest year
+                    </Trans>
+                  ),
+                },
+                {
+                  value: "progress",
+                  label: (
+                    <Trans id="sunshine.costs-and-tariffs.progress-over-time">
+                      Progress over time
+                    </Trans>
+                  ),
+                },
+              ]}
+              value={viewBy}
+              setValue={setViewBy}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <Combobox
+              id="compare-with-selection"
+              label={t({
+                id: "sunshine.costs-and-tariffs.compare-with",
+                message: "Compare With",
+              })}
+              items={[
+                "sunshine.costs-and-tariffs.all-peer-group",
+                "sunshine.costs-and-tariffs.selected-operators",
+              ]}
+              selectedItem={compareWith}
+              setSelectedItem={setCompareWith}
+              getItemLabel={(item) =>
+                getLocalizedLabel({
+                  id: item,
+                })
+              }
+            />
+          </Grid>
+        </Grid>
+
+        {/* Scatter Plot */}
+        <Box sx={{ height: 400, width: "100%" }}>
+          {/* This is a placeholder for the ScatterPlot component */}
+          <Typography color="text.secondary" sx={{ pt: 10 }}>
+            <Trans id="sunshine.costs-and-tariffs.scatter-plot-description">
+              Scatter Plot visualization showing network costs across different
+              levels (End Consumer Level, Low Voltage Distribution, Medium
+              Voltage Distribution)
+            </Trans>
+          </Typography>
+
+          {/* Implement your ScatterPlot component here */}
+          {/* <ScatterPlot /> */}
+        </Box>
+        {/* Footer Info */}
+        <CardSource date={`${updateDate}`} source={"Lindas"} />
+      </CardContent>
+    </Card>
+  );
+};
+
+export default NetworkCostsTrendCard;

--- a/src/components/peer-group-card.tsx
+++ b/src/components/peer-group-card.tsx
@@ -24,7 +24,9 @@ const PeerGroupCard: React.FC<
             Latest year ({latestYear})
           </Trans>
         </Typography>
-        <Typography variant="body1">{peerGroupLabel}</Typography>
+        <Typography variant="body1" fontWeight={700}>
+          {peerGroupLabel}
+        </Typography>
       </CardContent>
     </Card>
   );

--- a/src/components/peer-group-card.tsx
+++ b/src/components/peer-group-card.tsx
@@ -1,0 +1,33 @@
+import { Trans } from "@lingui/macro";
+import { Typography, Card, CardContent, CardProps } from "@mui/material";
+import React from "react";
+
+import { PeerGroup } from "src/domain/data";
+import { getPeerGroupLabels } from "src/domain/translation";
+
+const PeerGroupCard: React.FC<
+  {
+    latestYear: string;
+    peerGroup: PeerGroup;
+  } & CardProps
+> = ({ latestYear, peerGroup, ...props }) => {
+  const { peerGroupLabel } = getPeerGroupLabels(peerGroup);
+
+  return (
+    <Card {...props}>
+      <CardContent>
+        <Typography variant="h3" gutterBottom>
+          <Trans id="sunshine.costs-and-tariffs.peer-group">Peer Group</Trans>
+        </Typography>
+        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+          <Trans id="sunshine.costs-and-tariffs.latest-year">
+            Latest year ({latestYear})
+          </Trans>
+        </Typography>
+        <Typography variant="body1">{peerGroupLabel}</Typography>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default PeerGroupCard;

--- a/src/components/storybook/story-grid.tsx
+++ b/src/components/storybook/story-grid.tsx
@@ -11,6 +11,8 @@ interface StoryGridProps {
   cols?: number;
   cellClassName?: string;
   storyClassName?: string;
+  title: string;
+  reference?: string;
 }
 
 const DocsStory: FC<DocBlock.DocsStoryProps & { className?: string }> = ({
@@ -97,8 +99,10 @@ export const StoryGrid: FC<StoryGridProps> = ({
   cols = 3,
   cellClassName,
   storyClassName,
+  title,
+  reference,
 }) => {
-  const { componentStories, projectAnnotations, getStoryContext } =
+  const { componentStories, projectAnnotations, getStoryContext, ...ctx } =
     useContext(DocsContext);
 
   let stories = componentStories();
@@ -139,46 +143,48 @@ export const StoryGrid: FC<StoryGridProps> = ({
   }
 
   const groupEntries = Object.entries(groups);
-  return groupEntries.map(([group, stories]) => (
-    <DesignStory title="Kitchen Sink" reference="BUND Library">
-      <Box
-        sx={{
-          "& + &": {
-            marginTop: "2rem",
-          },
-        }}
-        key={group}
-      >
-        {groupEntries.length > 1 ? (
-          <Typography variant="h3" className="sb-unstyled">
-            {titleCase(group)}
-          </Typography>
-        ) : null}
-        <StoryGridLayout cols={cols} key={group}>
-          {stories.map(
-            (story) =>
-              story && (
-                <Box
-                  key={story.id}
-                  sx={{
-                    display: "grid",
-                    gridTemplateRows: "subgrid",
-                    gridRow: "span/3",
-                    marginBottom: "2.5rem",
-                  }}
-                  className={cellClassName}
-                >
-                  <DocsStory
-                    of={story.moduleExport}
-                    expanded
-                    __forceInitialArgs
-                    className={storyClassName}
-                  />
-                </Box>
-              )
-          )}
-        </StoryGridLayout>
-      </Box>
+  return (
+    <DesignStory title={title} reference={reference}>
+      {groupEntries.map(([group, stories]) => (
+        <Box
+          sx={{
+            "& + &": {
+              marginTop: "2rem",
+            },
+          }}
+          key={group}
+        >
+          {groupEntries.length > 1 ? (
+            <Typography variant="h3" className="sb-unstyled">
+              {titleCase(group)}
+            </Typography>
+          ) : null}
+          <StoryGridLayout cols={cols} key={group}>
+            {stories.map(
+              (story) =>
+                story && (
+                  <Box
+                    key={story.id}
+                    sx={{
+                      display: "grid",
+                      gridTemplateRows: "subgrid",
+                      gridRow: "span/3",
+                      marginBottom: "2.5rem",
+                    }}
+                    className={cellClassName}
+                  >
+                    <DocsStory
+                      of={story.moduleExport}
+                      expanded
+                      __forceInitialArgs
+                      className={storyClassName}
+                    />
+                  </Box>
+                )
+            )}
+          </StoryGridLayout>
+        </Box>
+      ))}
     </DesignStory>
-  ));
+  );
 };

--- a/src/components/table-comparison-card.tsx
+++ b/src/components/table-comparison-card.tsx
@@ -1,0 +1,59 @@
+import {
+  Typography,
+  Card,
+  CardContent,
+  TableBody,
+  TableRow,
+  TableCell,
+  CardProps,
+} from "@mui/material";
+import React from "react";
+
+import ComparisonTable from "src/components/comparison-table";
+import UnitValueWithTrend from "src/components/unit-value-with-trend";
+
+export type Trend = "stable" | "increasing" | "decreasing";
+
+const TableComparisonCard: React.FC<
+  {
+    title: React.ReactNode;
+    subtitle: React.ReactNode;
+    rows: {
+      label: React.ReactNode;
+      value: { value: number; unit: string; trend: Trend };
+    }[];
+  } & Omit<CardProps, "title" | "subtitle" | "rows">
+> = ({ title, subtitle, rows, ...props }) => (
+  <Card {...props}>
+    <CardContent>
+      <Typography variant="h3" gutterBottom>
+        {title}
+      </Typography>
+      <Typography variant="subtitle2" color="text.  secondary" gutterBottom>
+        {subtitle}
+      </Typography>
+      <ComparisonTable size="small">
+        <TableBody>
+          {rows.map((row, index) => (
+            <TableRow key={index}>
+              <TableCell>
+                <Typography variant="body3" color="text.secondary">
+                  {row.label}
+                </Typography>
+              </TableCell>
+              <TableCell>
+                <UnitValueWithTrend
+                  value={row.value.value}
+                  unit={row.value.unit}
+                  trend={row.value.trend}
+                />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </ComparisonTable>
+    </CardContent>
+  </Card>
+);
+
+export default TableComparisonCard;

--- a/src/components/unit-value-with-trend.tsx
+++ b/src/components/unit-value-with-trend.tsx
@@ -1,0 +1,33 @@
+import { Box, Typography } from "@mui/material";
+
+const UnitValueWithTrend: React.FC<{
+  value: number;
+  unit: string;
+  trend: "stable" | "increasing" | "decreasing";
+}> = ({ value, unit, trend }) => {
+  // TODO
+  const trendIcon = {
+    stable: "↔️",
+    increasing: "📈",
+    decreasing: "📉",
+  }[trend];
+
+  return (
+    <Box sx={{ display: "inline-flex", alignItems: "baseline", gap: 1 }}>
+      <span>{trendIcon}</span>
+      <Typography
+        variant="h3"
+        color="text.primary"
+        component="span"
+        fontWeight={700}
+      >
+        {value}
+      </Typography>
+      <Typography variant="caption" color="text.primary">
+        {unit}
+      </Typography>
+    </Box>
+  );
+};
+
+export default UnitValueWithTrend;

--- a/src/data/shared-page-props.tsx
+++ b/src/data/shared-page-props.tsx
@@ -41,7 +41,9 @@ export type Props =
 
 export const handleMunicipalityEntity = async (
   params: Omit<PageParams, "entity"> & { res: ServerResponse<IncomingMessage> }
-): Promise<Props> => {
+): Promise<
+  Extract<Props, { entity: "municipality" } | { status: "notfound" }>
+> => {
   const { id, locale, res } = params!;
   const municipality = await getMunicipality({ id });
 
@@ -71,7 +73,7 @@ export const handleMunicipalityEntity = async (
 };
 export const handleOperatorsEntity = async (
   params: Omit<PageParams, "entity"> & { res: ServerResponse<IncomingMessage> }
-): Promise<Props> => {
+): Promise<Extract<Props, { entity: "operator" } | { status: "notfound" }>> => {
   const { id, locale, res } = params!;
   const operator = await getOperator({ id });
 
@@ -93,7 +95,7 @@ export const handleOperatorsEntity = async (
 
 export const handleCantonEntity = async (
   params: Omit<PageParams, "entity"> & { res: ServerResponse<IncomingMessage> }
-): Promise<Props> => {
+): Promise<Extract<Props, { entity: "canton" } | { status: "notfound" }>> => {
   const { id, locale, res } = params!;
   const canton = await getCanton({ id, locale: locale! });
 

--- a/src/domain/data.ts
+++ b/src/domain/data.ts
@@ -111,3 +111,44 @@ export const categories = [
   "C6",
   "C7",
 ];
+
+export type PeerGroup = {
+  energyDensity: string;
+  settlementDensity: string;
+};
+
+export type NetworkLevel = {
+  id: string;
+};
+
+export type SunshineCostsAndTariffsData = {
+  networkLevel: {
+    id: string;
+  };
+  latestYear: string;
+  operatorRate: number;
+  peerGroupMedianRate: number;
+  peerGroup: {
+    energyDensity: string;
+    settlementDensity: string;
+  };
+  updateDate: string;
+};
+
+export const fetchOperatorCostsAndTariffsData = async (id: string) => {
+  return {
+    peerGroup: {
+      energyDensity: "low",
+      settlementDensity: "rural",
+    },
+
+    networkLevel: {
+      id: "NE7",
+    },
+    latestYear: "2024",
+
+    operatorRate: 23.4,
+    peerGroupMedianRate: 25.6,
+    updateDate: "March 7, 2024, 1:28 PM",
+  };
+};

--- a/src/domain/data.ts
+++ b/src/domain/data.ts
@@ -129,6 +129,12 @@ export type SunshineCostsAndTariffsData = {
     };
     peerGroupMedianRate: number;
     operatorRate: number;
+    yearlyData: {
+      year: string;
+      rate: number;
+      operator: number;
+      category: string;
+    }[];
   };
   operator: {
     peerGroup: {
@@ -155,6 +161,17 @@ export const fetchOperatorCostsAndTariffsData = async (operatorId: string) => {
       },
       operatorRate: 23.4,
       peerGroupMedianRate: 25.6,
+      yearlyData: [
+        { year: "2022", rate: 21.9, operator: 410, category: "H1" },
+        { year: "2023", rate: 22.8, operator: 410, category: "H1" },
+        { year: "2024", rate: 23.4, operator: 410, category: "H1" },
+        { year: "2022", rate: 20.5, operator: 390, category: "H1" },
+        { year: "2023", rate: 21.3, operator: 390, category: "H1" },
+        { year: "2024", rate: 22.0, operator: 390, category: "H1" },
+        { year: "2022", rate: 19.0, operator: 370, category: "H1" },
+        { year: "2023", rate: 19.8, operator: 370, category: "H1" },
+        { year: "2024", rate: 20.5, operator: 370, category: "H1" },
+      ],
     },
     latestYear: "2024",
 

--- a/src/domain/data.ts
+++ b/src/domain/data.ts
@@ -121,8 +121,26 @@ export type NetworkLevel = {
   id: string;
 };
 
+export type Category = {
+  id: string;
+};
+
 export type SunshineCostsAndTariffsData = {
   latestYear: string;
+  netTariffs: {
+    category: {
+      id: string;
+    };
+    peerGroupMedianRate: number;
+    operatorRate: number;
+    yearlyData: {
+      year: string;
+      rate: number;
+      operator: number;
+      category: string;
+    }[];
+  };
+
   networkCosts: {
     networkLevel: {
       id: string;
@@ -171,6 +189,18 @@ export const fetchOperatorCostsAndTariffsData = async (operatorId: string) => {
         { year: "2022", rate: 19.0, operator: 370, category: "H1" },
         { year: "2023", rate: 19.8, operator: 370, category: "H1" },
         { year: "2024", rate: 20.5, operator: 370, category: "H1" },
+      ],
+    },
+    netTariffs: {
+      category: {
+        id: "H1",
+      },
+      operatorRate: 0.12,
+      peerGroupMedianRate: 0.15,
+      yearlyData: [
+        { year: "2022", rate: 0.11, operator: 0.1, category: "H1" },
+        { year: "2023", rate: 0.12, operator: 0.11, category: "H1" },
+        { year: "2024", rate: 0.12, operator: 0.12, category: "H1" },
       ],
     },
     latestYear: "2024",

--- a/src/domain/data.ts
+++ b/src/domain/data.ts
@@ -122,33 +122,42 @@ export type NetworkLevel = {
 };
 
 export type SunshineCostsAndTariffsData = {
-  networkLevel: {
-    id: string;
-  };
   latestYear: string;
-  operatorRate: number;
-  peerGroupMedianRate: number;
-  peerGroup: {
-    energyDensity: string;
-    settlementDensity: string;
+  networkCosts: {
+    networkLevel: {
+      id: string;
+    };
+    peerGroupMedianRate: number;
+    operatorRate: number;
+  };
+  operator: {
+    peerGroup: {
+      energyDensity: string;
+      settlementDensity: string;
+    };
   };
   updateDate: string;
 };
 
-export const fetchOperatorCostsAndTariffsData = async (id: string) => {
+// We will need operatorId to fetch the data for the operator
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const fetchOperatorCostsAndTariffsData = async (operatorId: string) => {
   return {
-    peerGroup: {
-      energyDensity: "low",
-      settlementDensity: "rural",
+    operator: {
+      peerGroup: {
+        energyDensity: "low",
+        settlementDensity: "rural",
+      },
     },
-
-    networkLevel: {
-      id: "NE7",
+    networkCosts: {
+      networkLevel: {
+        id: "NE7",
+      },
+      operatorRate: 23.4,
+      peerGroupMedianRate: 25.6,
     },
     latestYear: "2024",
 
-    operatorRate: 23.4,
-    peerGroupMedianRate: 25.6,
     updateDate: "March 7, 2024, 1:28 PM",
-  };
+  } satisfies SunshineCostsAndTariffsData;
 };

--- a/src/domain/translation.tsx
+++ b/src/domain/translation.tsx
@@ -1,6 +1,6 @@
 import { t } from "@lingui/macro";
 
-import { NetworkLevel, PeerGroup } from "src/domain/data";
+import { Category, NetworkLevel, PeerGroup } from "src/domain/data";
 
 export const getLocalizedLabel = ({ id }: { id: string }): string => {
   switch (id) {
@@ -80,6 +80,49 @@ export const getLocalizedLabel = ({ id }: { id: string }): string => {
       return t({ id: "selector.category.C6", message: `C6` });
     case "C7":
       return t({ id: "selector.category.C7", message: `C7` });
+
+    // Long versions taken from the Kategorie Info Dialog
+    case "H1-long":
+      return t({
+        id: "selector.category.H1-long",
+        message: `H1 - 2-Zimmerwohnung mit Elektroherd`,
+      });
+    case "H2-long":
+      return t({
+        id: "selector.category.H2-long",
+        message: `H2 - 4-Zimmerwohnung mit Elektroherd`,
+      });
+    case "H3-long":
+      return t({
+        id: "selector.category.H3-long",
+        message: `H3 - 4-Zimmerwohnung mit Elektroherd und Elektroboiler`,
+      });
+    case "H4-long":
+      return t({
+        id: "selector.category.H4-long",
+        message: `H4 - 5-Zimmerwohnung mit Elektroherd und Tumbler`,
+      });
+    case "H5-long":
+      return t({
+        id: "selector.category.H5-long",
+        message: `H5 - 5-Zimmer-Einfamilienhaus mit Elektroherd, Elektroboiler und Tumbler`,
+      });
+    case "H6-long":
+      return t({
+        id: "selector.category.H6-long",
+        message: `H6 - 5-Zimmer-Einfamilienhaus mit elektrischer Widerstandsheizung`,
+      });
+    case "H7-long":
+      return t({
+        id: "selector.category.H7-long",
+        message: `H7 - 5-Zimmer-Einfamilienhaus mit Wärmepumpe zur Beheizung`,
+      });
+    case "H8-long":
+      return t({
+        id: "selector.category.H8-long",
+        message: `H8 - Grosse, hoch elektrifizierte Eigentumswohnung`,
+      });
+
     case "H-group":
       return t({ id: "selector.category.H-group", message: `Haushalte` });
     case "C-group":
@@ -235,5 +278,12 @@ export const getNetworkLevelLabels = function (networkLevel: NetworkLevel) {
   return {
     short: getLocalizedLabel({ id: `network-level.${networkLevel.id}.short` }),
     long: getLocalizedLabel({ id: `network-level.${networkLevel.id}.long` }),
+  };
+};
+
+export const getCategoryLabels = function (category: Category) {
+  return {
+    short: getLocalizedLabel({ id: `${category.id}` }),
+    long: getLocalizedLabel({ id: `${category.id}-long` }),
   };
 };

--- a/src/domain/translation.tsx
+++ b/src/domain/translation.tsx
@@ -128,6 +128,86 @@ export const getLocalizedLabel = ({ id }: { id: string }): string => {
         id: "rangeplot.select.sorting.alpha-desc",
         message: `Alphabetisch absteigend`,
       });
+
+    case "peer-group.settlement-density.na":
+      return t({
+        id: "peer-group.settlement-density.na",
+        message: `Keine Angabe`,
+      });
+    case "peer-group.settlement-density.tourist":
+      return t({
+        id: "peer-group.settlement-density.tourist",
+        message: `Tourismus`,
+      });
+    case "peer-group.settlement-density.mountain":
+      return t({
+        id: "peer-group.settlement-density.mountain",
+        message: `Berggebiet`,
+      });
+    case "peer-group.settlement-density.unknown":
+      return t({
+        id: "peer-group.settlement-density.unknown",
+        message: `Unbekannt`,
+      });
+    case "peer-group.settlement-density.medium":
+      return t({
+        id: "peer-group.settlement-density.medium",
+        message: `Mittlere Siedlungsdichte`,
+      });
+    case "peer-group.settlement-density.rural":
+      return t({
+        id: "peer-group.settlement-density.rural",
+        message: `Ländliche Siedlungsdichte`,
+      });
+    case "peer-group.energy-density.na":
+      return t({
+        id: "peer-group.energy-density.na",
+        message: `Keine Angabe`,
+      });
+    case "peer-group.energy-density.high":
+      return t({
+        id: "peer-group.energy-density.high",
+        message: `Hohe Energiedichte`,
+      });
+    case "peer-group.energy-density.low":
+      return t({
+        id: "peer-group.energy-density.low",
+        message: `Niedrige Energiedichte`,
+      });
+
+    // NL (Not yet sure about translations)
+    case "network-level.NL5.short":
+      return t({ id: "network-level.NL5.short", message: `NL5` });
+    case "network-level.NL5.long":
+      return t({ id: "network-level.NL5.long", message: `Hochspannung` });
+    case "network-level.NL6.short":
+      return t({ id: "network-level.NL6.short", message: `NL6` });
+    case "network-level.NL6.long":
+      return t({ id: "network-level.NL6.long", message: `Mittelspannung` });
+    case "network-level.NL7.short":
+      return t({ id: "network-level.NL7.short", message: `NL7` });
+
+    // NE (Not yet sure about translations)
+    case "network-level.NE5.short":
+      return t({ id: "network-level.NE5.short", message: `NE5` });
+    case "network-level.NE5.long":
+      return t({ id: "network-level.NE5.long", message: `Hochspannung` });
+    case "network-level.NE7.short":
+      return t({ id: "network-level.NE7.short", message: `NE7` });
+    case "network-level.NE7.long":
+      return t({ id: "network-level.NE7.long", message: `Niederspannung` });
+
+    case "sunshine.costs-and-tariffs.all-peer-group":
+      return t({
+        id: "sunshine.costs-and-tariffs.all-peer-group",
+        message: `Alle Peer-Group-Netzbetreiber`,
+      });
+    case "sunshine.costs-and-tariffs.selected-operators":
+      return t({
+        id: "sunshine.costs-and-tariffs.selected-operators",
+        message: `Ausgewählte Netzbetreiber`,
+      });
+
     default:
       return id;
   }

--- a/src/domain/translation.tsx
+++ b/src/domain/translation.tsx
@@ -1,5 +1,7 @@
 import { t } from "@lingui/macro";
 
+import { NetworkLevel, PeerGroup } from "src/domain/data";
+
 export const getLocalizedLabel = ({ id }: { id: string }): string => {
   switch (id) {
     case "collapsed-operator":
@@ -211,4 +213,27 @@ export const getLocalizedLabel = ({ id }: { id: string }): string => {
     default:
       return id;
   }
+};
+
+export const getPeerGroupLabels = function (peerGroup: PeerGroup) {
+  const settlementDensityLabel = getLocalizedLabel({
+    id: `peer-group.settlement-density.${peerGroup.settlementDensity}`,
+  });
+  const energyDensityLabel = getLocalizedLabel({
+    id: `peer-group.energy-density.${peerGroup.energyDensity}`,
+  });
+
+  const peerGroupLabel = `${settlementDensityLabel} / ${energyDensityLabel}`;
+  return {
+    peerGroupLabel,
+    settlementDensityLabel,
+    energyDensityLabel,
+  };
+};
+
+export const getNetworkLevelLabels = function (networkLevel: NetworkLevel) {
+  return {
+    short: getLocalizedLabel({ id: `network-level.${networkLevel.id}.short` }),
+    long: getLocalizedLabel({ id: `network-level.${networkLevel.id}.long` }),
+  };
 };

--- a/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+++ b/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -107,11 +107,9 @@ const CostsAndTariffsNavigation: React.FC<{
 
 const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
   const {
-    networkLevel,
+    networkCosts: { networkLevel, operatorRate, peerGroupMedianRate },
+    operator: { peerGroup },
     latestYear,
-    operatorRate,
-    peerGroupMedianRate,
-    peerGroup,
     updateDate,
   } = props.costsAndTariffs;
   const networkLabels = getNetworkLevelLabels(networkLevel);

--- a/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+++ b/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -14,6 +14,7 @@ import {
   DetailsPageTitle,
 } from "src/components/detail-page/layout";
 import { DetailsPageSidebar } from "src/components/detail-page/sidebar";
+import NetTariffsTrendCard from "src/components/net-tariffs-trend-card";
 import NetworkCostsTrendCard from "src/components/network-costs-trend-card";
 import PeerGroupCard from "src/components/peer-group-card";
 import TableComparisonCard, {
@@ -29,6 +30,7 @@ import {
   SunshineCostsAndTariffsData,
 } from "src/domain/data";
 import {
+  getCategoryLabels,
   getLocalizedLabel,
   getNetworkLevelLabels,
 } from "src/domain/translation";
@@ -196,6 +198,92 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
   );
 };
 
+const NetTariffs = (props: Extract<Props, { status: "found" }>) => {
+  const {
+    netTariffs: { category, operatorRate, peerGroupMedianRate },
+    operator: { peerGroup },
+    latestYear,
+    updateDate,
+  } = props.costsAndTariffs;
+  const categoryLabels = getCategoryLabels(category);
+
+  const operatorLabel = props.name;
+
+  const comparisonCardProps = {
+    title: (
+      <Trans id="sunshine.costs-and-tariffs.net-tariffs-comparison-title">
+        Net Tariffs {categoryLabels.long}
+      </Trans>
+    ),
+    subtitle: (
+      <Trans id="sunshine.costs-and-tariffs.latest-year">
+        Latest year ({latestYear})
+      </Trans>
+    ),
+    rows: [
+      {
+        label: (
+          <Trans id="sunshine.costs-and-tariffs.operator">
+            {operatorLabel}
+          </Trans>
+        ),
+        value: {
+          value: operatorRate,
+          unit: "Rp./km",
+          trend: "stable" satisfies Trend,
+        },
+      },
+      {
+        label: (
+          <Trans id="sunshine.costs-and-tariffs.median-peer-group">
+            Median Peer Group
+          </Trans>
+        ),
+        value: {
+          value: peerGroupMedianRate,
+          unit: "Rp./km",
+          trend: "stable" as Trend,
+        },
+      },
+    ],
+  } satisfies React.ComponentProps<typeof TableComparisonCard>;
+
+  return (
+    <>
+      <CardGrid
+        sx={{
+          gridTemplateColumns: {
+            xs: "1fr", // Single column on small screens
+            sm: "repeat(2, 1fr)", // Two columns on medium screens
+          },
+          gridTemplateRows: ["auto auto auto", "auto auto"], // Three rows: two for cards, one for trend chart
+          gridTemplateAreas: [
+            `"peer-group" "net-tariffs" "net-tariffs-trend"`, // One column on small screens
+            `"peer-group net-tariffs" "net-tariffs-trend net-tariffs-trend"`, // Two columns on medium screens
+          ],
+        }}
+      >
+        <PeerGroupCard
+          latestYear={latestYear}
+          peerGroup={peerGroup}
+          sx={{ gridArea: "peer-group" }}
+        />
+
+        <TableComparisonCard
+          {...comparisonCardProps}
+          sx={{ gridArea: "net-tariffs" }}
+        />
+
+        <NetTariffsTrendCard
+          sx={{ gridArea: "net-tariffs-trend" }}
+          peerGroup={peerGroup}
+          updateDate={updateDate}
+        />
+      </CardGrid>
+    </>
+  );
+};
+
 const CostsAndTariffs = (props: Props) => {
   const { query } = useRouter();
   const [activeTab, setActiveTab] = useState<TabOption>(
@@ -251,21 +339,7 @@ const CostsAndTariffs = (props: Props) => {
       />
 
       {activeTab === TabOption.NETWORK_COSTS && <NetworkCosts {...props} />}
-
-      {activeTab === TabOption.NET_TARIFFS && (
-        <Box sx={{ textAlign: "center", py: 8 }}>
-          <Typography variant="h5">
-            <Trans id="sunshine.costs-and-tariffs.net-tariffs-content">
-              Net Tariffs Content
-            </Trans>
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            <Trans id="sunshine.costs-and-tariffs.under-development">
-              This section is under development.
-            </Trans>
-          </Typography>
-        </Box>
-      )}
+      {activeTab === TabOption.NET_TARIFFS && <NetTariffs {...props} />}
 
       {activeTab === TabOption.ENERGY_TARIFFS && (
         <Box sx={{ textAlign: "center", py: 8 }}>

--- a/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+++ b/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -1,0 +1,552 @@
+import { Trans, t } from "@lingui/macro";
+import {
+  Box,
+  Typography,
+  Tabs,
+  Tab,
+  Card,
+  CardContent,
+  Grid,
+  gridClasses,
+  cardClasses,
+  Table,
+  TableBody,
+  TableRow,
+  TableCell,
+  tableClasses,
+  tableCellClasses,
+} from "@mui/material";
+import { GetServerSideProps } from "next";
+import ErrorPage from "next/error";
+import { useRouter } from "next/router";
+import React, { useState } from "react";
+
+import { ButtonGroup } from "src/components/button-group";
+import { Combobox } from "src/components/combobox";
+import { DetailPageBanner } from "src/components/detail-page/banner";
+import {
+  DetailsPageLayout,
+  DetailsPageHeader,
+  DetailsPageSubtitle,
+  DetailsPageTitle,
+} from "src/components/detail-page/layout";
+import { DetailsPageSidebar } from "src/components/detail-page/sidebar";
+import {
+  handleOperatorsEntity,
+  PageParams,
+  Props as SharedPageProps,
+} from "src/data/shared-page-props";
+import { getLocalizedLabel } from "src/domain/translation";
+import { defaultLocale } from "src/locales/locales";
+
+enum TabOption {
+  NETWORK_COSTS = 0,
+  NET_TARIFFS = 1,
+  ENERGY_TARIFFS = 2,
+}
+
+type OperatorSunshineData = {
+  networkLevel: {
+    id: string;
+  };
+  latestYear: string;
+  operatorRate: number;
+  peerGroupMedianRate: number;
+  peerGroup: {
+    energyDensity: string;
+    settlementDensity: string;
+  };
+  updateDate: string;
+};
+type Props =
+  | (Extract<SharedPageProps, { entity: "operator"; status: "found" }> & {
+      sunshine: OperatorSunshineData;
+    })
+  | { status: "notfound" };
+
+export const getServerSideProps: GetServerSideProps<
+  Props,
+  PageParams
+> = async ({ params, res, locale }) => {
+  const { id, entity } = params!;
+
+  if (entity !== "operator") {
+    return {
+      props: {
+        status: "notfound",
+      },
+    };
+  }
+
+  const props = await handleOperatorsEntity({
+    id,
+    locale: locale ?? defaultLocale,
+    res,
+  });
+
+  const sunshineMockedData = {
+    peerGroup: {
+      energyDensity: "low",
+      settlementDensity: "rural",
+    },
+
+    networkLevel: {
+      id: "NE7",
+    },
+    latestYear: "2024",
+
+    operatorRate: 23.4,
+    peerGroupMedianRate: 25.6,
+    updateDate: "March 7, 2024, 1:28 PM",
+  };
+
+  return {
+    props: {
+      ...props,
+      sunshine: sunshineMockedData as OperatorSunshineData,
+    },
+  };
+};
+
+const getPeerGroupLabels = function (peerGroup: {
+  energyDensity: string;
+  settlementDensity: string;
+}) {
+  const settlementDensityLabel = getLocalizedLabel({
+    id: `peer-group.settlement-density.${peerGroup.settlementDensity}`,
+  });
+  const energyDensityLabel = getLocalizedLabel({
+    id: `peer-group.energy-density.${peerGroup.energyDensity}`,
+  });
+
+  const peerGroupLabel = `${settlementDensityLabel} / ${energyDensityLabel}`;
+  return {
+    peerGroupLabel,
+    settlementDensityLabel,
+    energyDensityLabel,
+  };
+};
+
+const getNetworkLevelLabels = function (networkLevel: { id: string }) {
+  return {
+    short: getLocalizedLabel({ id: `network-level.${networkLevel.id}.short` }),
+    long: getLocalizedLabel({ id: `network-level.${networkLevel.id}.long` }),
+  };
+};
+
+const CostsAndTariffsNavigation: React.FC<{
+  activeTab: unknown;
+  handleTabChange: (event: React.SyntheticEvent, newValue: number) => void;
+}> = ({ activeTab, handleTabChange }) => {
+  return (
+    <Tabs value={activeTab} onChange={handleTabChange}>
+      <Tab
+        label={
+          <Trans id="sunshine.costs-and-tariffs.network-costs">
+            Network Costs
+          </Trans>
+        }
+      />
+      <Tab
+        label={
+          <Trans id="sunshine.costs-and-tariffs.net-tariffs">Net Tariffs</Trans>
+        }
+      />
+      <Tab
+        label={
+          <Trans id="sunshine.costs-and-tariffs.energy-tariffs">
+            Energy Tariffs
+          </Trans>
+        }
+      />
+    </Tabs>
+  );
+};
+
+const CardSource = ({ date, source }: { date: string; source: string }) => (
+  <Box
+    sx={{
+      mt: 4,
+      color: "text.secondary",
+      typography: "caption",
+    }}
+  >
+    <div>
+      <Trans id="sunshine.costs-and-tariffs.date">Date: {date}</Trans>
+    </div>
+    <div>
+      <Trans id="sunshine.costs-and-tariffs.source">Source: {source}</Trans>
+    </div>
+  </Box>
+);
+
+const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
+  const [compareWith, setCompareWith] = useState(
+    "sunshine.costs-and-tariffs.all-peer-group"
+  );
+  const [viewBy, setViewBy] = useState("latest");
+
+  const {
+    networkLevel,
+    latestYear,
+    operatorRate,
+    peerGroupMedianRate,
+    peerGroup,
+    updateDate,
+  } = props.sunshine;
+  const { peerGroupLabel } = getPeerGroupLabels(peerGroup);
+  const networkLabels = getNetworkLevelLabels(networkLevel);
+
+  const operatorLabel = props.name;
+
+  return (
+    <>
+      {/* Summary Cards */}
+      <Box
+        display="grid"
+        sx={{
+          // Card inside the grid takes full height of their cells
+          [`& .${gridClasses.item} .${cardClasses.root}`]: {
+            height: "100%",
+          },
+
+          gap: "1rem",
+          gridTemplateColumns: {
+            xs: "1fr", // Single column on small screens
+            sm: "repeat(2, 1fr)", // Two columns on medium screens
+          },
+
+          gridTemplateRows: ["auto auto auto", "auto auto"], // Three rows: two for cards, one for trend chart
+
+          // On Desktop, peer group and network costs cards are side by side
+          // Network costs trend is below them
+          // On Mobile, they are stacked
+          gridTemplateAreas: [
+            `"peer-group" "network-costs" "network-costs-trend"`, // One column on small screens
+            `"peer-group network-costs" "network-costs-trend network-costs-trend"`, // Two columns on medium screens
+          ],
+
+          [`& .${cardClasses.root}`]: {
+            boxShadow: 2,
+            padding: 4,
+          },
+        }}
+      >
+        {/* Peer group */}
+        <Card sx={{ gridArea: "peer-group" }}>
+          <CardContent>
+            <Typography variant="h3" gutterBottom>
+              <Trans id="sunshine.costs-and-tariffs.peer-group">
+                Peer Group
+              </Trans>
+            </Typography>
+            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+              <Trans id="sunshine.costs-and-tariffs.latest-year">
+                Latest year ({latestYear})
+              </Trans>
+            </Typography>
+            <Typography variant="body1">{peerGroupLabel}</Typography>
+          </CardContent>
+        </Card>
+
+        {/* Network costs */}
+        <Card sx={{ gridArea: "network-costs" }}>
+          <CardContent>
+            <Typography variant="h3" gutterBottom>
+              <Trans id="sunshine.costs-and-tariffs.network-costs-end-consumer">
+                Network Costs at {networkLabels.long} Level
+              </Trans>
+            </Typography>
+            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+              <Trans id="sunshine.costs-and-tariffs.latest-year">
+                Latest year ({latestYear})
+              </Trans>
+            </Typography>
+            <Table
+              size="small"
+              sx={{
+                mb: 2,
+                width: "100%",
+
+                [`& .${tableClasses.root}`]: {
+                  tableLayout: "fixed", // Ensures the table takes full width
+                  width: "100%",
+                },
+
+                // Make sure the 1st column takes 50% of the width
+                [`& .${tableCellClasses.root}:first-child`]: {
+                  paddingLeft: 0,
+                  width: "50%", // Ensures the first column takes 50% of the width
+                },
+                [`& .${tableCellClasses.root}:last-child`]: {
+                  textAlign: "right", // Ensures the first column takes 50% of the width
+                },
+              }}
+            >
+              <TableBody>
+                <TableRow>
+                  <TableCell>
+                    <Typography variant="body3" color="text.secondary">
+                      <Trans id="sunshine.costs-and-tariffs.operator">
+                        {operatorLabel}
+                      </Trans>
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <UnitValueWithTrend
+                      value={operatorRate}
+                      unit="Rp./km"
+                      trend="stable"
+                    />
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>
+                    <Typography variant="body3" color="text.secondary">
+                      <Trans id="sunshine.costs-and-tariffs.median-peer-group">
+                        Median Peer Group
+                      </Trans>
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <UnitValueWithTrend
+                      value={peerGroupMedianRate}
+                      unit="Rp./km"
+                      trend="stable"
+                    />
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        {/* Network Cost Trend */}
+        <Card sx={{ gridArea: "network-costs-trend" }}>
+          <CardContent>
+            <Typography variant="h3" gutterBottom>
+              <Trans id="sunshine.costs-and-tariffs.network-cost-trend">
+                Network Cost Trend
+              </Trans>
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              gutterBottom
+              mb={8}
+            >
+              <Trans id="sunshine.costs-and-tariffs.benchmarking-peer-group">
+                Benchmarking within the Peer Group: {peerGroupLabel}
+              </Trans>
+            </Typography>
+
+            {/* Dropdown Controls */}
+            <Grid container spacing={3} sx={{ mb: 3 }}>
+              <Grid item xs={12} sm={6}>
+                <Box>
+                  <Typography variant="caption" gutterBottom></Typography>
+                  <ButtonGroup
+                    id="view-by-button-group"
+                    label={t({
+                      id: "sunshine.costs-and-tariffs.view-by",
+                      message: "View By",
+                    })}
+                    options={[
+                      {
+                        value: "latest",
+                        label: (
+                          <Trans id="sunshine.costs-and-tariffs.latest-year-option">
+                            Latest year
+                          </Trans>
+                        ),
+                      },
+                      {
+                        value: "progress",
+                        label: (
+                          <Trans id="sunshine.costs-and-tariffs.progress-over-time">
+                            Progress over time
+                          </Trans>
+                        ),
+                      },
+                    ]}
+                    value={viewBy}
+                    setValue={setViewBy}
+                  />
+                </Box>
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <Box>
+                  <Combobox
+                    id="compare-with-selection"
+                    label={t({
+                      id: "sunshine.costs-and-tariffs.compare-with",
+                      message: "Compare With",
+                    })}
+                    items={[
+                      "sunshine.costs-and-tariffs.all-peer-group",
+                      "sunshine.costs-and-tariffs.selected-operators",
+                    ]}
+                    selectedItem={compareWith}
+                    setSelectedItem={setCompareWith}
+                    getItemLabel={(item) =>
+                      getLocalizedLabel({
+                        id: item,
+                      })
+                    }
+                  />
+                </Box>
+              </Grid>
+            </Grid>
+
+            {/* Scatter Plot */}
+            <Box sx={{ height: 400, width: "100%" }}>
+              {/* This is a placeholder for the ScatterPlot component */}
+              <Typography color="text.secondary" sx={{ pt: 10 }}>
+                <Trans id="sunshine.costs-and-tariffs.scatter-plot-description">
+                  Scatter Plot visualization showing network costs across
+                  different levels (End Consumer Level, Low Voltage
+                  Distribution, Medium Voltage Distribution)
+                </Trans>
+              </Typography>
+
+              {/* Implement your ScatterPlot component here */}
+              {/* <ScatterPlot /> */}
+            </Box>
+            {/* Footer Info */}
+            <CardSource date={`${updateDate}`} source={"Lindas "} />
+          </CardContent>
+        </Card>
+      </Box>
+    </>
+  );
+};
+
+const UnitValueWithTrend: React.FC<{
+  value: number;
+  unit: string;
+  trend: "stable" | "increasing" | "decreasing";
+}> = ({ value, unit, trend }) => {
+  const trendIcon = {
+    stable: "↔️",
+    increasing: "📈",
+    decreasing: "📉",
+  }[trend];
+
+  return (
+    <Box sx={{ display: "inline-flex", alignItems: "baseline", gap: 1 }}>
+      <span>{trendIcon}</span>
+      <Typography
+        variant="h3"
+        color="text.primary"
+        component="span"
+        fontWeight={700}
+      >
+        {value}
+      </Typography>
+      <Typography variant="caption" color="text.primary">
+        {unit}
+      </Typography>
+    </Box>
+  );
+};
+
+const CostsAndTariffs = (props: Props) => {
+  const { query } = useRouter();
+  const [activeTab, setActiveTab] = useState<TabOption>(
+    TabOption.NETWORK_COSTS
+  );
+
+  if (props.status === "notfound") {
+    return <ErrorPage statusCode={404} />;
+  }
+
+  const { id, name, entity } = props;
+
+  const pageTitle = `${getLocalizedLabel({ id: entity })} ${name} – ${t({
+    id: "sunshine.costs-and-tariffs.title",
+    message: "Costs and Tariffs",
+  })}`;
+
+  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+    setActiveTab(newValue);
+  };
+
+  const bannerContent = (
+    <DetailPageBanner
+      id={id}
+      name={name}
+      municipalities={props.municipalities}
+      entity={entity}
+    />
+  );
+
+  const sidebarContent = <DetailsPageSidebar id={id} entity={entity} />;
+
+  const mainContent = (
+    <>
+      <DetailsPageHeader>
+        <DetailsPageTitle>
+          <Trans id="sunshine.costs-and-tariffs.title">Costs and Tariffs</Trans>
+        </DetailsPageTitle>
+        <DetailsPageSubtitle>
+          <Trans id="sunshine.costs-and-tariffs.description">
+            This page provides an overview of electricity costs and tariffs,
+            including network costs, net tariffs, and energy tariffs. Compare
+            different providers and analyze trends within your peer group to
+            better understand your position in the market.
+          </Trans>
+        </DetailsPageSubtitle>
+      </DetailsPageHeader>
+
+      {/* Tab Navigation */}
+      <CostsAndTariffsNavigation
+        activeTab={activeTab}
+        handleTabChange={handleTabChange}
+      />
+
+      {activeTab === TabOption.NETWORK_COSTS && <NetworkCosts {...props} />}
+
+      {activeTab === TabOption.NET_TARIFFS && (
+        <Box sx={{ textAlign: "center", py: 8 }}>
+          <Typography variant="h5">
+            <Trans id="sunshine.costs-and-tariffs.net-tariffs-content">
+              Net Tariffs Content
+            </Trans>
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            <Trans id="sunshine.costs-and-tariffs.under-development">
+              This section is under development.
+            </Trans>
+          </Typography>
+        </Box>
+      )}
+
+      {activeTab === TabOption.ENERGY_TARIFFS && (
+        <Box sx={{ textAlign: "center", py: 8 }}>
+          <Typography variant="h5">
+            <Trans id="sunshine.costs-and-tariffs.energy-tariffs-content">
+              Energy Tariffs Content
+            </Trans>
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            <Trans id="sunshine.costs-and-tariffs.under-development-energy">
+              This section is under development.
+            </Trans>
+          </Typography>
+        </Box>
+      )}
+    </>
+  );
+
+  return (
+    <DetailsPageLayout
+      title={pageTitle}
+      BannerContent={bannerContent}
+      SidebarContent={sidebarContent}
+      MainContent={mainContent}
+      download={query.download}
+    />
+  );
+};
+
+export default CostsAndTariffs;

--- a/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+++ b/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -7,8 +7,6 @@ import {
   Card,
   CardContent,
   Grid,
-  gridClasses,
-  cardClasses,
   Table,
   TableBody,
   TableRow,
@@ -22,6 +20,7 @@ import { useRouter } from "next/router";
 import React, { useState } from "react";
 
 import { ButtonGroup } from "src/components/button-group";
+import CardGrid from "src/components/card-grid";
 import { Combobox } from "src/components/combobox";
 import { DetailPageBanner } from "src/components/detail-page/banner";
 import {
@@ -202,15 +201,8 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
   return (
     <>
       {/* Summary Cards */}
-      <Box
-        display="grid"
+      <CardGrid
         sx={{
-          // Card inside the grid takes full height of their cells
-          [`& .${gridClasses.item} .${cardClasses.root}`]: {
-            height: "100%",
-          },
-
-          gap: "1rem",
           gridTemplateColumns: {
             xs: "1fr", // Single column on small screens
             sm: "repeat(2, 1fr)", // Two columns on medium screens
@@ -225,11 +217,6 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
             `"peer-group" "network-costs" "network-costs-trend"`, // One column on small screens
             `"peer-group network-costs" "network-costs-trend network-costs-trend"`, // Two columns on medium screens
           ],
-
-          [`& .${cardClasses.root}`]: {
-            boxShadow: 2,
-            padding: 4,
-          },
         }}
       >
         {/* Peer group */}
@@ -416,7 +403,7 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
             <CardSource date={`${updateDate}`} source={"Lindas "} />
           </CardContent>
         </Card>
-      </Box>
+      </CardGrid>
     </>
   );
 };

--- a/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+++ b/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -7,12 +7,9 @@ import {
   Card,
   CardContent,
   Grid,
-  Table,
   TableBody,
   TableRow,
   TableCell,
-  tableClasses,
-  tableCellClasses,
 } from "@mui/material";
 import { GetServerSideProps } from "next";
 import ErrorPage from "next/error";
@@ -22,6 +19,7 @@ import React, { useState } from "react";
 import { ButtonGroup } from "src/components/button-group";
 import CardGrid from "src/components/card-grid";
 import { Combobox } from "src/components/combobox";
+import ComparisonTable from "src/components/comparison-table";
 import { DetailPageBanner } from "src/components/detail-page/banner";
 import {
   DetailsPageLayout,
@@ -30,6 +28,7 @@ import {
   DetailsPageTitle,
 } from "src/components/detail-page/layout";
 import { DetailsPageSidebar } from "src/components/detail-page/sidebar";
+import UnitValueWithTrend from "src/components/unit-value-with-trend";
 import {
   handleOperatorsEntity,
   PageParams,
@@ -244,32 +243,16 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
                 Network Costs at {networkLabels.long} Level
               </Trans>
             </Typography>
-            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+            <Typography
+              variant="subtitle2"
+              color="text.  secondary"
+              gutterBottom
+            >
               <Trans id="sunshine.costs-and-tariffs.latest-year">
                 Latest year ({latestYear})
               </Trans>
             </Typography>
-            <Table
-              size="small"
-              sx={{
-                mb: 2,
-                width: "100%",
-
-                [`& .${tableClasses.root}`]: {
-                  tableLayout: "fixed", // Ensures the table takes full width
-                  width: "100%",
-                },
-
-                // Make sure the 1st column takes 50% of the width
-                [`& .${tableCellClasses.root}:first-child`]: {
-                  paddingLeft: 0,
-                  width: "50%", // Ensures the first column takes 50% of the width
-                },
-                [`& .${tableCellClasses.root}:last-child`]: {
-                  textAlign: "right", // Ensures the first column takes 50% of the width
-                },
-              }}
-            >
+            <ComparisonTable size="small">
               <TableBody>
                 <TableRow>
                   <TableCell>
@@ -304,7 +287,7 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
                   </TableCell>
                 </TableRow>
               </TableBody>
-            </Table>
+            </ComparisonTable>
           </CardContent>
         </Card>
 
@@ -330,58 +313,53 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
             {/* Dropdown Controls */}
             <Grid container spacing={3} sx={{ mb: 3 }}>
               <Grid item xs={12} sm={6}>
-                <Box>
-                  <Typography variant="caption" gutterBottom></Typography>
-                  <ButtonGroup
-                    id="view-by-button-group"
-                    label={t({
-                      id: "sunshine.costs-and-tariffs.view-by",
-                      message: "View By",
-                    })}
-                    options={[
-                      {
-                        value: "latest",
-                        label: (
-                          <Trans id="sunshine.costs-and-tariffs.latest-year-option">
-                            Latest year
-                          </Trans>
-                        ),
-                      },
-                      {
-                        value: "progress",
-                        label: (
-                          <Trans id="sunshine.costs-and-tariffs.progress-over-time">
-                            Progress over time
-                          </Trans>
-                        ),
-                      },
-                    ]}
-                    value={viewBy}
-                    setValue={setViewBy}
-                  />
-                </Box>
+                <ButtonGroup
+                  id="view-by-button-group"
+                  label={t({
+                    id: "sunshine.costs-and-tariffs.view-by",
+                    message: "View By",
+                  })}
+                  options={[
+                    {
+                      value: "latest",
+                      label: (
+                        <Trans id="sunshine.costs-and-tariffs.latest-year-option">
+                          Latest year
+                        </Trans>
+                      ),
+                    },
+                    {
+                      value: "progress",
+                      label: (
+                        <Trans id="sunshine.costs-and-tariffs.progress-over-time">
+                          Progress over time
+                        </Trans>
+                      ),
+                    },
+                  ]}
+                  value={viewBy}
+                  setValue={setViewBy}
+                />
               </Grid>
               <Grid item xs={12} sm={6}>
-                <Box>
-                  <Combobox
-                    id="compare-with-selection"
-                    label={t({
-                      id: "sunshine.costs-and-tariffs.compare-with",
-                      message: "Compare With",
-                    })}
-                    items={[
-                      "sunshine.costs-and-tariffs.all-peer-group",
-                      "sunshine.costs-and-tariffs.selected-operators",
-                    ]}
-                    selectedItem={compareWith}
-                    setSelectedItem={setCompareWith}
-                    getItemLabel={(item) =>
-                      getLocalizedLabel({
-                        id: item,
-                      })
-                    }
-                  />
-                </Box>
+                <Combobox
+                  id="compare-with-selection"
+                  label={t({
+                    id: "sunshine.costs-and-tariffs.compare-with",
+                    message: "Compare With",
+                  })}
+                  items={[
+                    "sunshine.costs-and-tariffs.all-peer-group",
+                    "sunshine.costs-and-tariffs.selected-operators",
+                  ]}
+                  selectedItem={compareWith}
+                  setSelectedItem={setCompareWith}
+                  getItemLabel={(item) =>
+                    getLocalizedLabel({
+                      id: item,
+                    })
+                  }
+                />
               </Grid>
             </Grid>
 
@@ -405,35 +383,6 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
         </Card>
       </CardGrid>
     </>
-  );
-};
-
-const UnitValueWithTrend: React.FC<{
-  value: number;
-  unit: string;
-  trend: "stable" | "increasing" | "decreasing";
-}> = ({ value, unit, trend }) => {
-  const trendIcon = {
-    stable: "↔️",
-    increasing: "📈",
-    decreasing: "📉",
-  }[trend];
-
-  return (
-    <Box sx={{ display: "inline-flex", alignItems: "baseline", gap: 1 }}>
-      <span>{trendIcon}</span>
-      <Typography
-        variant="h3"
-        color="text.primary"
-        component="span"
-        fontWeight={700}
-      >
-        {value}
-      </Typography>
-      <Typography variant="caption" color="text.primary">
-        {unit}
-      </Typography>
-    </Box>
   );
 };
 


### PR DESCRIPTION
## Description

Add costs and tariffs page
- [x] Tested with the following Browsers: Firefox
- [x] Tested on the following devices: Macbook pro
- [x] Verified functionality: The costs and tariffs page is displayed and two tabs are implemented
- [ ] Storybook updated
- [ ] Automated tests added

## Checklist

- [x] I have tested my changes thoroughly
- [x] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [x] I have marked this PR with the appropriate label

## Notes for Reviewers

The goal of this PR is to have the components and structure ready to implement the other sunshine pages.
I tried to have in the end the individual sunshine tabs as short as possible since there are many which
will only change barely between tabs. Hence the introduction of shared components:

- PeerGroupCard
- TableComparisonCard
- CardGrid



### Known Limitations

- Data is mocked, will get better soon in another PR

### Future Improvements

- Other pages will be implemented, data will be mocked at graphql level
- 
