### PR TITLE
fix: Correctly output unplanned and total from saifi/saidi data

### DIFF
--- a/mocks/fetchPowerStability-426.json
+++ b/mocks/fetchPowerStability-426.json
@@ -1,5 +1,5 @@
 {
-  "latestYear": "2024",
+  "latestYear": 2024,
   "operator": {
     "peerGroup": {
       "settlementDensity": "Mountain",
@@ -7,142 +7,142 @@
     }
   },
   "saidi": {
-    "operatorMinutes": 44.6043242396,
-    "peerGroupMinutes": 22.6477406564,
+    "operatorTotal": 44.6043242396,
+    "peerGroupTotal": 22.6477406564,
     "yearlyData": [
       {
         "year": 2024,
-        "minutes": 22.6477406564,
-        "operator": 694,
-        "operator_name": "RadiantArc Power",
-        "planned": false
+        "total": 22.6477406564,
+        "operator": 515,
+        "operator_name": "Fluxonomy Energy",
+        "unplanned": 10.8663473594
       },
       {
         "year": 2024,
-        "minutes": 51.5796399034,
-        "operator": 845,
-        "operator_name": "GreenVibe Power",
-        "planned": false
+        "total": 51.5796399034,
+        "operator": 965,
+        "operator_name": "PulseNova Energy",
+        "unplanned": 9.6740689609
       },
       {
         "year": 2024,
-        "minutes": 25.0733966871,
-        "operator": 922,
-        "operator_name": "GridHaven Energy",
-        "planned": false
+        "total": 25.0733966871,
+        "operator": 491,
+        "operator_name": "PureShift Power",
+        "unplanned": 10.2890395283
       },
       {
         "year": 2024,
-        "minutes": 44.6043242396,
-        "operator": 159,
+        "total": 44.6043242396,
+        "operator": 955,
+        "operator_name": "TrueAmp Utilities",
+        "unplanned": 37.7769059146
+      },
+      {
+        "year": 2024,
+        "total": 27.8072223704,
+        "operator": 230,
         "operator_name": "ClarityGrid Utilities",
-        "planned": false
+        "unplanned": 15.1045884793
       },
       {
         "year": 2024,
-        "minutes": 27.8072223704,
-        "operator": 743,
-        "operator_name": "Zephyrion Grid",
-        "planned": false
+        "total": 16.7291675154,
+        "operator": 670,
+        "operator_name": "Soltrix Energy",
+        "unplanned": 15.6410511047
       },
       {
         "year": 2024,
-        "minutes": 16.7291675154,
-        "operator": 307,
-        "operator_name": "WindLoom Utilities",
-        "planned": false
+        "total": 10.6333277769,
+        "operator": 921,
+        "operator_name": "FusionSpan Utilities",
+        "unplanned": 0.2505973218
       },
       {
         "year": 2024,
-        "minutes": 10.6333277769,
-        "operator": 732,
-        "operator_name": "NexCraft Power",
-        "planned": false
+        "total": 8.8868028713,
+        "operator": 104,
+        "operator_name": "Greenbeat Grid",
+        "unplanned": 0
       },
       {
         "year": 2024,
-        "minutes": 8.8868028713,
-        "operator": 887,
-        "operator_name": "Windova Power",
-        "planned": true
-      },
-      {
-        "year": 2024,
-        "minutes": 14.0699144743,
-        "operator": 911,
-        "operator_name": "AeroTide Power",
-        "planned": false
+        "total": 14.0699144743,
+        "operator": 118,
+        "operator_name": "AetherForge Energy",
+        "unplanned": 8.3813969101
       }
     ]
   },
   "saifi": {
-    "operatorMinutes": 0.7396167344,
-    "peerGroupMinutes": 0.3035262388,
+    "operatorTotal": 0.7396167344,
+    "peerGroupTotal": 0.3035262388,
     "yearlyData": [
       {
         "year": 2024,
-        "minutes": 0.3959103083,
-        "operator": 694,
-        "operator_name": "RadiantArc Power",
-        "planned": false
+        "total": 0.3959103083,
+        "operator": 515,
+        "operator_name": "Fluxonomy Energy",
+        "unplanned": 0.1709180815
       },
       {
         "year": 2024,
-        "minutes": 0.3035262388,
-        "operator": 845,
-        "operator_name": "GreenVibe Power",
-        "planned": false
+        "total": 0.3035262388,
+        "operator": 965,
+        "operator_name": "PulseNova Energy",
+        "unplanned": 0.155755342
       },
       {
         "year": 2024,
-        "minutes": 0.3387837228,
-        "operator": 922,
-        "operator_name": "GridHaven Energy",
-        "planned": false
+        "total": 0.3387837228,
+        "operator": 491,
+        "operator_name": "PureShift Power",
+        "unplanned": 0.1946637044
       },
       {
         "year": 2024,
-        "minutes": 0.7396167344,
-        "operator": 159,
+        "total": 0.7396167344,
+        "operator": 955,
+        "operator_name": "TrueAmp Utilities",
+        "unplanned": 0.6480981646
+      },
+      {
+        "year": 2024,
+        "total": 0.2742139886,
+        "operator": 230,
         "operator_name": "ClarityGrid Utilities",
-        "planned": false
+        "unplanned": 0.1789233757
       },
       {
         "year": 2024,
-        "minutes": 0.2742139886,
-        "operator": 743,
-        "operator_name": "Zephyrion Grid",
-        "planned": false
+        "total": 0.6368627395,
+        "operator": 670,
+        "operator_name": "Soltrix Energy",
+        "unplanned": 0.6247366279
       },
       {
         "year": 2024,
-        "minutes": 0.6368627395,
-        "operator": 307,
-        "operator_name": "WindLoom Utilities",
-        "planned": false
+        "total": 0.1490248375,
+        "operator": 921,
+        "operator_name": "FusionSpan Utilities",
+        "unplanned": 0.0022225927
       },
       {
         "year": 2024,
-        "minutes": 0.1490248375,
-        "operator": 732,
-        "operator_name": "NexCraft Power",
-        "planned": false
+        "total": 0.2211485367,
+        "operator": 104,
+        "operator_name": "Greenbeat Grid",
+        "unplanned": 0
       },
       {
         "year": 2024,
-        "minutes": 0.2211485367,
-        "operator": 887,
-        "operator_name": "Windova Power",
-        "planned": true
-      },
-      {
-        "year": 2024,
-        "minutes": 0.2297086501,
-        "operator": 911,
-        "operator_name": "AeroTide Power",
-        "planned": false
+        "total": 0.2297086501,
+        "operator": 118,
+        "operator_name": "AetherForge Energy",
+        "unplanned": 0.1025787509
       }
     ]
   },
-  "updateDate": "June 5, 2025 at 01:40 PM"
+  "updateDate": "June 12, 2025 at 11:24 AM"
 }

--- a/src/domain/data.ts
+++ b/src/domain/data.ts
@@ -3,7 +3,11 @@ import { useMemo } from "react";
 
 import buildEnv from "src/env/build";
 import { TariffCategory } from "src/graphql/resolver-mapped-types";
-import { NetworkCostsData, TariffsData } from "src/graphql/resolver-types";
+import {
+  NetworkCostsData,
+  StabilityData,
+  TariffsData,
+} from "src/graphql/resolver-types";
 import { chartPalette } from "src/themes/palette";
 
 export type ObservationValue = string | number | boolean | Date;
@@ -168,28 +172,8 @@ export type SunshineCostsAndTariffsData = {
 
 export type SunshinePowerStabilityData = {
   latestYear: string;
-  saidi: {
-    operatorMinutes: number;
-    peerGroupMinutes: number;
-    yearlyData: {
-      year: number;
-      minutes: number;
-      operator: number;
-      operator_name: string;
-      planned: boolean;
-    }[];
-  };
-  saifi: {
-    operatorMinutes: number;
-    peerGroupMinutes: number;
-    yearlyData: {
-      year: number;
-      minutes: number;
-      operator: number;
-      operator_name: string;
-      planned: boolean;
-    }[];
-  };
+  saidi: StabilityData;
+  saifi: StabilityData;
 
   operator: {
     peerGroup: {

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -346,17 +346,17 @@ export type SearchResult = {
 
 export type StabilityData = {
   __typename: "StabilityData";
-  operatorMinutes: Scalars["Float"]["output"];
-  peerGroupMinutes: Scalars["Float"]["output"];
+  operatorTotal: Scalars["Float"]["output"];
+  peerGroupTotal: Scalars["Float"]["output"];
   yearlyData: Array<StabilityDataRow>;
 };
 
 export type StabilityDataRow = {
   __typename: "StabilityDataRow";
-  minutes: Scalars["Float"]["output"];
   operator: Scalars["Int"]["output"];
   operator_name: Scalars["String"]["output"];
-  planned: Scalars["Boolean"]["output"];
+  total: Scalars["Float"]["output"];
+  unplanned: Scalars["Float"]["output"];
   year: Scalars["Int"]["output"];
 };
 
@@ -862,15 +862,15 @@ export type SaidiQuery = {
   __typename: "Query";
   saidi: {
     __typename: "StabilityData";
-    operatorMinutes: number;
-    peerGroupMinutes: number;
+    operatorTotal: number;
+    peerGroupTotal: number;
     yearlyData: Array<{
       __typename: "StabilityDataRow";
       year: number;
-      minutes: number;
+      total: number;
+      unplanned: number;
       operator: number;
       operator_name: string;
-      planned: boolean;
     }>;
   };
 };
@@ -883,15 +883,15 @@ export type SaifiQuery = {
   __typename: "Query";
   saifi: {
     __typename: "StabilityData";
-    operatorMinutes: number;
-    peerGroupMinutes: number;
+    operatorTotal: number;
+    peerGroupTotal: number;
     yearlyData: Array<{
       __typename: "StabilityDataRow";
       year: number;
-      minutes: number;
+      total: number;
+      unplanned: number;
       operator: number;
       operator_name: string;
-      planned: boolean;
     }>;
   };
 };
@@ -1350,14 +1350,14 @@ export function useNetTariffsQuery(
 export const SaidiDocument = gql`
   query Saidi($filter: StabilityFilter!) {
     saidi(filter: $filter) {
-      operatorMinutes
-      peerGroupMinutes
+      operatorTotal
+      peerGroupTotal
       yearlyData {
         year
-        minutes
+        total
+        unplanned
         operator
         operator_name
-        planned
       }
     }
   }
@@ -1374,14 +1374,14 @@ export function useSaidiQuery(
 export const SaifiDocument = gql`
   query Saifi($filter: StabilityFilter!) {
     saifi(filter: $filter) {
-      operatorMinutes
-      peerGroupMinutes
+      operatorTotal
+      peerGroupTotal
       yearlyData {
         year
-        minutes
+        total
+        unplanned
         operator
         operator_name
-        planned
       }
     }
   }

--- a/src/graphql/resolver-types.ts
+++ b/src/graphql/resolver-types.ts
@@ -364,17 +364,17 @@ export type SearchResult = {
 
 export type StabilityData = {
   __typename?: "StabilityData";
-  operatorMinutes: Scalars["Float"]["output"];
-  peerGroupMinutes: Scalars["Float"]["output"];
+  operatorTotal: Scalars["Float"]["output"];
+  peerGroupTotal: Scalars["Float"]["output"];
   yearlyData: Array<StabilityDataRow>;
 };
 
 export type StabilityDataRow = {
   __typename?: "StabilityDataRow";
-  minutes: Scalars["Float"]["output"];
   operator: Scalars["Int"]["output"];
   operator_name: Scalars["String"]["output"];
-  planned: Scalars["Boolean"]["output"];
+  total: Scalars["Float"]["output"];
+  unplanned: Scalars["Float"]["output"];
   year: Scalars["Int"]["output"];
 };
 
@@ -1127,8 +1127,8 @@ export type StabilityDataResolvers<
   ContextType = ServerContext,
   ParentType extends ResolversParentTypes["StabilityData"] = ResolversParentTypes["StabilityData"]
 > = ResolversObject<{
-  operatorMinutes?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
-  peerGroupMinutes?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
+  operatorTotal?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
+  peerGroupTotal?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   yearlyData?: Resolver<
     Array<ResolversTypes["StabilityDataRow"]>,
     ParentType,
@@ -1141,10 +1141,10 @@ export type StabilityDataRowResolvers<
   ContextType = ServerContext,
   ParentType extends ResolversParentTypes["StabilityDataRow"] = ResolversParentTypes["StabilityDataRow"]
 > = ResolversObject<{
-  minutes?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   operator?: Resolver<ResolversTypes["Int"], ParentType, ContextType>;
   operator_name?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
-  planned?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
+  total?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
+  unplanned?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   year?: Resolver<ResolversTypes["Int"], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -300,15 +300,15 @@ input TariffsFilter {
 
 type StabilityDataRow {
   year: Int!
-  minutes: Float!
+  total: Float!
+  unplanned: Float!
   operator: Int!
   operator_name: String!
-  planned: Boolean!
 }
 
 type StabilityData {
-  operatorMinutes: Float!
-  peerGroupMinutes: Float!
+  operatorTotal: Float!
+  peerGroupTotal: Float!
   yearlyData: [StabilityDataRow!]!
 }
 

--- a/src/lib/db/sql.ts
+++ b/src/lib/db/sql.ts
@@ -111,7 +111,9 @@ export const getStabilityMetrics = async ({
       ORDER BY period DESC, operator_id
     `;
 
+  console.log(sql);
   const result = await query<StabilityMetricRecord>(sql);
+  console.log(result);
   return result;
 };
 export const getTariffs = async ({

--- a/src/lib/db/sunshine-data.ts
+++ b/src/lib/db/sunshine-data.ts
@@ -5,7 +5,12 @@ import {
   SunshineOperationalStandardsData,
   SunshinePowerStabilityData,
 } from "src/domain/data";
-import { NetworkCostsData, Trend } from "src/graphql/resolver-types";
+import {
+  NetworkCostsData,
+  StabilityData,
+  TariffsData,
+  Trend,
+} from "src/graphql/resolver-types";
 import {
   getOperatorData,
   getNetworkCosts,
@@ -228,12 +233,7 @@ export const fetchEnergyTariffsData = async ({
   operatorId: number;
   category: TariffCategory;
   period: number;
-}): Promise<{
-  category: TariffCategory;
-  operatorRate: number | null;
-  peerGroupMedianRate: number | null;
-  yearlyData: TariffRecord[];
-}> => {
+}): Promise<TariffsData> => {
   const operatorData = await getOperatorData(operatorId);
   if (!operatorData) {
     throw new Error(`Peer group not found for operator ID: ${operatorId}`);
@@ -346,17 +346,7 @@ export const fetchSaidi = async ({
 }: {
   operatorId: number;
   period: number;
-}): Promise<{
-  operatorMinutes: number;
-  peerGroupMinutes: number;
-  yearlyData: {
-    year: number;
-    minutes: number;
-    operator: number;
-    operator_name: string;
-    planned: boolean;
-  }[];
-}> => {
+}): Promise<StabilityData> => {
   const operatorData = await getOperatorData(operatorId);
   if (!operatorData) {
     throw new Error(`Peer group not found for operator ID: ${operatorId}`);
@@ -386,14 +376,14 @@ export const fetchSaidi = async ({
   });
 
   return {
-    operatorMinutes: operatorStability?.[0]?.saidi_total || 0,
-    peerGroupMinutes: peerGroupMedianStability?.median_saidi_total || 0,
+    operatorTotal: operatorStability?.[0]?.saidi_total || 0,
+    peerGroupTotal: peerGroupMedianStability?.median_saidi_total || 0,
     yearlyData: peerGroupYearlyStability.map((x) => ({
       year: x.period,
-      minutes: x.saidi_total,
+      total: x.saidi_total,
       operator: x.operator_id,
       operator_name: x.operator_name,
-      planned: x.saidi_unplanned === 0,
+      unplanned: x.saidi_unplanned,
     })),
   };
 };
@@ -410,17 +400,7 @@ export const fetchSaifi = async ({
 }: {
   operatorId: number;
   period: number;
-}): Promise<{
-  operatorMinutes: number;
-  peerGroupMinutes: number;
-  yearlyData: {
-    year: number;
-    minutes: number;
-    operator: number;
-    operator_name: string;
-    planned: boolean;
-  }[];
-}> => {
+}): Promise<StabilityData> => {
   const operatorData = await getOperatorData(operatorId);
   if (!operatorData) {
     throw new Error(`Peer group not found for operator ID: ${operatorId}`);
@@ -449,14 +429,14 @@ export const fetchSaifi = async ({
   });
 
   return {
-    operatorMinutes: operatorStability?.[0]?.saifi_total || 0,
-    peerGroupMinutes: peerGroupMedianStability?.median_saifi_total || 0,
+    operatorTotal: operatorStability?.[0]?.saifi_total || 0,
+    peerGroupTotal: peerGroupMedianStability?.median_saifi_total || 0,
     yearlyData: peerGroupYearlyStability.map((x) => ({
       year: x.period,
-      minutes: x.saifi_total,
+      total: x.saifi_total,
       operator: x.operator_id,
       operator_name: x.operator_name,
-      planned: x.saifi_unplanned === 0,
+      unplanned: x.saifi_unplanned,
     })),
   };
 };

--- a/src/pages/sunshine/[entity]/[id]/power-stability.tsx
+++ b/src/pages/sunshine/[entity]/[id]/power-stability.tsx
@@ -80,14 +80,14 @@ export const getServerSideProps: GetServerSideProps<
 export const SaidiDocument = gql`
   query Saidi($filter: StabilityFilter!) {
     saidi(filter: $filter) {
-      operatorMinutes
-      peerGroupMinutes
+      operatorTotal
+      peerGroupTotal
       yearlyData {
         year
-        minutes
+        total
+        unplanned
         operator
         operator_name
-        planned
       }
     }
   }
@@ -96,14 +96,14 @@ export const SaidiDocument = gql`
 export const SaifiDocument = gql`
   query Saifi($filter: StabilityFilter!) {
     saifi(filter: $filter) {
-      operatorMinutes
-      peerGroupMinutes
+      operatorTotal
+      peerGroupTotal
       yearlyData {
         year
-        minutes
+        total
+        unplanned
         operator
         operator_name
-        planned
       }
     }
   }
@@ -169,7 +169,7 @@ const SaidiSaifi = (
           <Trans id="sunshine.power-stability.operator">{operatorLabel}</Trans>
         ),
         value: {
-          value: data.operatorMinutes,
+          value: data.operatorTotal,
           unit: "min/year",
 
           // TODO Compute the trend
@@ -183,7 +183,7 @@ const SaidiSaifi = (
           </Trans>
         ),
         value: {
-          value: data.peerGroupMinutes,
+          value: data.peerGroupTotal,
           unit: "min/year",
 
           // TODO Compute the trend


### PR DESCRIPTION
## Description

We did not correctly output the "planned" / "unplanned" data from the power
stability rows. Previously we would have a boolean "planned" on each yearly
row and it was not clear that the operatorMinutes were the total.
The "planned" boolean was not correct.

Now, each year row contains "total" and "unplanned".

To get the planned, one only has to do total - unplanned.

## Notes for Reviewers

@noahonyejese This will impact your work on the power stability, I think you should
rebase your work onto this PR and then adapt.
