### PR TITLE
Feat/network costs chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ You can also check the
   - Load mocked data through duckdb in Sunshine pages, see README
   - Load data through urql in sunshine pages, urql client cache is primed by the server
   - Added Scatterplot Chart to sunshine charts
-
+  - Ability to change network level on costs and tariffs > network costs page.
 - Fixes
   - Fixed map layout issues on mobile
   - Dropdown adjustments

--- a/e2e/sunshine.spec.ts
+++ b/e2e/sunshine.spec.ts
@@ -14,6 +14,8 @@ test.describe("Sunshine details page", () => {
     await expect(resp?.status()).toEqual(200);
     await snapshot({
       note: "Sunshine details page",
+      locator: await page.getByTestId("details-page-content"),
+      fullPage: true,
     });
   });
 });

--- a/src/components/comparison-table.stories.tsx
+++ b/src/components/comparison-table.stories.tsx
@@ -2,6 +2,7 @@ import { TableBody, TableRow, TableCell, Typography } from "@mui/material";
 
 import ComparisonTable from "src/components/comparison-table";
 import UnitValueWithTrend from "src/components/unit-value-with-trend";
+import { Trend } from "src/graphql/resolver-types";
 
 export const Example = () => {
   const operatorLabel = "Operator XYZ";
@@ -20,7 +21,7 @@ export const Example = () => {
             <UnitValueWithTrend
               value={operatorRate}
               unit="Rp./km"
-              trend="stable"
+              trend={Trend.Down}
             />
           </TableCell>
         </TableRow>
@@ -34,7 +35,7 @@ export const Example = () => {
             <UnitValueWithTrend
               value={peerGroupMedianRate}
               unit="Rp./km"
-              trend="stable"
+              trend={Trend.Stable}
             />
           </TableCell>
         </TableRow>

--- a/src/components/detail-page/layout.tsx
+++ b/src/components/detail-page/layout.tsx
@@ -77,6 +77,7 @@ const DetailPageContentLayout = ({ children, selector, download }: Props) => {
             flexDirection: "column",
             gap: 10,
           }}
+          data-testid="details-page-content"
           display={"flex"}
         >
           {renderedChildren}

--- a/src/components/table-comparison-card.tsx
+++ b/src/components/table-comparison-card.tsx
@@ -21,7 +21,7 @@ const TableComparisonCard: React.FC<
     rows: {
       label: React.ReactNode;
       value:
-        | { value: number; unit: string; trend: Trend }
+        | { value: number; unit: string; trend: Trend; round?: number }
         | { value: React.ReactElement | string };
     }[];
   } & Omit<CardProps, "title" | "subtitle" | "rows">
@@ -49,6 +49,7 @@ const TableComparisonCard: React.FC<
                     value={row.value.value}
                     unit={row.value.unit}
                     trend={row.value.trend}
+                    round={row.value.round}
                   />
                 ) : (
                   <Typography variant="body3">{row.value.value}</Typography>

--- a/src/components/table-comparison-card.tsx
+++ b/src/components/table-comparison-card.tsx
@@ -11,8 +11,7 @@ import React from "react";
 
 import ComparisonTable from "src/components/comparison-table";
 import UnitValueWithTrend from "src/components/unit-value-with-trend";
-
-export type Trend = "stable" | "increasing" | "decreasing";
+import { Trend } from "src/graphql/resolver-types";
 
 const TableComparisonCard: React.FC<
   {
@@ -21,7 +20,12 @@ const TableComparisonCard: React.FC<
     rows: {
       label: React.ReactNode;
       value:
-        | { value: number; unit: string; trend: Trend; round?: number }
+        | {
+            value: number;
+            unit: string;
+            trend: Trend | undefined | null;
+            round?: number;
+          }
         | { value: React.ReactElement | string };
     }[];
   } & Omit<CardProps, "title" | "subtitle" | "rows">

--- a/src/components/trend-icon.tsx
+++ b/src/components/trend-icon.tsx
@@ -4,7 +4,7 @@ import { Icon } from "src/icons";
 
 type Trend = "stable" | "increasing" | "decreasing";
 const iconName = {
-  stable: "minus",
+  stable: null,
   increasing: "arrowup",
   decreasing: "arrowdown",
 } as const;
@@ -12,5 +12,5 @@ export const TrendIcon: React.FC<
   { trend: Trend } & Omit<ComponentProps<typeof Icon>, "name">
 > = ({ trend, ...props }) => {
   const icon = iconName[trend];
-  return <Icon {...props} name={icon} />;
+  return icon ? <Icon {...props} name={icon} /> : null;
 };

--- a/src/components/trend-icon.tsx
+++ b/src/components/trend-icon.tsx
@@ -1,16 +1,19 @@
 import { ComponentProps } from "react";
 
+import { Trend } from "src/graphql/resolver-types";
 import { Icon } from "src/icons";
 
-type Trend = "stable" | "increasing" | "decreasing";
 const iconName = {
-  stable: null,
-  increasing: "arrowup",
-  decreasing: "arrowdown",
+  [Trend.Stable]: null,
+  [Trend.Up]: "arrowup",
+  [Trend.Down]: "arrowdown",
 } as const;
 export const TrendIcon: React.FC<
-  { trend: Trend } & Omit<ComponentProps<typeof Icon>, "name">
+  { trend: Trend | undefined | null } & Omit<
+    ComponentProps<typeof Icon>,
+    "name"
+  >
 > = ({ trend, ...props }) => {
-  const icon = iconName[trend];
+  const icon = trend ? iconName[trend] : undefined;
   return icon ? <Icon {...props} name={icon} /> : null;
 };

--- a/src/components/unit-value-with-trend.tsx
+++ b/src/components/unit-value-with-trend.tsx
@@ -2,11 +2,18 @@ import { Box, Typography } from "@mui/material";
 
 import { TrendIcon } from "src/components/trend-icon";
 
+const roundTo = (value: number, round?: number): number => {
+  if (round === undefined) return value;
+  const factor = Math.pow(10, round);
+  return Math.round(value * factor) / factor;
+};
+
 const UnitValueWithTrend: React.FC<{
   value: number;
   unit: string;
   trend: "stable" | "increasing" | "decreasing";
-}> = ({ value, unit, trend }) => {
+  round?: number;
+}> = ({ value, unit, trend, round }) => {
   return (
     <Box sx={{ display: "inline-flex", alignItems: "baseline", gap: 1 }}>
       <span>
@@ -18,7 +25,7 @@ const UnitValueWithTrend: React.FC<{
         component="span"
         fontWeight={700}
       >
-        {value}
+        {roundTo(value, round)}
       </Typography>
       <Typography variant="caption" color="text.primary">
         {unit}

--- a/src/components/unit-value-with-trend.tsx
+++ b/src/components/unit-value-with-trend.tsx
@@ -1,6 +1,7 @@
 import { Box, Typography } from "@mui/material";
 
 import { TrendIcon } from "src/components/trend-icon";
+import { Trend } from "src/graphql/resolver-types";
 
 const roundTo = (value: number, round?: number): number => {
   if (round === undefined) return value;
@@ -11,7 +12,7 @@ const roundTo = (value: number, round?: number): number => {
 const UnitValueWithTrend: React.FC<{
   value: number;
   unit: string;
-  trend: "stable" | "increasing" | "decreasing";
+  trend: Trend | undefined | null;
   round?: number;
 }> = ({ value, unit, trend, round }) => {
   return (

--- a/src/domain/translation.tsx
+++ b/src/domain/translation.tsx
@@ -226,12 +226,13 @@ export const getLocalizedLabel = ({ id }: { id: string }): string => {
         message: `Low energy density`,
       });
 
+    case "network-level":
+      return t({ id: "network-level", message: `Network level` });
     // NL (Not yet sure about translations)
     case "network-level.NL5.short":
       return t({ id: "network-level.NL5.short", message: `NL5` });
     case "network-level.NL5.long":
       return t({ id: "network-level.NL5.long", message: `High voltage NL5` });
-
     case "network-level.NL6.short":
       return t({ id: "network-level.NL6.short", message: `NL6` });
     case "network-level.NL6.long":
@@ -247,6 +248,11 @@ export const getLocalizedLabel = ({ id }: { id: string }): string => {
       return t({ id: "network-level.NE5.short", message: `NE5` });
     case "network-level.NE5.long":
       return t({ id: "network-level.NE5.long", message: `High voltage NE5` });
+
+    case "network-level.NE6.short":
+      return t({ id: "network-level.NE6.short", message: `NE6` });
+    case "network-level.NE6.long":
+      return t({ id: "network-level.NE6.long", message: `Medium voltage NE6` });
 
     case "network-level.NE7.short":
       return t({ id: "network-level.NE7.short", message: `NE7` });

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -440,6 +440,12 @@ export type TariffsFilter = {
   period: Scalars["Int"]["input"];
 };
 
+export enum Trend {
+  Down = "down",
+  Stable = "stable",
+  Up = "up",
+}
+
 export type WikiContent = {
   __typename: "WikiContent";
   html: Scalars["String"]["output"];

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -98,7 +98,9 @@ export type NetworkCostsData = {
   __typename: "NetworkCostsData";
   networkLevel: NetworkLevel;
   operatorRate?: Maybe<Scalars["Float"]["output"]>;
+  operatorTrend?: Maybe<Trend>;
   peerGroupMedianRate?: Maybe<Scalars["Float"]["output"]>;
+  peerGroupMedianTrend?: Maybe<Trend>;
   yearlyData: Array<NetworkCostRow>;
 };
 
@@ -793,7 +795,9 @@ export type NetworkCostsQuery = {
   networkCosts: {
     __typename: "NetworkCostsData";
     operatorRate?: number | null;
+    operatorTrend?: Trend | null;
     peerGroupMedianRate?: number | null;
+    peerGroupMedianTrend?: Trend | null;
     networkLevel: { __typename: "NetworkLevel"; id: string };
     yearlyData: Array<{
       __typename: "NetworkCostRow";
@@ -1271,7 +1275,9 @@ export const NetworkCostsDocument = gql`
         id
       }
       operatorRate
+      operatorTrend
       peerGroupMedianRate
+      peerGroupMedianTrend
       yearlyData {
         year
         rate

--- a/src/graphql/resolver-types.ts
+++ b/src/graphql/resolver-types.ts
@@ -116,7 +116,9 @@ export type NetworkCostsData = {
   __typename?: "NetworkCostsData";
   networkLevel: NetworkLevel;
   operatorRate?: Maybe<Scalars["Float"]["output"]>;
+  operatorTrend?: Maybe<Trend>;
   peerGroupMedianRate?: Maybe<Scalars["Float"]["output"]>;
+  peerGroupMedianTrend?: Maybe<Trend>;
   yearlyData: Array<NetworkCostRow>;
 };
 
@@ -814,8 +816,18 @@ export type NetworkCostsDataResolvers<
     ParentType,
     ContextType
   >;
+  operatorTrend?: Resolver<
+    Maybe<ResolversTypes["Trend"]>,
+    ParentType,
+    ContextType
+  >;
   peerGroupMedianRate?: Resolver<
     Maybe<ResolversTypes["Float"]>,
+    ParentType,
+    ContextType
+  >;
+  peerGroupMedianTrend?: Resolver<
+    Maybe<ResolversTypes["Trend"]>,
     ParentType,
     ContextType
   >;

--- a/src/graphql/resolver-types.ts
+++ b/src/graphql/resolver-types.ts
@@ -458,6 +458,12 @@ export type TariffsFilter = {
   period: Scalars["Int"]["input"];
 };
 
+export enum Trend {
+  Down = "down",
+  Stable = "stable",
+  Up = "up",
+}
+
 export type WikiContent = {
   __typename?: "WikiContent";
   html: Scalars["String"]["output"];
@@ -629,6 +635,7 @@ export type ResolversTypes = ResolversObject<{
     }
   >;
   TariffsFilter: TariffsFilter;
+  Trend: Trend;
   WikiContent: ResolverTypeWrapper<WikiContent>;
   WikiContentInfo: ResolverTypeWrapper<Scalars["WikiContentInfo"]["output"]>;
 }>;

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -244,6 +244,12 @@ input SunshineDataFilter {
 # TODO Map more closely to predefined strings
 scalar TariffCategory
 
+enum Trend {
+  up
+  down
+  stable
+}
+
 type NetworkCostsData {
   networkLevel: NetworkLevel!
   operatorRate: Float

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -253,7 +253,9 @@ enum Trend {
 type NetworkCostsData {
   networkLevel: NetworkLevel!
   operatorRate: Float
+  operatorTrend: Trend
   peerGroupMedianRate: Float
+  peerGroupMedianTrend: Trend
   yearlyData: [NetworkCostRow!]!
 }
 

--- a/src/lib/db/sql.ts
+++ b/src/lib/db/sql.ts
@@ -304,7 +304,8 @@ export const getLatestYearPowerStability = async (
   `);
   return latestYearData[0]?.year || "2024";
 };
-export type NetworkCostRecord = {
+
+type NetworkCostRecord = {
   operator_id: number;
   operator_name: string;
   year: number;

--- a/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+++ b/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -1,10 +1,12 @@
-import { t, Trans } from "@lingui/macro";
+import { Trans, t } from "@lingui/macro";
+import { Box } from "@mui/material";
 import { GetServerSideProps } from "next";
 import ErrorPage from "next/error";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
 import { gql } from "urql";
 
+import { ButtonGroup } from "src/components/button-group";
 import CardGrid from "src/components/card-grid";
 import { DetailPageBanner } from "src/components/detail-page/banner";
 import {
@@ -191,7 +193,29 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
   } satisfies React.ComponentProps<typeof TableComparisonCard>;
 
   return (
-    <>
+    <div>
+      <Box sx={{ mb: 2 }}>
+        <ButtonGroup
+          id="basic-button-group"
+          label={getLocalizedLabel({ id: "network-level" })}
+          options={[
+            {
+              value: "NE5",
+              label: getLocalizedLabel({ id: "network-level.NE5.short" }),
+            },
+            {
+              value: "NE6",
+              label: getLocalizedLabel({ id: "network-level.NE6.short" }),
+            },
+            {
+              value: "NE7",
+              label: getLocalizedLabel({ id: "network-level.NE7.short" }),
+            },
+          ]}
+          value={networkLevel}
+          setValue={setNetworkLevel}
+        />
+      </Box>
       <CardGrid
         sx={{
           gridTemplateColumns: {
@@ -230,7 +254,7 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
           networkCosts={networkCosts}
         />
       </CardGrid>
-    </>
+    </div>
   );
 };
 

--- a/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+++ b/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -168,6 +168,7 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
               value: operatorRate,
               unit: "Rp./km",
               trend: "stable" as Trend,
+              round: 0,
             },
           }
         : null,
@@ -182,6 +183,7 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
               value: peerGroupMedianRate,
               unit: "Rp./km",
               trend: "stable" as Trend,
+              round: 0,
             },
           }
         : null,

--- a/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+++ b/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -23,9 +23,7 @@ import {
   CostAndTariffsTabOption,
   CostsAndTariffsNavigation,
 } from "src/components/sunshine-tabs";
-import TableComparisonCard, {
-  Trend,
-} from "src/components/table-comparison-card";
+import TableComparisonCard from "src/components/table-comparison-card";
 import {
   handleOperatorsEntity,
   PageParams,
@@ -44,6 +42,7 @@ import {
   useNetworkCostsQuery,
 } from "src/graphql/queries";
 import { TariffCategory } from "src/graphql/resolver-mapped-types";
+import { Trend } from "src/graphql/resolver-types";
 import { fetchOperatorCostsAndTariffsData } from "src/lib/db/sunshine-data";
 import { truthy } from "src/lib/truthy";
 import { defaultLocale } from "src/locales/config";
@@ -324,7 +323,7 @@ const EnergyTariffs = (props: Extract<Props, { status: "found" }>) => {
             value: {
               value: operatorRate,
               unit: "Rp./km",
-              trend: "stable" as Trend,
+              trend: Trend.Stable,
             },
           }
         : null,
@@ -338,7 +337,7 @@ const EnergyTariffs = (props: Extract<Props, { status: "found" }>) => {
             value: {
               value: peerGroupMedianRate,
               unit: "Rp./km",
-              trend: "stable" as Trend,
+              trend: Trend.Stable,
             },
           }
         : null,

--- a/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+++ b/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -105,7 +105,9 @@ export const NetworkCostsDocument = gql`
         id
       }
       operatorRate
+      operatorTrend
       peerGroupMedianRate
+      peerGroupMedianTrend
       yearlyData {
         year
         rate
@@ -141,7 +143,13 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
     // TODO
     return null;
   }
-  const { operatorRate, peerGroupMedianRate, yearlyData } = networkCosts;
+  const {
+    operatorRate,
+    operatorTrend,
+    peerGroupMedianRate,
+    peerGroupMedianTrend,
+    yearlyData,
+  } = networkCosts;
   const networkLabels = getNetworkLevelLabels({ id: networkLevel });
 
   const operatorLabel = props.name;
@@ -168,7 +176,7 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
             value: {
               value: operatorRate,
               unit: "Rp./km",
-              trend: "stable" as Trend,
+              trend: operatorTrend,
               round: 0,
             },
           }
@@ -183,7 +191,7 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
             value: {
               value: peerGroupMedianRate,
               unit: "Rp./km",
-              trend: "stable" as Trend,
+              trend: peerGroupMedianTrend,
               round: 0,
             },
           }

--- a/src/pages/sunshine/[entity]/[id]/power-stability.tsx
+++ b/src/pages/sunshine/[entity]/[id]/power-stability.tsx
@@ -19,9 +19,7 @@ import {
   PowerStabilityNavigation,
   PowerStabilityTabOption,
 } from "src/components/sunshine-tabs";
-import TableComparisonCard, {
-  Trend,
-} from "src/components/table-comparison-card";
+import TableComparisonCard from "src/components/table-comparison-card";
 import {
   handleOperatorsEntity,
   PageParams,
@@ -30,6 +28,7 @@ import {
 import { SunshinePowerStabilityData } from "src/domain/data";
 import { getLocalizedLabel } from "src/domain/translation";
 import { useSaidiQuery, useSaifiQuery } from "src/graphql/queries";
+import { Trend } from "src/graphql/resolver-types";
 import { fetchPowerStability } from "src/lib/db/sunshine-data";
 import { defaultLocale } from "src/locales/config";
 
@@ -172,7 +171,9 @@ const SaidiSaifi = (
         value: {
           value: data.operatorMinutes,
           unit: "min/year",
-          trend: "decreasing" satisfies Trend,
+
+          // TODO Compute the trend
+          trend: Trend.Down,
         },
       },
       {
@@ -184,7 +185,9 @@ const SaidiSaifi = (
         value: {
           value: data.peerGroupMinutes,
           unit: "min/year",
-          trend: "stable" as Trend,
+
+          // TODO Compute the trend
+          trend: Trend.Stable,
         },
       },
     ],


### PR DESCRIPTION
## Description

- Add the network level button group to the "network costs" in costs and tariffs page
- Add an automated E2E test as a safety net to check if loading the operator page works

This shows that the graphql approach to load the data is functional and can be built upon.
We see that the chart changes when clicking the network level button.

Testing: Go to /sunshine/operator/416/costs-and-tariffs and click the network level button group.

## Testing Performed

- [x] Tested with the following Browsers: Firefox
- [x] Tested on the following devices: Macbook pro
- [x] Verified functionality: Went to the page and clicked the button group
- [x] Automated tests added

## Checklist

- [x] I have tested my changes thoroughly
- [x] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [x] I have marked this PR with the appropriate label
- [x] I have added an entry in the changelog

## Notes for Reviewers

The rest of the implementation for other tabs will be done in later PRs.
