### PR TITLE
Connect MultiCombobox with Sunshine pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ You can also check the
 
   - Added stacked horizontal charts for power stability to the sunshine charts
   - Added Error States & enhanced existing hint styles
-  - Added new Select All or MultiCombobox variant integrated into costs and tariffs pages
+  - Added new Select All or MultiCombobox variant integrated into sunshine pages
 
 - Storybook
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ You can also check the
 
   - Added stacked horizontal charts for power stability to the sunshine charts
   - Added Error States & enhanced existing hint styles
+  - Added new Select All or MultiCombobox variant integrated into costs and tariffs pages
 
 - Storybook
 

--- a/src/components/charts-generic/bars/bars-stacked-state.tsx
+++ b/src/components/charts-generic/bars/bars-stacked-state.tsx
@@ -129,7 +129,7 @@ const useStackedBarsState = ({
     );
 
     const margins = {
-      top: 50,
+      top: 20,
       right: 40,
       bottom: 40,
       left: maxYLabelWidth + LEFT_MARGIN_OFFSET,

--- a/src/components/combobox.stories.tsx
+++ b/src/components/combobox.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { Combobox, ComboboxItem, ComboboxMulti } from "./combobox";
+import { Combobox, ComboboxItem, MultiCombobox } from "./combobox";
 
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -141,7 +141,7 @@ export const UsageCategorySelection: Story = {
 };
 
 // Multi-Selection Example
-export const MultiSelection: StoryObj<typeof ComboboxMulti> = {
+export const MultiSelection: StoryObj<typeof MultiCombobox> = {
   render: () => {
     const [selectedMunicipalities, setSelectedMunicipalities] = useState([
       "zurich",
@@ -174,7 +174,7 @@ export const MultiSelection: StoryObj<typeof ComboboxMulti> = {
 
     return (
       <div style={{ width: "400px" }}>
-        <ComboboxMulti
+        <MultiCombobox
           id="municipality-multi-selection"
           label="Select Municipalities for Comparison"
           items={municipalities}

--- a/src/components/combobox.tsx
+++ b/src/components/combobox.tsx
@@ -34,7 +34,7 @@ const defaultOptionEqualToValue = (
   return option === value;
 };
 
-export const ComboboxMulti = ({
+export const MultiCombobox = ({
   id,
   label,
   items,

--- a/src/components/combobox.tsx
+++ b/src/components/combobox.tsx
@@ -126,7 +126,7 @@ export const ComboboxMulti = ({
           const { key, ...tagProps } = getTagProps({ index });
           return (
             <Chip
-              key={key}
+              key={`${key}-${id}-chip`}
               label={getItemLabel(option)}
               {...tagProps}
               size="xs"
@@ -140,7 +140,7 @@ export const ComboboxMulti = ({
         })
       }
       renderOption={(props, option) => (
-        <li {...props} key={option}>
+        <li {...props} key={`${option}-${id}-selectable`}>
           {getItemLabel(option)}
         </li>
       )}

--- a/src/components/detail-page/selector-multi.tsx
+++ b/src/components/detail-page/selector-multi.tsx
@@ -2,7 +2,7 @@ import { t, Trans } from "@lingui/macro";
 import { Box } from "@mui/material";
 import { useMemo } from "react";
 
-import { Combobox, ComboboxMulti } from "src/components/combobox";
+import { Combobox, MultiCombobox } from "src/components/combobox";
 import {
   CantonsCombobox,
   MunicipalitiesCombobox,
@@ -76,7 +76,7 @@ export const SelectorMulti = ({ entity }: { entity: Entity }) => {
             setSelectedItems={(items) => setQueryState({ canton: items })}
           />
         )}
-        <ComboboxMulti
+        <MultiCombobox
           id="periods"
           label={<Trans id="selector.years">years</Trans>}
           items={periods}

--- a/src/components/kitchen-sink.stories.tsx
+++ b/src/components/kitchen-sink.stories.tsx
@@ -17,7 +17,7 @@ import { chartPalette, palette } from "src/themes/palette";
 
 import { AnchorNav } from "./anchor-nav";
 import { ButtonGroup } from "./button-group";
-import { Combobox, ComboboxMulti } from "./combobox";
+import { Combobox, MultiCombobox } from "./combobox";
 import {
   ColorPaletteStack,
   ColorSwatch,
@@ -643,14 +643,14 @@ export const FormStory = () => {
         </DesignSection>
         <DesignSection
           title="Multi-Select"
-          note="Currently using ComboboxMulti + Autocomplete Component!"
+          note="Currently using MultiCombobox + Autocomplete Component!"
           sx={{
             gap: 8,
             maxWidth: 300,
           }}
         >
           {selectStates.map((state) => (
-            <ComboboxMulti
+            <MultiCombobox
               key={state}
               id={`multi-select-${state}`}
               disabled={state === "disabled"}

--- a/src/components/net-tariffs-trend-card.tsx
+++ b/src/components/net-tariffs-trend-card.tsx
@@ -12,7 +12,7 @@ import React, { useMemo, useState } from "react";
 import { ButtonGroup } from "src/components/button-group";
 import CardSource from "src/components/card-source";
 import { PeerGroup, SunshineCostsAndTariffsData } from "src/domain/data";
-import { containsDelimiter, filterByDelimiter } from "src/domain/helpers";
+import { filterByDelimiter } from "src/domain/helpers";
 import { getPeerGroupLabels } from "src/domain/translation";
 
 import { CardHeader } from "./detail-page/card";
@@ -51,11 +51,8 @@ const NetTariffsTrendCard: React.FC<
     return yearlyData.filter(
       (d) =>
         d.period === latestYear &&
-        (containsDelimiter(
-          compareWith,
-          "sunshine.select-all",
-          d.operator_id.toString()
-        ) ||
+        (compareWith.includes("sunshine.select-all") ||
+          compareWith.includes(d.operator_id.toString()) ||
           d.operator_id.toString() === operatorId)
     );
   }, [yearlyData, compareWith, latestYear, operatorId]);

--- a/src/components/net-tariffs-trend-card.tsx
+++ b/src/components/net-tariffs-trend-card.tsx
@@ -12,7 +12,7 @@ import React, { useMemo, useState } from "react";
 import { ButtonGroup } from "src/components/button-group";
 import CardSource from "src/components/card-source";
 import { PeerGroup, SunshineCostsAndTariffsData } from "src/domain/data";
-import { filterByDelimiter } from "src/domain/helpers";
+import { filterBySeparator } from "src/domain/helpers";
 import { getPeerGroupLabels } from "src/domain/translation";
 
 import { CardHeader } from "./detail-page/card";
@@ -147,7 +147,7 @@ const NetTariffsTrendCard: React.FC<
               selectedItems={compareWith}
               setSelectedItems={(items) =>
                 setCompareWith((prev) =>
-                  filterByDelimiter(items, prev, "sunshine.select-all")
+                  filterBySeparator(items, prev, "sunshine.select-all")
                 )
               }
             />

--- a/src/components/net-tariffs-trend-card.tsx
+++ b/src/components/net-tariffs-trend-card.tsx
@@ -37,20 +37,23 @@ const NetTariffsTrendCard: React.FC<
   const { yearlyData, ...restNetTariffs } = netTariffs;
   const latestYear = new Date().getFullYear();
   const latestYearDataItems = useMemo(() => {
-    return yearlyData.filter((d) => d.period === latestYear);
-  }, [yearlyData, latestYear]);
+    return yearlyData.filter(
+      (d) => d.period === latestYear && d.operator_id.toString() !== operatorId
+    );
+  }, [yearlyData, latestYear, operatorId]);
 
   const latestYearData = useMemo(() => {
     return yearlyData.filter(
       (d) =>
         d.period === latestYear &&
-        containsDelimiter(
+        (containsDelimiter(
           compareWith,
           "sunshine.select-all",
           d.operator_id.toString()
-        )
+        ) ||
+          d.operator_id.toString() === operatorId)
     );
-  }, [yearlyData, compareWith, latestYear]);
+  }, [yearlyData, compareWith, latestYear, operatorId]);
 
   return (
     <Card {...props}>

--- a/src/components/net-tariffs-trend-card.tsx
+++ b/src/components/net-tariffs-trend-card.tsx
@@ -16,7 +16,7 @@ import { containsDelimiter, filterByDelimiter } from "src/domain/helpers";
 import { getPeerGroupLabels } from "src/domain/translation";
 
 import { NetTariffsTrendChart } from "./net-tariffs-trend-chart";
-import { AllOrComboboxMulti } from "./query-combobox";
+import { AllOrMultiCombobox } from "./query-combobox";
 
 const NetTariffsTrendCard: React.FC<
   {
@@ -98,7 +98,7 @@ const NetTariffsTrendCard: React.FC<
             />
           </Grid>
           <Grid item xs={12} sm={6}>
-            <AllOrComboboxMulti
+            <AllOrMultiCombobox
               label={t({
                 id: "sunshine.costs-and-tariffs.compare-with",
                 message: "Compare With",

--- a/src/components/net-tariffs-trend-card.tsx
+++ b/src/components/net-tariffs-trend-card.tsx
@@ -117,7 +117,9 @@ const NetTariffsTrendCard: React.FC<
               ]}
               selectedItems={compareWith}
               setSelectedItems={(items) =>
-                setCompareWith(filterByDelimiter(items, "sunshine.select-all"))
+                setCompareWith((prev) =>
+                  filterByDelimiter(items, prev, "sunshine.select-all")
+                )
               }
             />
           </Grid>

--- a/src/components/net-tariffs-trend-card.tsx
+++ b/src/components/net-tariffs-trend-card.tsx
@@ -7,15 +7,16 @@ import {
   Grid,
   Typography,
 } from "@mui/material";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 
 import { ButtonGroup } from "src/components/button-group";
 import CardSource from "src/components/card-source";
-import { Combobox } from "src/components/combobox";
 import { PeerGroup, SunshineCostsAndTariffsData } from "src/domain/data";
-import { getLocalizedLabel, getPeerGroupLabels } from "src/domain/translation";
+import { containsDelimiter, filterByDelimiter } from "src/domain/helpers";
+import { getPeerGroupLabels } from "src/domain/translation";
 
 import { NetTariffsTrendChart } from "./net-tariffs-trend-chart";
+import { AllOrComboboxMulti } from "./query-combobox";
 
 const NetTariffsTrendCard: React.FC<
   {
@@ -26,14 +27,31 @@ const NetTariffsTrendCard: React.FC<
     operatorLabel: string;
   } & CardProps
 > = (props) => {
-  const [compareWith, setCompareWith] = useState(
-    "sunshine.costs-and-tariffs.all-peer-group"
-  );
+  const [compareWith, setCompareWith] = useState(["sunshine.select-all"]);
   const [viewBy, setViewBy] = useState("latest");
 
   const { peerGroup, updateDate, netTariffs, operatorId, operatorLabel } =
     props;
   const { peerGroupLabel } = getPeerGroupLabels(peerGroup);
+
+  const { yearlyData, ...restNetTariffs } = netTariffs;
+  const latestYear = new Date().getFullYear();
+  const latestYearDataItems = useMemo(() => {
+    return yearlyData.filter((d) => d.period === latestYear);
+  }, [yearlyData, latestYear]);
+
+  const latestYearData = useMemo(() => {
+    return yearlyData.filter(
+      (d) =>
+        d.period === latestYear &&
+        containsDelimiter(
+          compareWith,
+          "sunshine.select-all",
+          d.operator_id.toString()
+        )
+    );
+  }, [yearlyData, compareWith, latestYear]);
+
   return (
     <Card {...props}>
       <CardContent>
@@ -80,22 +98,23 @@ const NetTariffsTrendCard: React.FC<
             />
           </Grid>
           <Grid item xs={12} sm={6}>
-            <Combobox
-              id="compare-with-selection"
+            <AllOrComboboxMulti
               label={t({
                 id: "sunshine.costs-and-tariffs.compare-with",
                 message: "Compare With",
               })}
               items={[
-                "sunshine.costs-and-tariffs.all-peer-group",
-                "sunshine.costs-and-tariffs.selected-operators",
+                { id: "sunshine.select-all" },
+                ...latestYearDataItems.map((item) => {
+                  return {
+                    id: String(item.operator_id),
+                    name: item.operator_name,
+                  };
+                }),
               ]}
-              selectedItem={compareWith}
-              setSelectedItem={setCompareWith}
-              getItemLabel={(item) =>
-                getLocalizedLabel({
-                  id: item,
-                })
+              selectedItems={compareWith}
+              setSelectedItems={(items) =>
+                setCompareWith(filterByDelimiter(items, "sunshine.select-all"))
               }
             />
           </Grid>
@@ -106,7 +125,8 @@ const NetTariffsTrendCard: React.FC<
           <NetTariffsTrendChart
             id={operatorId}
             operatorLabel={operatorLabel}
-            observations={netTariffs}
+            observations={latestYearData}
+            netTariffs={restNetTariffs}
           />
         </Box>
         {/* Footer Info */}

--- a/src/components/net-tariffs-trend-chart.tsx
+++ b/src/components/net-tariffs-trend-chart.tsx
@@ -17,12 +17,14 @@ import { ScatterPlot } from "./charts-generic/scatter-plot/scatter-plot-state";
 import { SectionProps } from "./detail-page/card";
 
 type NetTariffsTrendChartProps = {
-  observations: SunshineCostsAndTariffsData["netTariffs"];
+  observations: SunshineCostsAndTariffsData["netTariffs"]["yearlyData"];
+  netTariffs: Omit<SunshineCostsAndTariffsData["netTariffs"], "yearlyData">;
   operatorLabel: string;
 };
 
 export const NetTariffsTrendChart = ({
   observations,
+  netTariffs,
   id,
   operatorLabel,
 }: NetTariffsTrendChartProps & Omit<SectionProps, "entity">) => {
@@ -33,8 +35,8 @@ export const NetTariffsTrendChart = ({
       }}
     >
       <ScatterPlot
-        medianValue={observations.peerGroupMedianRate ?? undefined}
-        data={observations.yearlyData.map((o) => ({
+        medianValue={netTariffs.peerGroupMedianRate ?? undefined}
+        data={observations.map((o) => ({
           ...o,
           category: getLocalizedLabel({
             id: `selector.category.${o.category}`,
@@ -51,7 +53,7 @@ export const NetTariffsTrendChart = ({
           style: {
             entity: "operator_id",
             colorDomain: [
-              ...new Set(observations.yearlyData.map((d) => d.operator_name)),
+              ...new Set(observations.map((d) => d.operator_name)),
             ] as string[],
             colorAcc: "operator_name",
             highlightValue: id,

--- a/src/components/network-cost-trend-chart.tsx
+++ b/src/components/network-cost-trend-chart.tsx
@@ -17,12 +17,14 @@ import { ScatterPlot } from "./charts-generic/scatter-plot/scatter-plot-state";
 import { SectionProps } from "./detail-page/card";
 
 type NetworkCostTrendChartProps = {
-  observations: SunshineCostsAndTariffsData["networkCosts"];
+  observations: SunshineCostsAndTariffsData["networkCosts"]["yearlyData"];
+  networkCosts: Omit<SunshineCostsAndTariffsData["networkCosts"], "yearlyData">;
   operatorLabel: string;
 };
 
 export const NetworkCostTrendChart = ({
   observations,
+  networkCosts,
   id,
   operatorLabel,
 }: NetworkCostTrendChartProps & Omit<SectionProps, "entity">) => {
@@ -33,8 +35,8 @@ export const NetworkCostTrendChart = ({
       }}
     >
       <ScatterPlot
-        medianValue={observations.peerGroupMedianRate ?? undefined}
-        data={observations.yearlyData.map((o) => ({
+        medianValue={networkCosts.peerGroupMedianRate ?? undefined}
+        data={observations.map((o) => ({
           ...o,
           network_level: getLocalizedLabel({
             id: `network-level.${o.network_level}.long`,
@@ -50,7 +52,7 @@ export const NetworkCostTrendChart = ({
           style: {
             entity: "operator_id",
             colorDomain: [
-              ...new Set(observations.yearlyData.map((d) => d.operator_name)),
+              ...new Set(observations.map((d) => d.operator_name)),
             ] as string[],
             colorAcc: "operator_name",
             highlightValue: id,

--- a/src/components/network-costs-trend-card.tsx
+++ b/src/components/network-costs-trend-card.tsx
@@ -37,20 +37,23 @@ const NetworkCostsTrendCard: React.FC<
   const latestYear = new Date().getFullYear();
   const { yearlyData, ...restNetworkCosts } = networkCosts;
   const latestYearDataItems = useMemo(() => {
-    return yearlyData.filter((d) => d.year === latestYear);
-  }, [yearlyData, latestYear]);
+    return yearlyData.filter(
+      (d) => d.year === latestYear && d.operator_id.toString() !== operatorId
+    );
+  }, [yearlyData, latestYear, operatorId]);
 
   const latestYearData = useMemo(() => {
     return yearlyData.filter(
       (d) =>
         d.year === latestYear &&
-        containsDelimiter(
+        (containsDelimiter(
           compareWith,
           "sunshine.select-all",
           d.operator_id.toString()
-        )
+        ) ||
+          d.operator_id.toString() === operatorId)
     );
-  }, [yearlyData, compareWith, latestYear]);
+  }, [yearlyData, compareWith, latestYear, operatorId]);
 
   return (
     <Card {...props}>

--- a/src/components/network-costs-trend-card.tsx
+++ b/src/components/network-costs-trend-card.tsx
@@ -117,7 +117,7 @@ const NetworkCostsTrendCard: React.FC<
               ]}
               selectedItems={compareWith}
               setSelectedItems={(items) =>
-                setCompareWith(filterByDelimiter(items, "sunshine.select-all"))
+                setCompareWith((prev) => filterByDelimiter(items, prev, "sunshine.select-all"))
               }
             />
           </Grid>

--- a/src/components/network-costs-trend-card.tsx
+++ b/src/components/network-costs-trend-card.tsx
@@ -12,7 +12,7 @@ import React, { useMemo, useState } from "react";
 import { ButtonGroup } from "src/components/button-group";
 import CardSource from "src/components/card-source";
 import { PeerGroup, SunshineCostsAndTariffsData } from "src/domain/data";
-import { filterByDelimiter } from "src/domain/helpers";
+import { filterBySeparator } from "src/domain/helpers";
 import { getPeerGroupLabels } from "src/domain/translation";
 
 import { CardHeader } from "./detail-page/card";
@@ -147,7 +147,7 @@ const NetworkCostsTrendCard: React.FC<
               selectedItems={compareWith}
               setSelectedItems={(items) =>
                 setCompareWith((prev) =>
-                  filterByDelimiter(items, prev, "sunshine.select-all")
+                  filterBySeparator(items, prev, "sunshine.select-all")
                 )
               }
             />

--- a/src/components/network-costs-trend-card.tsx
+++ b/src/components/network-costs-trend-card.tsx
@@ -16,7 +16,7 @@ import { containsDelimiter, filterByDelimiter } from "src/domain/helpers";
 import { getPeerGroupLabels } from "src/domain/translation";
 
 import { NetworkCostTrendChart } from "./network-cost-trend-chart";
-import { AllOrComboboxMulti } from "./query-combobox";
+import { AllOrMultiCombobox } from "./query-combobox";
 
 const NetworkCostsTrendCard: React.FC<
   {
@@ -98,7 +98,7 @@ const NetworkCostsTrendCard: React.FC<
             />
           </Grid>
           <Grid item xs={12} sm={6}>
-            <AllOrComboboxMulti
+            <AllOrMultiCombobox
               label={t({
                 id: "sunshine.costs-and-tariffs.compare-with",
                 message: "Compare With",

--- a/src/components/network-costs-trend-card.tsx
+++ b/src/components/network-costs-trend-card.tsx
@@ -12,7 +12,7 @@ import React, { useMemo, useState } from "react";
 import { ButtonGroup } from "src/components/button-group";
 import CardSource from "src/components/card-source";
 import { PeerGroup, SunshineCostsAndTariffsData } from "src/domain/data";
-import { containsDelimiter, filterByDelimiter } from "src/domain/helpers";
+import { filterByDelimiter } from "src/domain/helpers";
 import { getPeerGroupLabels } from "src/domain/translation";
 
 import { CardHeader } from "./detail-page/card";
@@ -51,11 +51,8 @@ const NetworkCostsTrendCard: React.FC<
     return yearlyData.filter(
       (d) =>
         d.year === latestYear &&
-        (containsDelimiter(
-          compareWith,
-          "sunshine.select-all",
-          d.operator_id.toString()
-        ) ||
+        (compareWith.includes("sunshine.select-all") ||
+          compareWith.includes(d.operator_id.toString()) ||
           d.operator_id.toString() === operatorId)
     );
   }, [yearlyData, compareWith, latestYear, operatorId]);
@@ -149,7 +146,9 @@ const NetworkCostsTrendCard: React.FC<
               ]}
               selectedItems={compareWith}
               setSelectedItems={(items) =>
-                setCompareWith((prev) => filterByDelimiter(items, prev, "sunshine.select-all"))
+                setCompareWith((prev) =>
+                  filterByDelimiter(items, prev, "sunshine.select-all")
+                )
               }
             />
           </Grid>

--- a/src/components/power-stability-card.tsx
+++ b/src/components/power-stability-card.tsx
@@ -12,7 +12,7 @@ import React, { useMemo, useState } from "react";
 import { ButtonGroup } from "src/components/button-group";
 import CardSource from "src/components/card-source";
 import { PeerGroup, SunshinePowerStabilityData } from "src/domain/data";
-import { filterByDelimiter } from "src/domain/helpers";
+import { filterBySeparator } from "src/domain/helpers";
 import { getLocalizedLabel, getPeerGroupLabels } from "src/domain/translation";
 
 import { PowerStabilityChart } from "./power-stability-chart";
@@ -158,7 +158,7 @@ const PowerStabilityCard: React.FC<
               selectedItems={compareWith}
               setSelectedItems={(items) =>
                 setCompareWith((prev) =>
-                  filterByDelimiter(items, prev, "sunshine.select-all")
+                  filterBySeparator(items, prev, "sunshine.select-all")
                 )
               }
             />

--- a/src/components/power-stability-card.tsx
+++ b/src/components/power-stability-card.tsx
@@ -28,10 +28,8 @@ const PowerStabilityCard: React.FC<
     attribute: keyof Pick<SunshinePowerStabilityData, "saidi" | "saifi">;
   } & CardProps
 > = (props) => {
-  const [compareWith, setCompareWith] = useState(
-    "sunshine.power-stability.all-peer-group"
-  );
   const [viewBy, setViewBy] = useState("latest");
+  const [overallOrRatio, setOverallOrRatio] = useState("overall");
 
   const {
     peerGroup,
@@ -115,8 +113,8 @@ const PowerStabilityCard: React.FC<
                     ),
                   },
                 ]}
-                value={viewBy}
-                setValue={setViewBy}
+                value={overallOrRatio}
+                setValue={setOverallOrRatio}
               />
             </Box>
           </Grid>

--- a/src/components/power-stability-card.tsx
+++ b/src/components/power-stability-card.tsx
@@ -97,7 +97,7 @@ const PowerStabilityCard: React.FC<
                 })}
                 options={[
                   {
-                    value: "latest",
+                    value: "overall",
                     label: (
                       <Trans id="sunshine.power-stability.overall-option">
                         Overall
@@ -105,7 +105,7 @@ const PowerStabilityCard: React.FC<
                     ),
                   },
                   {
-                    value: "progress",
+                    value: "ratio",
                     label: (
                       <Trans id="sunshine.power-stability.ratio-option">
                         Ratio

--- a/src/components/power-stability-card.tsx
+++ b/src/components/power-stability-card.tsx
@@ -12,7 +12,7 @@ import React, { useMemo, useState } from "react";
 import { ButtonGroup } from "src/components/button-group";
 import CardSource from "src/components/card-source";
 import { PeerGroup, SunshinePowerStabilityData } from "src/domain/data";
-import { containsDelimiter, filterByDelimiter } from "src/domain/helpers";
+import { filterByDelimiter } from "src/domain/helpers";
 import { getLocalizedLabel, getPeerGroupLabels } from "src/domain/translation";
 
 import { PowerStabilityChart } from "./power-stability-chart";
@@ -57,11 +57,8 @@ const PowerStabilityCard: React.FC<
     return observations.filter(
       (d) =>
         d.year === latestYear &&
-        (containsDelimiter(
-          compareWith,
-          "sunshine.select-all",
-          d.operator.toString()
-        ) ||
+        (compareWith.includes("sunshine.select-all") ||
+          compareWith.includes(d.operator.toString()) ||
           d.operator.toString() === operatorId)
     );
   }, [observations, compareWith, latestYear, operatorId]);

--- a/src/components/power-stability-card.tsx
+++ b/src/components/power-stability-card.tsx
@@ -7,14 +7,16 @@ import {
   Grid,
   Typography,
 } from "@mui/material";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 
 import { ButtonGroup } from "src/components/button-group";
 import CardSource from "src/components/card-source";
 import { PeerGroup, SunshinePowerStabilityData } from "src/domain/data";
+import { containsDelimiter, filterByDelimiter } from "src/domain/helpers";
 import { getLocalizedLabel, getPeerGroupLabels } from "src/domain/translation";
 
 import { PowerStabilityChart } from "./power-stability-chart";
+import { AllOrMultiCombobox } from "./query-combobox";
 
 const PowerStabilityCard: React.FC<
   {
@@ -28,6 +30,7 @@ const PowerStabilityCard: React.FC<
     attribute: keyof Pick<SunshinePowerStabilityData, "saidi" | "saifi">;
   } & CardProps
 > = (props) => {
+  const [compareWith, setCompareWith] = useState(["sunshine.select-all"]);
   const [viewBy, setViewBy] = useState("latest");
   const [overallOrRatio, setOverallOrRatio] = useState("overall");
 
@@ -40,6 +43,29 @@ const PowerStabilityCard: React.FC<
     attribute,
   } = props;
   const { peerGroupLabel } = getPeerGroupLabels(peerGroup);
+
+  //FIXME: doesn't seem to have any data in 2025
+  const latestYear = new Date().getFullYear() - 1;
+
+  const latestYearDataItems = useMemo(() => {
+    return observations.filter(
+      (d) => d.year === latestYear && d.operator.toString() !== operatorId
+    );
+  }, [observations, latestYear, operatorId]);
+
+  const latestYearData = useMemo(() => {
+    return observations.filter(
+      (d) =>
+        d.year === latestYear &&
+        (containsDelimiter(
+          compareWith,
+          "sunshine.select-all",
+          d.operator.toString()
+        ) ||
+          d.operator.toString() === operatorId)
+    );
+  }, [observations, compareWith, latestYear, operatorId]);
+
   return (
     <Card {...props}>
       <CardContent>
@@ -54,10 +80,9 @@ const PowerStabilityCard: React.FC<
           </Trans>
         </Typography>
 
-        {/* Dropdown Controls */}
         <Grid container spacing={3} sx={{ mb: 3 }}>
-          <Grid item xs={12} sm={6} sx={{ display: "flex" }}>
-            <Box sx={{ flex: 1 }}>
+          <Grid item xs={12} sm={4} sx={{ display: "flex" }}>
+            <Box sx={{ flex: 1, mt: 2.5 }}>
               <ButtonGroup
                 id="view-by-button-group-1"
                 label={t({
@@ -87,8 +112,8 @@ const PowerStabilityCard: React.FC<
               />
             </Box>
           </Grid>
-          <Grid item xs={12} sm={6} sx={{ display: "flex" }}>
-            <Box sx={{ flex: 1 }}>
+          <Grid item xs={12} sm={4} sx={{ display: "flex" }}>
+            <Box sx={{ flex: 1, mt: 2.5 }}>
               <ButtonGroup
                 id="view-by-button-group-2"
                 label={t({
@@ -118,12 +143,35 @@ const PowerStabilityCard: React.FC<
               />
             </Box>
           </Grid>
+          <Grid item xs={12} sm={4} sx={{ display: "flex" }}>
+            <AllOrMultiCombobox
+              label={t({
+                id: "sunshine.costs-and-tariffs.compare-with",
+                message: "Compare With",
+              })}
+              items={[
+                { id: "sunshine.select-all" },
+                ...latestYearDataItems.map((item) => {
+                  return {
+                    id: String(item.operator),
+                    name: item.operator_name,
+                  };
+                }),
+              ]}
+              selectedItems={compareWith}
+              setSelectedItems={(items) =>
+                setCompareWith((prev) =>
+                  filterByDelimiter(items, prev, "sunshine.select-all")
+                )
+              }
+            />
+          </Grid>
         </Grid>
 
         {/* Stacked Horizontal Bar Chart */}
         <Box sx={{ height: 400, width: "100%" }}>
           <PowerStabilityChart
-            observations={observations}
+            observations={latestYearData}
             id={operatorId}
             operatorLabel={operatorLabel}
           />

--- a/src/components/power-stability-card.tsx
+++ b/src/components/power-stability-card.tsx
@@ -169,7 +169,14 @@ const PowerStabilityCard: React.FC<
         </Grid>
 
         {/* Stacked Horizontal Bar Chart */}
-        <Box sx={{ height: 400, width: "100%" }}>
+        <Box
+          sx={{
+            height: 400,
+            width: "100%",
+            overflowY: "auto",
+            mt: 8,
+          }}
+        >
           <PowerStabilityChart
             observations={latestYearData}
             id={operatorId}

--- a/src/components/power-stability-chart.tsx
+++ b/src/components/power-stability-chart.tsx
@@ -82,6 +82,7 @@ export const PowerStabilityChart = ({
             __typename: "NominalDimension",
           },
         ]}
+        //FIXME: we need a better solution for this since having less bars increases the spacing between them
         aspectRatio={0.8}
       >
         <ChartContainer>

--- a/src/components/query-combobox.tsx
+++ b/src/components/query-combobox.tsx
@@ -1,7 +1,7 @@
 import { rollup } from "d3";
 import { useMemo, useState } from "react";
 
-import { ComboboxMulti, ComboboxMultiProps } from "src/components/combobox";
+import { ComboboxMultiProps, MultiCombobox } from "src/components/combobox";
 import { getLocalizedLabel } from "src/domain/translation";
 import {
   useCantonsQuery,
@@ -41,7 +41,7 @@ export const MunicipalitiesCombobox = (
   }, [items]);
 
   return (
-    <ComboboxMulti
+    <MultiCombobox
       {...comboboxMultiProps}
       id="municipalities"
       items={items.map(({ id }) => id)}
@@ -85,7 +85,7 @@ export const OperatorsCombobox = (
   }, [items]);
 
   return (
-    <ComboboxMulti
+    <MultiCombobox
       {...comboboxMultiProps}
       id="operators"
       max={8}
@@ -129,7 +129,7 @@ export const CantonsCombobox = (
   }, [items]);
 
   return (
-    <ComboboxMulti
+    <MultiCombobox
       {...comboboxMultiProps}
       id="operators"
       items={items.map(({ id }) => id)}
@@ -142,7 +142,7 @@ export const CantonsCombobox = (
   );
 };
 
-export const AllOrComboboxMulti = (
+export const AllOrMultiCombobox = (
   comboboxMultiProps: Pick<
     ComboboxMultiProps,
     "label" | "selectedItems" | "setSelectedItems"
@@ -158,7 +158,7 @@ export const AllOrComboboxMulti = (
   }, [items]);
 
   return (
-    <ComboboxMulti
+    <MultiCombobox
       {...comboboxMultiProps}
       items={items.map(({ id }) => id)}
       id="compare-with-selection"

--- a/src/components/query-combobox.tsx
+++ b/src/components/query-combobox.tsx
@@ -2,6 +2,7 @@ import { rollup } from "d3";
 import { useMemo, useState } from "react";
 
 import { ComboboxMulti, ComboboxMultiProps } from "src/components/combobox";
+import { getLocalizedLabel } from "src/domain/translation";
 import {
   useCantonsQuery,
   useMunicipalitiesQuery,
@@ -137,6 +138,39 @@ export const CantonsCombobox = (
       max={8}
       onInputValueChange={setInputValue}
       isLoading={gqlQuery.fetching && inputValue.length > 0}
+    />
+  );
+};
+
+export const AllOrComboboxMulti = (
+  comboboxMultiProps: Pick<
+    ComboboxMultiProps,
+    "label" | "selectedItems" | "setSelectedItems"
+  > & { items: { id: string; name?: string }[] }
+) => {
+  const { items } = comboboxMultiProps;
+  const itemById = useMemo(() => {
+    return rollup(
+      items,
+      (values) => values[0],
+      (d) => d.id
+    );
+  }, [items]);
+
+  return (
+    <ComboboxMulti
+      {...comboboxMultiProps}
+      items={items.map(({ id }) => id)}
+      id="compare-with-selection"
+      getItemLabel={(id) => {
+        return (
+          itemById.get(id)?.name ??
+          getLocalizedLabel({
+            id,
+          }) ??
+          `[${id}]`
+        );
+      }}
     />
   );
 };

--- a/src/components/scatter-plot.stories.tsx
+++ b/src/components/scatter-plot.stories.tsx
@@ -6,6 +6,9 @@ import { NetworkCostTrendChart } from "./network-cost-trend-chart";
 import { DesignGrid, DesignStory } from "./storybook/base-style";
 
 export const ScatterpotChart = () => {
+  const networkCosts =
+    data.networkCosts as SunshineCostsAndTariffsData["networkCosts"];
+  const { yearlyData, ...restNetworkCosts } = networkCosts;
   return (
     <DesignStory
       title="Scatterplot Chart"
@@ -15,9 +18,10 @@ export const ScatterpotChart = () => {
         <NetworkCostTrendChart
           id="11"
           operatorLabel="Elektrizitätswerk des Kantons Schaffhausen AG"
-          observations={
-            data.networkCosts as SunshineCostsAndTariffsData["networkCosts"]
-          }
+          observations={yearlyData.filter(
+            (d) => d.year === new Date().getFullYear()
+          )}
+          networkCosts={restNetworkCosts}
         />
       </DesignGrid>
     </DesignStory>

--- a/src/domain/helper.spec.ts
+++ b/src/domain/helper.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { filterBySeparator } from "./helpers";
+
+describe("filterBySeparator", () => {
+  it("should return [separator] if arr is empty", () => {
+    expect(filterBySeparator([], [], "|")).toEqual(["|"]);
+  });
+
+  it("should return [separator] if prev does not have separator and arr has separator", () => {
+    expect(filterBySeparator(["|"], [], "|")).toEqual(["|"]);
+  });
+
+  it("should return arr unchanged if prev has separator", () => {
+    expect(filterBySeparator(["a", "b"], ["|"], "|")).toEqual(["a", "b"]);
+  });
+
+  it("should return arr unchanged if arr does not contain separator", () => {
+    expect(filterBySeparator(["a", "b"], [], "|")).toEqual(["a", "b"]);
+  });
+
+  it("should return arr with separator if arr is empty and prev has separator", () => {
+    expect(filterBySeparator([], ["|"], "|")).toEqual(["|"]);
+  });
+});

--- a/src/domain/helpers.tsx
+++ b/src/domain/helpers.tsx
@@ -329,15 +329,18 @@ export const getTextWidth = (
 
   return ctx.measureText(text).width;
 };
-
 export const filterByDelimiter = (
   arr: string[],
+  prev: string[],
   delimiter: string
 ): string[] => {
+  const prevHasDelimiter = prev.includes(delimiter);
+  const arrHasDelimiter = arr.includes(delimiter);
+
   if (arr.length === 0) return [delimiter];
-  return arr.every((item) => item === delimiter)
-    ? arr
-    : arr.filter((item) => item !== delimiter);
+  if (!prevHasDelimiter && arrHasDelimiter) return [delimiter];
+
+  return arr.filter((item) => item !== delimiter);
 };
 
 export const containsDelimiter = (

--- a/src/domain/helpers.tsx
+++ b/src/domain/helpers.tsx
@@ -329,16 +329,17 @@ export const getTextWidth = (
 
   return ctx.measureText(text).width;
 };
-export const filterByDelimiter = (
+
+export const filterBySeparator = (
   arr: string[],
   prev: string[],
-  delimiter: string
+  separator: string
 ): string[] => {
-  const prevHasDelimiter = prev.includes(delimiter);
-  const arrHasDelimiter = arr.includes(delimiter);
+  const prevHasSeparator = prev.includes(separator);
+  const arrHasSeparator = arr.includes(separator);
 
-  if (arr.length === 0) return [delimiter];
-  if (!prevHasDelimiter && arrHasDelimiter) return [delimiter];
+  if (arr.length === 0) return [separator];
+  if (!prevHasSeparator && arrHasSeparator) return [separator];
 
-  return arr.filter((item) => item !== delimiter);
+  return arr.filter((item) => item !== separator);
 };

--- a/src/domain/helpers.tsx
+++ b/src/domain/helpers.tsx
@@ -342,11 +342,3 @@ export const filterByDelimiter = (
 
   return arr.filter((item) => item !== delimiter);
 };
-
-export const containsDelimiter = (
-  arr: string[],
-  delimiter: string,
-  item: string
-): boolean => {
-  return arr.includes(delimiter) || arr.includes(item);
-};

--- a/src/domain/helpers.tsx
+++ b/src/domain/helpers.tsx
@@ -329,3 +329,21 @@ export const getTextWidth = (
 
   return ctx.measureText(text).width;
 };
+
+export const filterByDelimiter = (
+  arr: string[],
+  delimiter: string
+): string[] => {
+  if (arr.length === 0) return [delimiter];
+  return arr.every((item) => item === delimiter)
+    ? arr
+    : arr.filter((item) => item !== delimiter);
+};
+
+export const containsDelimiter = (
+  arr: string[],
+  delimiter: string,
+  item: string
+): boolean => {
+  return arr.includes(delimiter) || arr.includes(item);
+};

--- a/src/domain/translation.tsx
+++ b/src/domain/translation.tsx
@@ -293,10 +293,10 @@ export const getLocalizedLabel = ({ id }: { id: string }): string => {
     case "network-level.NL7.long":
       return t({ id: "network-level.NL7.long", message: `Low voltage NL7` });
 
-    case "sunshine.costs-and-tariffs.all-peer-group":
+    case "sunshine.select-all":
       return t({
-        id: "sunshine.costs-and-tariffs.all-peer-group",
-        message: `All peer group network operators`,
+        id: "sunshine.select-all",
+        message: `Select All`,
       });
     case "sunshine.costs-and-tariffs.selected-operators":
       return t({


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR adds new Select all or use MultiCombobox and integrates it with the scatterplot charts on costs and tariffs

## Related Issues
<!-- Link any related issues using #issue_number format -->

## Testing Performed
<!-- Describe the testing you've done -->

- [x] Tested with the following Browsers: Chrome, Safari <!-- [Chrome, Firefox, Safari, etc] -->
- [x] Tested on the following devices: MacBook Pro, Large Monitor <!-- [MacBook Pro, iPhone 13, iPad, etc] -->
- [x] Verified functionality: Manually <!-- [Tested this functionality manually, automated, etc] -->
- [x] Storybook updated
- [ ] Automated tests added


### Testing/Reproduction Steps
1. Navigate to this [link](https://elcom-electricity-price-website-git-feat-connect-th-638c7c-ixt1.vercel.app/sunshine/operator/486/costs-and-tariffs)
2. Click on Compared with `MultiCombobox` 
3. ✅ See how when you select other operators, `Select all` is no longer used
4. ✅ See how when removing all operators, automatically `Select all` is used
5. ⚠️ Select a lot of operators see how large `MultiCombobox` gets 


## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [x] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [x] I have marked this PR with the appropriate label
- [x] I have added an entry in the changelog

## Notes for Reviewers
<!-- Add any notes that might help reviewers understand your changes. -->

<!--
### Configuration Required
- Environment variables:
- Feature flags:
- Database changes:

### Known Limitations
-

### Performance Considerations
-

### Alternative Approaches Considered
-

### Future Improvements
-
-->
cc. @ptbrowne future PR will include moving the layout to the new design, additionally naming conventions from the data `period` or `year` `operator_id` or `operator` might be a good refactor but not urgent

Discussing whether this is optimal behaviour can be postponed. Here are some thoughts: 
-> ⚠️ Multi Combobox gets large 