### PR TITLE
Fix details drawer

### DIFF
--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -102,6 +102,17 @@ export type ListItemType = {
     | null;
 };
 
+export const getEntityFromListState = (listState: ListState): Entity => {
+  switch (listState) {
+    case "MUNICIPALITIES":
+      return "municipality";
+    case "OPERATORS":
+      return "operator";
+    case "CANTONS":
+      return "canton";
+  }
+};
+
 const ListItems = ({
   items,
   colorScale,

--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -26,7 +26,7 @@ import { useFlag } from "src/utils/flags";
 
 import { AnchorNav } from "./anchor-nav";
 import { InlineDrawer } from "./drawer";
-import { ListState, useMap } from "./map-context";
+import { useMap } from "./map-context";
 import { MapDetailsContent } from "./map-details-content";
 
 type ListItemProps = {
@@ -35,7 +35,7 @@ type ListItemProps = {
   value: number;
   colorScale: (d: number) => string;
   formatNumber: (d: number) => string;
-  listState: ListState;
+  entity: Entity;
   handleClick?: MouseEventHandler<HTMLAnchorElement>;
 };
 
@@ -45,16 +45,10 @@ const ListItem = ({
   value,
   colorScale,
   formatNumber,
-  listState,
+  entity,
   handleClick,
 }: ListItemProps) => {
   const { setValue: setHighlightContext } = useContext(HighlightContext);
-  const entity =
-    listState === "MUNICIPALITIES"
-      ? "municipality"
-      : listState === "OPERATORS"
-      ? "operator"
-      : ("canton" as Entity);
 
   return (
     <AnchorNav
@@ -102,25 +96,14 @@ export type ListItemType = {
     | null;
 };
 
-export const getEntityFromListState = (listState: ListState): Entity => {
-  switch (listState) {
-    case "MUNICIPALITIES":
-      return "municipality";
-    case "OPERATORS":
-      return "operator";
-    case "CANTONS":
-      return "canton";
-  }
-};
-
 const ListItems = ({
   items,
   colorScale,
-  listState,
+  entity: entity,
 }: {
   items: [string, ListItemType][];
   colorScale: ScaleThreshold<number, string>;
-  listState: ListState;
+  entity: Entity;
 }) => {
   const [truncated, setTruncated] = useState<number>(TRUNCATION_INCREMENT);
   const formatNumber = useFormatCurrency();
@@ -128,23 +111,12 @@ const ListItems = ({
   const isSunshine = useFlag("sunshine");
   const router = useRouter();
 
-  const getEntity = (): Entity => {
-    switch (listState) {
-      case "MUNICIPALITIES":
-        return "municipality";
-      case "OPERATORS":
-        return "operator";
-      case "CANTONS":
-        return "canton";
-    }
-  };
-
   const handleListItemSelect = useEvent(
     (_: MouseEvent<HTMLAnchorElement, globalThis.MouseEvent>, id: string) => {
       if (isSunshine) {
         setActiveId(id);
       } else {
-        router.push(`/${getEntity()}/${id}`);
+        router.push(`/${entity}/${id}`);
       }
     }
   );
@@ -165,8 +137,7 @@ const ListItems = ({
         <InlineDrawer open={!!selectedItem} onClose={() => setActiveId(null)}>
           <MapDetailsContent
             colorScale={colorScale}
-            entity={getEntity()}
-            listState={listState}
+            entity={entity}
             selectedItem={selectedItem}
             onBack={() => setActiveId(null)}
           />
@@ -181,7 +152,7 @@ const ListItems = ({
             label={d.label || d.id}
             colorScale={colorScale}
             formatNumber={formatNumber}
-            listState={listState}
+            entity={entity}
             handleClick={(e) => handleListItemSelect(e, d.id)}
           />
         );
@@ -275,12 +246,12 @@ export const List = ({
   grouped,
   colorScale,
   fetching,
-  listState,
+  entity,
 }: {
   grouped: Groups;
   colorScale: ScaleThreshold<number, string>;
   fetching: boolean;
-  listState: ListState;
+  entity: Entity;
 }) => {
   const [sortState, setSortState] = useState<SortState>("ASC");
   const [searchQuery, setSearchQuery] = useState<string>("");
@@ -383,11 +354,7 @@ export const List = ({
       {fetching ? (
         <PlaceholderListItems />
       ) : (
-        <ListItems
-          items={listItems}
-          colorScale={colorScale}
-          listState={listState}
-        />
+        <ListItems items={listItems} colorScale={colorScale} entity={entity} />
       )}
     </Box>
   );

--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -6,7 +6,6 @@ import {
   MouseEvent,
   MouseEventHandler,
   useContext,
-  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -114,8 +113,6 @@ const ListItems = ({
 }) => {
   const [truncated, setTruncated] = useState<number>(TRUNCATION_INCREMENT);
   const formatNumber = useFormatCurrency();
-  const [open, setOpen] = useState<boolean>(false);
-  const [selectedItem, setSelectedItem] = useState<ListItemType | null>(null);
   const { activeId, setActiveId } = useMap();
   const isSunshine = useFlag("sunshine");
   const router = useRouter();
@@ -140,13 +137,13 @@ const ListItems = ({
       }
     }
   );
-  useEffect(() => {
+
+  const selectedItem = useMemo(() => {
     if (activeId) {
       const selected = items.find(([itemId]) => itemId === activeId);
-      setSelectedItem(selected?.[1] ?? null);
-      setOpen(true);
+      return selected?.[1] ?? null;
     }
-  }, [activeId, items, listState]);
+  }, [activeId, items]);
 
   const listItems =
     items.length > truncated ? items.slice(0, truncated) : items;
@@ -154,14 +151,13 @@ const ListItems = ({
   return (
     <Box>
       {selectedItem && (
-        <InlineDrawer open={open} onClose={() => setOpen(false)}>
+        <InlineDrawer open={!!selectedItem} onClose={() => setActiveId(null)}>
           <MapDetailsContent
             colorScale={colorScale}
             entity={getEntity()}
             listState={listState}
-            setOpen={setOpen}
             selectedItem={selectedItem}
-            setActiveId={setActiveId}
+            onBack={() => setActiveId(null)}
           />
         </InlineDrawer>
       )}

--- a/src/components/map-context.tsx
+++ b/src/components/map-context.tsx
@@ -7,13 +7,13 @@ import {
   useState,
 } from "react";
 
-export type ListState = "MUNICIPALITIES" | "OPERATORS" | "CANTONS";
+import { Entity } from "src/domain/data";
 
 type MapContextType = {
   activeId: string | null;
   setActiveId: Dispatch<SetStateAction<string | null>>;
-  listState: ListState;
-  setListState: Dispatch<SetStateAction<ListState>>;
+  entity: Entity;
+  setEntity: Dispatch<SetStateAction<Entity>>;
 };
 
 const MapContext = createContext<MapContextType | undefined>(undefined);
@@ -29,11 +29,11 @@ export const MapProvider = ({
   setActiveId,
   children,
 }: MapProviderProps) => {
-  const [listState, setListState] = useState<ListState>("MUNICIPALITIES");
+  const [entity, setEntity] = useState<Entity>("municipality");
 
   return (
     <MapContext.Provider
-      value={{ activeId, setActiveId, listState, setListState }}
+      value={{ activeId, setActiveId, entity: entity, setEntity: setEntity }}
     >
       {children}
     </MapContext.Provider>

--- a/src/components/map-details-content.tsx
+++ b/src/components/map-details-content.tsx
@@ -16,7 +16,6 @@ import {
 } from "src/lib/use-query-state";
 
 import { ListItemType } from "./list";
-import { ListState } from "./map-context";
 
 type MapDetailsContentProps = {
   onBack: () => void;
@@ -49,7 +48,7 @@ const MapDetailsContentWrapper = (props: MapDetailsContentProps) => {
   );
 };
 
-type MapDetailProps = ListItemType & { entity: ListState };
+type MapDetailProps = ListItemType & { entity: Entity };
 
 const MapDetailsEntityHeader = (props: MapDetailProps) => {
   const { entity, label, canton, cantonLabel } = props;
@@ -65,7 +64,7 @@ const MapDetailsEntityHeader = (props: MapDetailProps) => {
           {label}
         </Typography>
       </Stack>
-      {entity !== "CANTONS" && canton && cantonLabel && (
+      {entity !== "canton" && canton && cantonLabel && (
         <Typography variant="body3" color={"text.500"}>
           <Trans id="search.result.canton">Canton</Trans>:{" "}
           <Link
@@ -82,19 +81,10 @@ const MapDetailsEntityHeader = (props: MapDetailProps) => {
   );
 };
 
-const entityTableRows: Record<
-  ListState,
-  (keyof QueryStateSingleElectricity)[]
-> = {
-  OPERATORS: ["period", "priceComponent", "category", "product"],
-  MUNICIPALITIES: [
-    "period",
-    "priceComponent",
-    "category",
-    "product",
-    "operator",
-  ],
-  CANTONS: ["period", "priceComponent", "category", "product"],
+const entityTableRows: Record<Entity, (keyof QueryStateSingleElectricity)[]> = {
+  operator: ["period", "priceComponent", "category", "product"],
+  municipality: ["period", "priceComponent", "category", "product", "operator"],
+  canton: ["period", "priceComponent", "category", "product"],
 };
 
 const MapDetailsEntityTable = (
@@ -200,15 +190,14 @@ const KeyValueTableRow = <T extends Record<string, string | undefined>>(props: {
 export const MapDetailsContent: React.FC<{
   colorScale: ScaleThreshold<number, string>;
   entity: Entity;
-  listState: ListState;
   selectedItem: ListItemType;
   onBack: () => void;
-}> = ({ colorScale, entity, listState, selectedItem, onBack }) => (
+}> = ({ colorScale, entity, selectedItem, onBack }) => (
   <MapDetailsContentWrapper onBack={onBack}>
-    <MapDetailsEntityHeader entity={listState} {...selectedItem} />
+    <MapDetailsEntityHeader entity={entity} {...selectedItem} />
     <MapDetailsEntityTable
       colorScale={colorScale}
-      entity={listState}
+      entity={entity}
       {...selectedItem}
     />
     <Divider />

--- a/src/components/map-details-content.tsx
+++ b/src/components/map-details-content.tsx
@@ -202,22 +202,9 @@ export const MapDetailsContent: React.FC<{
   entity: Entity;
   listState: ListState;
   selectedItem: ListItemType;
-  setActiveId: React.Dispatch<React.SetStateAction<string | null>>;
-  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
-}> = ({
-  colorScale,
-  entity,
-  listState,
-  selectedItem,
-  setActiveId,
-  setOpen,
-}) => (
-  <MapDetailsContentWrapper
-    onBack={() => {
-      setOpen(false);
-      setActiveId(null);
-    }}
-  >
+  onBack: () => void;
+}> = ({ colorScale, entity, listState, selectedItem, onBack }) => (
+  <MapDetailsContentWrapper onBack={onBack}>
     <MapDetailsEntityHeader entity={listState} {...selectedItem} />
     <MapDetailsEntityTable
       colorScale={colorScale}

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -20,7 +20,6 @@ import { DownloadImage } from "src/components/detail-page/download-image";
 import { InlineDrawer } from "src/components/drawer";
 import { InfoBanner } from "src/components/info-banner";
 import {
-  getEntityFromListState,
   groupsFromCantonElectricityObservations,
   groupsFromElectricityMunicipalities,
   groupsFromElectricityOperators,
@@ -29,7 +28,7 @@ import {
   ListItemType,
 } from "src/components/list";
 import { ChoroplethMap, ChoroplethMapProps } from "src/components/map";
-import { ListState, MapProvider, useMap } from "src/components/map-context";
+import { MapProvider, useMap } from "src/components/map-context";
 import { MapDetailsContent } from "src/components/map-details-content";
 import OperatorsMap from "src/components/operators-map";
 import ShareButton from "src/components/share-button";
@@ -263,13 +262,13 @@ const IndexPageContent = ({
     />
   );
 
-  const { listState, setListState } = useMap();
+  const { entity, setEntity } = useMap();
 
   const listGroups = useMemo(() => {
     if (isElectricityTab) {
-      return listState === "CANTONS"
+      return entity === "canton"
         ? groupsFromCantonElectricityObservations(cantonMedianObservations)
-        : listState === "OPERATORS"
+        : entity === "operator"
         ? groupsFromElectricityOperators(observations)
         : groupsFromElectricityMunicipalities(observations);
     } else {
@@ -280,7 +279,7 @@ const IndexPageContent = ({
     }
   }, [
     isElectricityTab,
-    listState,
+    entity,
     cantonMedianObservations,
     observations,
     sunshineObservations,
@@ -289,7 +288,7 @@ const IndexPageContent = ({
 
   const list = (
     <List
-      listState={isElectricityTab ? listState : "OPERATORS"}
+      entity={isElectricityTab ? entity : "operator"}
       grouped={listGroups}
       colorScale={colorScale}
       fetching={
@@ -301,34 +300,34 @@ const IndexPageContent = ({
   );
 
   const listButtonGroup = isElectricityTab ? (
-    <ButtonGroup<ListState>
+    <ButtonGroup<Entity>
       id="list-state-tabs"
       options={[
         {
-          value: "MUNICIPALITIES",
+          value: "municipality",
           label: t({
             id: "list.municipalities",
             message: "Municipalities",
           }),
         },
         {
-          value: "CANTONS",
+          value: "canton",
           label: t({ id: "list.cantons", message: "Cantons" }),
         },
         {
-          value: "OPERATORS",
+          value: "operator",
           label: t({
             id: "list.operators",
             message: "Network operator",
           }),
         },
       ]}
-      value={listState}
+      value={entity}
       label={t({
         id: "list.viewby.label",
         message: "View according to",
       })}
-      setValue={setListState}
+      setValue={setEntity}
     />
   ) : null;
 
@@ -343,7 +342,7 @@ const IndexPageContent = ({
     <DetailsDrawer
       selectedItem={selectedItem}
       colorScale={isElectricityTab ? colorScale : sunshineColorScale}
-      entity={getEntityFromListState(listState)}
+      entity={entity}
     />
   );
 

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -332,9 +332,16 @@ const IndexPageContent = ({
     />
   ) : null;
 
+  const selectedItem = useMemo(() => {
+    if (activeId) {
+      const selected = listGroups.find(([itemId]) => itemId === activeId);
+      return selected?.[1] ?? null;
+    }
+  }, [activeId, listGroups]);
+
   const detailsDrawer = (
     <DetailsDrawer
-      items={listGroups}
+      selectedItem={selectedItem}
       colorScale={isElectricityTab ? colorScale : sunshineColorScale}
       entity={getEntityFromListState(listState)}
     />
@@ -398,19 +405,22 @@ const IndexPageContent = ({
               }}
             >
               {detailsDrawer}
-              <CombinedSelectors />
-
-              <Box
-                sx={{
-                  px: 6,
-                  flexDirection: "column",
-                  gap: 4,
-                }}
-                display="flex"
-              >
-                {listButtonGroup}
-                {list}
-              </Box>
+              {selectedItem ? null : (
+                <>
+                  <CombinedSelectors />
+                  <Box
+                    sx={{
+                      px: 6,
+                      flexDirection: "column",
+                      gap: 4,
+                    }}
+                    display="flex"
+                  >
+                    {listButtonGroup}
+                    {list}
+                  </Box>
+                </>
+              )}
             </Box>
 
             <Box
@@ -466,8 +476,12 @@ const IndexPageContent = ({
             }}
           >
             {detailsDrawer}
-            <CombinedSelectors />
-            {list}
+            {selectedItem ? null : (
+              <>
+                <CombinedSelectors />
+                {list}
+              </>
+            )}
           </Box>
         </Box>
       </ApplicationLayout>
@@ -476,22 +490,15 @@ const IndexPageContent = ({
 };
 
 const DetailsDrawer = ({
-  items,
+  selectedItem,
   colorScale,
   entity,
 }: {
-  items: [string, ListItemType][];
+  selectedItem: ListItemType | undefined | null;
   colorScale: ScaleThreshold<number, string, never>;
   entity: Entity;
 }) => {
-  const { activeId, setActiveId } = useMap();
-  const selectedItem = useMemo(() => {
-    if (activeId) {
-      const selected = items.find(([itemId]) => itemId === activeId);
-      return selected?.[1] ?? null;
-    }
-  }, [activeId, items]);
-
+  const { setActiveId } = useMap();
   return (
     selectedItem && (
       <InlineDrawer open={!!selectedItem} onClose={() => setActiveId(null)}>

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -262,7 +262,8 @@ const IndexPageContent = ({
     />
   );
 
-  const { entity, setEntity } = useMap();
+  const { entity: mapEntity, setEntity } = useMap();
+  const entity = isElectricityTab ? mapEntity : "operator";
 
   const listGroups = useMemo(() => {
     if (isElectricityTab) {


### PR DESCRIPTION
## Description

This PR fixes the position of the drawer.
It lifts the management of the drawer out of the details drawer out of the 
list itself to put it in the page. It hides the selectors if the drawer is
opened.

Right now, it is a bit crude to hide the selectors. In the future, I would
like to use the ModalProps.container to directly render the Drawer inside
the scrollable panel. I think it will be better and will allow for an
animation.

I also remove the ListState concept which was a duplicate of the entity
concept.

There will be future improvements but with this PR, the drawer is not
completely broken ;)
