### PR TITLE
Latest year indicator for mini charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ You can also check the
   - Use same map tooltip as energy for sunshine map
   - Hover on operator list for sunshine indicators highlights operators on map
   - Sunshine map has better styling and is closer to the current prices map
+  - Added Latest Year indicator to map details panel mini line chart
 
 - Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,11 @@ You can also check the
   - Hover on operator list for sunshine indicators highlights operators on map
   - Sunshine map has better styling and is closer to the current prices map
 
-# 2.1.0
+- Maintenance
+
+  - Added Screenshot testing to all sunshine details pages and sub categories
+
+# 2.1.0 - 2025-06-19
 
 - Features
 

--- a/e2e/sunshine.spec.ts
+++ b/e2e/sunshine.spec.ts
@@ -2,20 +2,65 @@ import { expect } from "@playwright/test";
 
 import { test } from "./common";
 
+/**
+ * FIXME - This test suite is currently flaky and needs to be fixed.
+ *
+ * waitForLoadState often causes issues it doesn't work as expected causing screenshots while the page is still loading
+ */
 test.describe("Sunshine details page", () => {
-  test("it should be possible to load a sunshine details page", async ({
-    withFlag,
-    page,
-    snapshot,
-  }) => {
-    const resp = await page.goto(
-      withFlag("/sunshine/operator/426/costs-and-tariffs", { sunshine: true })
-    );
-    await expect(resp?.status()).toEqual(200);
-    await snapshot({
-      note: "Sunshine details page",
-      locator: await page.getByTestId("details-page-content"),
-      fullPage: true,
+  const tabs = [
+    {
+      url: "/sunshine/operator/426/costs-and-tariffs",
+      buttonLabel: "net-tariffs-tab",
+      screenshotLabel: "Net Tariffs",
+    },
+    {
+      url: "/sunshine/operator/426/costs-and-tariffs",
+      buttonLabel: "energy-tariffs-tab",
+      screenshotLabel: "Energy Tariffs",
+    },
+    {
+      url: "/sunshine/operator/426/power-stability",
+      buttonLabel: "saifi-tab",
+      screenshotLabel: "SAIFI",
+    },
+    {
+      url: "/sunshine/operator/426/operational-standards",
+      buttonLabel: "service-quality-tab",
+      screenshotLabel: "Service Quality",
+    },
+    {
+      url: "/sunshine/operator/426/operational-standards",
+      buttonLabel: "compliance-tab",
+      screenshotLabel: "Compliance",
+    },
+  ];
+
+  for (const { url, buttonLabel, screenshotLabel } of tabs) {
+    test(`it should load the sunshine details page for ${screenshotLabel}`, async ({
+      withFlag,
+      page,
+      snapshot,
+    }) => {
+      const resp = await page.goto(withFlag(url, { sunshine: true }));
+      await expect(resp?.status()).toEqual(200);
+      await page.waitForLoadState("networkidle");
+
+      await snapshot({
+        note: `${screenshotLabel} - Initial`,
+        locator: await page.getByTestId("details-page-content"),
+        fullPage: true,
+      });
+
+      const tabButton = await page.getByTestId(buttonLabel);
+      await tabButton.click();
+      await page.waitForLoadState("networkidle");
+
+      await snapshot({
+        note: `${screenshotLabel} - After Click`,
+        locator: await page.getByTestId("details-page-content"),
+        fullPage: true,
+      });
     });
-  });
+  }
 });

--- a/src/components/charts-generic/interaction/latest-indicator.tsx
+++ b/src/components/charts-generic/interaction/latest-indicator.tsx
@@ -1,0 +1,60 @@
+import { Box } from "@mui/material";
+
+import {
+  LinesState,
+  useChartState,
+} from "src/components/charts-generic/use-chart-state";
+
+export const LatestIndicator = () => {
+  const { bounds, xScale, yScale, xUniqueValues, data, getX, getY } =
+    useChartState() as LinesState;
+
+  if (!xUniqueValues.length) return null;
+
+  const latestXValue = xUniqueValues[xUniqueValues.length - 1];
+  const xAnchor = xScale(latestXValue);
+
+  // Find latest Y based on data matching latest X
+  const dataAtLatestX = data.find(
+    (d) => getX(d).getTime() === latestXValue.getTime()
+  );
+  if (!dataAtLatestX) return null;
+
+  const yValue = getY(dataAtLatestX);
+  const yAnchor = yScale(yValue);
+
+  return (
+    <>
+      {/* Dashed vertical line */}
+      <Box
+        sx={{
+          position: "absolute",
+          top: bounds.margins.top + yAnchor,
+          left: xAnchor + bounds.margins.left,
+          height: bounds.chartHeight - yAnchor,
+          width: 0,
+          borderLeft: "1px dashed",
+          borderColor: "secondary.300",
+          transform: "translateX(-50%)",
+          pointerEvents: "none",
+        }}
+      />
+
+      {/* Black dot at latest X/Y */}
+      <Box
+        sx={{
+          position: "absolute",
+          top: bounds.margins.top + yAnchor,
+          left: xAnchor + bounds.margins.left,
+          width: 10,
+          height: 10,
+          borderRadius: "50%",
+          bgcolor: "black",
+          border: "2px solid white",
+          transform: "translate(-50%, -50%)",
+          pointerEvents: "none",
+        }}
+      />
+    </>
+  );
+};

--- a/src/components/detail-page/price-evolution-line-chart.tsx
+++ b/src/components/detail-page/price-evolution-line-chart.tsx
@@ -41,6 +41,8 @@ import { EMPTY_ARRAY } from "src/lib/empty-array";
 import { useLocale } from "src/lib/use-locale";
 import { useQueryStateElectricity } from "src/lib/use-query-state";
 
+import { LatestIndicator } from "../charts-generic/interaction/latest-indicator";
+
 const DOWNLOAD_ID: Download = "evolution";
 
 export const PriceEvolutionCard = ({
@@ -104,7 +106,8 @@ export const PriceEvolution = ({
   id,
   entity,
   priceComponents,
-}: SectionProps & { priceComponents: string[] }) => {
+  mini,
+}: SectionProps & { priceComponents: string[]; mini?: boolean }) => {
   const locale = useLocale();
   const [{ category, municipality, operator, canton, product }] =
     useQueryStateElectricity();
@@ -158,6 +161,7 @@ export const PriceEvolution = ({
           observations={observations as GenericObservation[]}
           entity={entity}
           priceComponents={priceComponents}
+          mini={mini}
         />
       </WithClassName>
     </div>
@@ -169,9 +173,11 @@ export const PriceEvolutionLineCharts = memo(
     observations,
     entity,
     priceComponents,
+    mini,
   }: Pick<SectionProps, "entity"> & {
     priceComponents: string[];
     observations: GenericObservation[];
+    mini?: boolean;
   }) => {
     return (
       <Box
@@ -189,6 +195,7 @@ export const PriceEvolutionLineCharts = memo(
               pc={pc}
               entity={entity}
               observations={observations}
+              mini={mini}
             />
           );
         })}
@@ -202,8 +209,9 @@ const PriceEvolutionLineChart = (props: {
   i: number;
   observations: GenericObservation[];
   entity: Entity;
+  mini?: boolean;
 }) => {
-  const { pc, entity, i, observations } = props;
+  const { pc, entity, i, observations, mini } = props;
 
   const withUniqueEntityId: GenericObservation[] = observations.map((obs) => ({
     uniqueId:
@@ -276,7 +284,7 @@ const PriceEvolutionLineChart = (props: {
           </ChartSvg>
 
           {hasMultipleLines && <Ruler />}
-
+          {mini && <LatestIndicator />}
           <HoverDotMultiple />
 
           <Tooltip type={hasMultipleLines ? "multiple" : "single"} />

--- a/src/components/map-details-content.tsx
+++ b/src/components/map-details-content.tsx
@@ -205,6 +205,7 @@ export const MapDetailsContent: React.FC<{
       priceComponents={["total"]}
       id={selectedItem.id}
       entity={entity}
+      mini
     />
     <Button
       variant="contained"

--- a/src/components/sunshine-tabs.tsx
+++ b/src/components/sunshine-tabs.tsx
@@ -1,5 +1,5 @@
 import { Trans } from "@lingui/macro";
-import { Tabs, Tab } from "@mui/material";
+import { Tab, Tabs } from "@mui/material";
 import React from "react";
 
 export enum CostAndTariffsTabOption {
@@ -15,6 +15,7 @@ export const CostsAndTariffsNavigation: React.FC<{
   return (
     <Tabs value={activeTab} onChange={handleTabChange}>
       <Tab
+        data-testid="network-costs-tab"
         value={CostAndTariffsTabOption.NETWORK_COSTS}
         label={
           <Trans id="sunshine.costs-and-tariffs.network-costs">
@@ -23,12 +24,14 @@ export const CostsAndTariffsNavigation: React.FC<{
         }
       />
       <Tab
+        data-testid="net-tariffs-tab"
         value={CostAndTariffsTabOption.NET_TARIFFS}
         label={
           <Trans id="sunshine.costs-and-tariffs.net-tariffs">Net Tariffs</Trans>
         }
       />
       <Tab
+        data-testid="energy-tariffs-tab"
         value={CostAndTariffsTabOption.ENERGY_TARIFFS}
         label={
           <Trans id="sunshine.costs-and-tariffs.energy-tariffs">
@@ -52,6 +55,7 @@ export const PowerStabilityNavigation: React.FC<{
   return (
     <Tabs value={activeTab} onChange={handleTabChange}>
       <Tab
+        data-testid="saidi-tab"
         value={PowerStabilityTabOption.SAIDI}
         label={
           <Trans id="sunshine.power-stability.saidi">
@@ -60,6 +64,7 @@ export const PowerStabilityNavigation: React.FC<{
         }
       />
       <Tab
+        data-testid="saifi-tab"
         value={PowerStabilityTabOption.SAIFI}
         label={
           <Trans id="sunshine.power-stability.saifi">
@@ -84,6 +89,7 @@ export const OperationalStandardsNavigation: React.FC<{
   return (
     <Tabs value={activeTab} onChange={handleTabChange}>
       <Tab
+        data-testid="product-variety-tab"
         value={OperationalStandardsTabOption.PRODUCT_VARIETY}
         label={
           <Trans id="sunshine.operational-standards.product-variety">
@@ -92,6 +98,7 @@ export const OperationalStandardsNavigation: React.FC<{
         }
       />
       <Tab
+        data-testid="service-quality-tab"
         value={OperationalStandardsTabOption.SERVICE_QUALITY}
         label={
           <Trans id="sunshine.operational-standards.service-quality">
@@ -100,6 +107,7 @@ export const OperationalStandardsNavigation: React.FC<{
         }
       />
       <Tab
+        data-testid="compliance-tab"
         value={OperationalStandardsTabOption.COMPLIANCE}
         label={
           <Trans id="sunshine.operational-standards.compliance">


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR adds the missing latest year indicator to the mini chart on the map details panel.

## Related Issues
<!-- Link any related issues using #issue_number format -->

## Testing Performed
<!-- Describe the testing you've done -->

- [x] Tested with the following Browsers: Chrome, Safari <!-- [Chrome, Firefox, Safari, etc] -->
- [x] Tested on the following devices: MacBook Pro, Large Monitor <!-- [MacBook Pro, iPhone 13, iPad, etc] -->
- [x] Verified functionality: Manually <!-- [Tested this functionality manually, automated, etc] -->
- [ ] Storybook updated
- [ ] Automated tests added

<!--
### Testing or Reproduction Steps

### Testing/Reproduction Steps
1. Navigate to [specific page]
2. Click on [specific element]
3. Observe [expected behavior]
-->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [x] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [x] I have marked this PR with the appropriate label
- [x] I have added an entry in the changelog

## Notes for Reviewers
<!-- Add any notes that might help reviewers understand your changes. -->

<!--
### Configuration Required
- Environment variables:
- Feature flags:
- Database changes:

### Known Limitations
-

### Performance Considerations
-

### Alternative Approaches Considered
-

### Future Improvements
-
-->
