### PR TITLE
Wiki info slugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,14 @@ You can also check the
 
   - Added Overview Details Page
 
-Enhancements
+- Enhancements
 
-- Add Query state to details pages
+  - Add Query state to details pages
+  - Add ability to debug info dialog slugs (via flag\_\_debugInfoDialog)
+
+- Fixes
+
+  - Fix some of the info dialogs used
 
 # 2.3.1 - 2025-06-26
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "dev": "make content && NODE_OPTIONS='--openssl-legacy-provider --max_old_space_size=4096' next",
     "update-wiki-content": "make content",
+    "wiki-content:update-types": "tsx scripts/wiki-content.ts pages --format typescript --file src/domain/data.ts",
     "build": "lingui compile && yarn build-storybook && NODE_OPTIONS='--max_old_space_size=16384 --openssl-legacy-provider' next build -d && mkdir .next/server/pages/sunshine-data/ && cp src/sunshine-data/*.enc  .next/server/pages/sunshine-data/",
     "start": "GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE='' NODE_OPTIONS='-r \"./configure-proxy\" --max_old_space_size=2048 --openssl-legacy-provider --unhandled-rejections=warn' next start -p $PORT",
     "typecheck": "tsc --noEmit",
@@ -148,6 +149,7 @@
     "@types/clownface": "^1.2.2",
     "@types/d3": "^6.3.0",
     "@types/fs-extra": "^9.0.11",
+    "@types/jscodeshift": "^17.3.0",
     "@types/k6": "^0.46.3",
     "@types/lodash": "^4.14.182",
     "@types/node": "^22.13.16",

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "accent-cli": "^0.16.2",
     "argparse": "^2.0.1",
     "babel-plugin-macros": "^3.0.1",
+    "dotenv": "^17.0.1",
     "eslint": "^8.50.0",
     "eslint-config-next": "15.0.4",
     "eslint-plugin-import": "^2.28.1",

--- a/scripts/wiki-content.ts
+++ b/scripts/wiki-content.ts
@@ -1,0 +1,204 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-console */
+
+import * as fs from "fs";
+
+import { ArgumentParser } from "argparse";
+import { config } from "dotenv";
+import jscodeshift from "jscodeshift";
+
+import { wikiPageSlugs } from "src/domain/data";
+import { getCachedWikiPages, WikiPage } from "src/domain/gitlab-wiki-api";
+
+// Load environment variables from .env file
+config();
+
+const getAllWikiPages = async (): Promise<WikiPage[]> => {
+  const gitlabWikiUrl = process.env.GITLAB_WIKI_URL;
+  const gitlabWikiToken = process.env.GITLAB_WIKI_TOKEN;
+
+  if (!gitlabWikiUrl || !gitlabWikiToken) {
+    throw new Error(
+      "Please set GITLAB_WIKI_URL and GITLAB_WIKI_TOKEN environment variables to fetch content from GitLab Wiki."
+    );
+  }
+
+  try {
+    const wikiPages = await getCachedWikiPages(
+      `${gitlabWikiUrl}?with_content=1`,
+      gitlabWikiToken
+    );
+
+    return wikiPages;
+  } catch (e: unknown) {
+    const error = e instanceof Error ? e : new Error(String(e));
+    console.error("Getting Wiki from API failed with error:", error.message);
+    throw e;
+  }
+};
+
+const fetchWikiPages = async () => {
+  const pages = await getAllWikiPages();
+
+  // Group pages by their base page name
+  const groupedPages = new Map<string, LocalizedWikiPage[]>();
+
+  // Define the LocalizedWikiPage type
+  type LocalizedWikiPage = WikiPage & {
+    baseSlug: string;
+    language: string;
+  };
+
+  pages.forEach((page) => {
+    // Try to parse slug in the format <page>/<language> with named groups
+    // @ts-expect-error TypeScript does not recognize the named groups in the regex,
+    // but it works at runtime
+    const match = page.slug.match(/^(?<page>.+)\/(?<language>[a-z]{2})$/);
+    if (match?.groups) {
+      const baseSlug = match.groups.page;
+      const language = match.groups.language;
+
+      if (!groupedPages.has(baseSlug)) {
+        groupedPages.set(baseSlug, []);
+      }
+
+      // Add the page with additional properties
+      groupedPages.get(baseSlug)?.push({
+        ...page,
+        baseSlug,
+        language,
+      } as LocalizedWikiPage);
+    }
+  });
+
+  // Get available pages (those with content)
+  const available = Array.from(groupedPages.keys());
+
+  // Get missing pages (those defined in wikiPageSlugs but not found)
+  const existing = new Set(available);
+  const missing = [...wikiPageSlugs.available, ...wikiPageSlugs.missing].filter(
+    (slug) => !existing.has(slug)
+  );
+
+  return {
+    available,
+    missing,
+  };
+};
+
+const main = async (): Promise<void> => {
+  const parser = new ArgumentParser({
+    description: "Script to manage wiki content from GitLab",
+  });
+
+  const subparsers = parser.add_subparsers({
+    title: "commands",
+    dest: "command",
+    required: true,
+  });
+
+  // Create pages subparser
+  const pagesParser = subparsers.add_parser("pages", {
+    help: "Get available and missing wiki pages",
+  });
+
+  pagesParser.add_argument("--format", {
+    choices: ["text", "json", "typescript"],
+    default: "text",
+    help: "Output format for the list of wiki pages",
+  });
+
+  pagesParser.add_argument("--variable-name", {
+    help: "Output variable name for the TypeScript format",
+  });
+
+  pagesParser.add_argument("--file", {
+    help: "File to save the output to (only for typescript formats)",
+  });
+
+  const args = parser.parse_args();
+  const { format, command } = args;
+
+  switch (command) {
+    case "pages":
+      const result = await fetchWikiPages();
+      if (format === "json") {
+        console.log(JSON.stringify(result, null, 2));
+      } else if (format === "text") {
+        console.log("Available pages:");
+        result.available.forEach((slug) => {
+          console.log(`  - ${slug}`);
+        });
+        console.log("\nMissing pages:");
+        result.missing.forEach((slug) => {
+          console.log(`  - ${slug}`);
+        });
+      } else if (format === "typescript") {
+        // read the file path from args.file, parse it with jscodeshift and replace the variable
+        // declaration with the new value
+        if (!args.file) {
+          console.error(
+            "Please provide a file path with --file for TypeScript output."
+          );
+          process.exit(1);
+        }
+        const variableName = args.variable_name || "wikiPageSlugs";
+        const filePath = args.file;
+
+        //  parse with jscodeshift
+        const fileContent = fs.readFileSync(filePath, "utf8");
+        const root = jscodeshift.withParser("ts")(fileContent);
+        const variableDeclaration = root.find(
+          jscodeshift.VariableDeclaration,
+          (node) => {
+            const decl = node.declarations[0];
+            if (
+              !decl ||
+              decl.type !== "VariableDeclarator" ||
+              decl.id.type !== "Identifier"
+            ) {
+              return false;
+            }
+            return decl.id.name === variableName;
+          }
+        );
+        const source = `const a = ${JSON.stringify(result, null, 2)} as const`;
+        const literal = jscodeshift
+          .withParser("tsx")(source)
+          .find(jscodeshift.TSAsExpression)
+          .get(0).node;
+        const declaration = jscodeshift.variableDeclaration("const", [
+          jscodeshift.variableDeclarator(
+            jscodeshift.identifier(variableName),
+            literal
+          ),
+        ]);
+        if (variableDeclaration.length > 0) {
+          variableDeclaration.replaceWith(declaration);
+        } else {
+          root.get().node.program.body.push(declaration);
+        }
+        const output = root.toSource();
+        // Write the output to the specified file
+        fs.writeFile(filePath, output, (err: NodeJS.ErrnoException | null) => {
+          if (err) {
+            console.error(`Error writing to file ${filePath}:`, err.message);
+            process.exit(1);
+          }
+          console.log(`Wiki pages saved to ${filePath}`);
+        });
+      }
+      break;
+    default:
+      console.error(`Unknown command: ${command}`);
+      process.exit(1);
+  }
+};
+
+// Run the script if called directly
+if (require.main === module) {
+  main().catch((error) => {
+    console.error("Script failed:", error);
+    process.exit(1);
+  });
+}

--- a/src/components/button-group.tsx
+++ b/src/components/button-group.tsx
@@ -2,6 +2,7 @@ import { Box, Typography } from "@mui/material";
 import { ChangeEventHandler, ReactNode, useCallback } from "react";
 
 import { VisuallyHidden } from "src/components/visually-hidden";
+import { WikiPageSlug } from "src/domain/data";
 
 import { InfoDialogButton } from "./info-dialog";
 
@@ -12,7 +13,7 @@ type ButtonGroupProps<T> = {
   setValue: (value: T) => void;
   label?: string;
   showLabel?: boolean;
-  infoDialogSlug?: string;
+  infoDialogSlug?: WikiPageSlug;
 };
 
 const STYLES = {

--- a/src/components/combobox.stories.tsx
+++ b/src/components/combobox.stories.tsx
@@ -77,7 +77,7 @@ export const MunicipalitySelection: Story = {
           selectedItem={selectedMunicipality}
           setSelectedItem={setSelectedMunicipality}
           getItemLabel={getLabel}
-          infoDialogSlug="municipality-info"
+          infoDialogSlug="help-municipalities-and-grid-operators-info"
         />
       </div>
     );

--- a/src/components/combobox.tsx
+++ b/src/components/combobox.tsx
@@ -5,6 +5,7 @@ import TextField from "@mui/material/TextField";
 import { useEffect, useMemo, useState } from "react";
 
 import { InfoDialogButton } from "src/components/info-dialog";
+import { WikiPageSlug } from "src/domain/data";
 import { getLocalizedLabel } from "src/domain/translation";
 import { Icon } from "src/icons";
 
@@ -193,7 +194,7 @@ export const Combobox = <T extends string>({
   setSelectedItem: (selectedItem: T) => void;
   getItemLabel?: (item: T) => string;
   showLabel?: boolean;
-  infoDialogSlug?: string;
+  infoDialogSlug?: WikiPageSlug;
   disabled?: boolean;
   error?: boolean;
 }) => {

--- a/src/components/info-dialog.tsx
+++ b/src/components/info-dialog.tsx
@@ -28,6 +28,7 @@ import { useWikiContentQuery } from "src/graphql/queries";
 import { Icon } from "src/icons";
 import { useLocale } from "src/lib/use-locale";
 import { theme } from "src/themes/elcom";
+import { useFlag } from "src/utils/flags";
 
 const DialogContent = ({
   contentQuery,
@@ -204,8 +205,22 @@ export const InfoDialogButton = ({
     close: closeDialog,
     open: openDialog,
   } = useDisclosure();
+  const debugInfoDialog = useFlag("debugInfoDialog");
   return (
     <>
+      {debugInfoDialog && (
+        <Box
+          sx={{
+            background: "hotpink",
+            fontSize: 10,
+            height: 16,
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          slug: {slug}
+        </Box>
+      )}
       <IconButton
         color="tertiary"
         sx={{

--- a/src/components/info-dialog.tsx
+++ b/src/components/info-dialog.tsx
@@ -23,6 +23,7 @@ import { createPortal } from "react-dom";
 import { LoadingIcon, NoContentHint } from "src/components/hint";
 import { useDisclosure } from "src/components/use-disclosure";
 import { VisuallyHidden } from "src/components/visually-hidden";
+import { WikiPageSlug } from "src/domain/data";
 import { useWikiContentQuery } from "src/graphql/queries";
 import { Icon } from "src/icons";
 import { useLocale } from "src/lib/use-locale";
@@ -193,7 +194,7 @@ export const InfoDialogButton = ({
   type = "fill",
 }: {
   label: string;
-  slug: string;
+  slug: WikiPageSlug;
   iconOnly?: boolean;
   iconSize?: number;
   type?: "fill" | "outline";

--- a/src/components/network-costs-trend-card.tsx
+++ b/src/components/network-costs-trend-card.tsx
@@ -108,9 +108,11 @@ export const NetworkCostsTrendCard: React.FC<NetworkCostsTrendCardProps> = (
                 iconOnly
                 iconSize={24}
                 type="outline"
-                //FIXME: use correct slug
-                slug="help-costs-and-tariffs"
-                label={"sunshine.costs-and-tariffs.network-cost-trend"}
+                slug="help-network-costs"
+                label={t({
+                  id: "sunshine.costs-and-tariffs.network-cost-trend",
+                  message: "Network Cost Trend",
+                })}
               />
               <DownloadImage
                 iconOnly

--- a/src/domain/data.ts
+++ b/src/domain/data.ts
@@ -278,10 +278,9 @@ export const wikiPageSlugs = {
     "home-banner",
   ],
   missing: [
-    "help.calculation",
+    "help-costs-and-tariffs",
     "help-net-tariffs",
     "help-operational-standards",
-    "help-costs-and-tariffs",
     "help-net-tariff-category",
     "help-energy-tariff-category",
     "help-indicator",

--- a/src/domain/data.ts
+++ b/src/domain/data.ts
@@ -282,6 +282,11 @@ export const wikiPageSlugs = {
     "help-net-tariffs",
     "help-operational-standards",
     "help-costs-and-tariffs",
+    "help-net-tariff-category",
+    "help-energy-tariff-category",
+    "help-indicator",
+    "help-typology",
+    "help-network-level",
   ],
 } as const;
 

--- a/src/domain/data.ts
+++ b/src/domain/data.ts
@@ -278,7 +278,6 @@ export const wikiPageSlugs = {
     "home-banner",
   ],
   missing: [
-    "help-costs-and-tariffs",
     "help-net-tariffs",
     "help-operational-standards",
     "help-net-tariff-category",

--- a/src/domain/data.ts
+++ b/src/domain/data.ts
@@ -255,7 +255,7 @@ export const asTariffCategory = (category: string): TariffCategory => {
  * Use `bun wiki-content:update-types` to update this variable
  */
 export const wikiPageSlugs = {
-  "available": [
+  available: [
     "help-calculation",
     "help-canton-comparison",
     "help-categories",
@@ -275,14 +275,16 @@ export const wikiPageSlugs = {
     "help-saidi",
     "help-saifi",
     "help-search-list",
-    "home-banner"
+    "home-banner",
   ],
-  "missing": [
+  missing: [
     "help.calculation",
     "help-net-tariffs",
     "help-operational-standards",
-    "help-costs-and-tariffs"
-  ]
+    "help-costs-and-tariffs",
+  ],
 } as const;
 
-export type WikiPageSlug = (typeof wikiPageSlugs)["available"][number];
+export type WikiPageSlug = (typeof wikiPageSlugs)[
+  | "available"
+  | "missing"][number];

--- a/src/domain/data.ts
+++ b/src/domain/data.ts
@@ -250,3 +250,39 @@ export const asTariffCategory = (category: string): TariffCategory => {
   }
   throw new Error(`Invalid network category: ${category}`);
 };
+
+/**
+ * Use `bun wiki-content:update-types` to update this variable
+ */
+export const wikiPageSlugs = {
+  "available": [
+    "help-calculation",
+    "help-canton-comparison",
+    "help-categories",
+    "help-compliance",
+    "help-download-raw-data",
+    "help-energy-tariffs",
+    "help-fixcosts",
+    "help-grid-tariffs",
+    "help-municipalities-and-grid-operators-info",
+    "help-network-costs",
+    "help-price-comparison",
+    "help-price-components",
+    "help-price-distribution",
+    "help-price-evolution",
+    "help-product-variety",
+    "help-products",
+    "help-saidi",
+    "help-saifi",
+    "help-search-list",
+    "home-banner"
+  ],
+  "missing": [
+    "help.calculation",
+    "help-net-tariffs",
+    "help-operational-standards",
+    "help-costs-and-tariffs"
+  ]
+} as const;
+
+export type WikiPageSlug = (typeof wikiPageSlugs)["available"][number];

--- a/src/domain/gitlab-wiki-api.ts
+++ b/src/domain/gitlab-wiki-api.ts
@@ -22,7 +22,7 @@ type WikiCacheJson = {
 
 const CACHE_TTL = 1000;
 
-export const fetchWithTimeout = async (
+const fetchWithTimeout = async (
   url: string,
   options: RequestInit & { timeout?: number; agent?: https.Agent } = {}
 ) => {

--- a/src/domain/gitlab-wiki-api.ts
+++ b/src/domain/gitlab-wiki-api.ts
@@ -8,23 +8,21 @@ import { getWikiPage as getStaticWikiPage } from "src/domain/gitlab-wiki-static"
 import serverEnv from "src/env/server";
 import { setupUndiciHttpAgent } from "src/pages/api/http-agent";
 
-type WikiPage = {
+export type WikiPage = {
   format: string;
   slug: string;
   title: string;
   content: string;
 };
 
-type WikiPages = WikiPage[];
-
 type WikiCacheJson = {
   _created: number;
-  pages: WikiPages;
+  pages: WikiPage[];
 };
 
 const CACHE_TTL = 1000;
 
-const fetchWithTimeout = async (
+export const fetchWithTimeout = async (
   url: string,
   options: RequestInit & { timeout?: number; agent?: https.Agent } = {}
 ) => {
@@ -46,10 +44,10 @@ const fetchWithTimeout = async (
   return value as Response;
 };
 
-const getCachedWikiPages = async (
+export const getCachedWikiPages = async (
   url: string,
   token: string
-): Promise<WikiPages> => {
+): Promise<WikiPage[]> => {
   const filePath = path.join(os.tmpdir(), url.replace(/\W+/g, "-") + ".json");
 
   if (fs.existsSync(filePath)) {
@@ -71,7 +69,7 @@ const getCachedWikiPages = async (
     // the GLOBAL_AGENT_FORCE_GLOBAL_AGENT variable is set
     agent: https.globalAgent,
   });
-  const pages: WikiPages = await res.json();
+  const pages: WikiPage[] = await res.json();
 
   const json: WikiCacheJson = { _created: Date.now(), pages };
   await fs.writeJSON(filePath, json);

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -372,7 +372,9 @@ const Query: QueryResolvers = {
   wikiContent: async (_, { locale, slug }) => {
     // Exit early if home-banner is requested and it's disabled
     const extraInfo = await getExtraInfo(slug);
-    const wikiPage = await getWikiPage(`${slug}/${locale}`);
+    const wikiPage = await getWikiPage(
+      `${slug}/${locale === "en" ? "de" : locale}`
+    );
 
     if (!wikiPage) {
       return null;

--- a/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+++ b/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -382,6 +382,8 @@ const EnergyTariffs = (props: Extract<Props, { status: "found" }>) => {
             value: {
               value: operatorRate,
               unit: RP_PER_KM,
+              round: 2,
+              // TODO
               trend: Trend.Stable,
             },
           }
@@ -396,6 +398,8 @@ const EnergyTariffs = (props: Extract<Props, { status: "found" }>) => {
             value: {
               value: peerGroupMedianRate,
               unit: RP_PER_KM,
+              round: 2,
+              // TODO
               trend: Trend.Stable,
             },
           }
@@ -560,6 +564,8 @@ const NetTariffs = (props: Extract<Props, { status: "found" }>) => {
             value: {
               value: operatorRate,
               unit: RP_PER_KM,
+              round: 2,
+              // TODO
               trend: "stable" as Trend,
             },
           }
@@ -574,6 +580,8 @@ const NetTariffs = (props: Extract<Props, { status: "found" }>) => {
             value: {
               value: peerGroupMedianRate,
               unit: RP_PER_KM,
+              round: 2,
+              // TODO
               trend: "stable" as Trend,
             },
           }
@@ -634,7 +642,7 @@ const NetTariffs = (props: Extract<Props, { status: "found" }>) => {
             </Trans>
           }
           infoDialogProps={{
-            slug: "help-network-costs",
+            slug: "help-net-tariffs",
             label: t({
               id: "sunshine.costs-and-tariffs.net-tariffs-trend",
               message: "Net Tariffs Trend",

--- a/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+++ b/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -612,8 +612,7 @@ const NetTariffs = (props: Extract<Props, { status: "found" }>) => {
             getItemLabel={getItemLabel}
             selectedItem={category}
             setSelectedItem={(item) => _setCategory(item as TariffCategory)}
-            //FIXME: Might need change
-            infoDialogSlug="help-categories"
+            infoDialogSlug="help-net-tariff-category"
           />
         </Box>
 

--- a/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+++ b/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -634,7 +634,7 @@ const NetTariffs = (props: Extract<Props, { status: "found" }>) => {
             </Trans>
           }
           infoDialogProps={{
-            slug: "help-net-tariffs",
+            slug: "help-network-costs",
             label: t({
               id: "sunshine.costs-and-tariffs.net-tariffs-trend",
               message: "Net Tariffs Trend",

--- a/src/pages/sunshine/[entity]/[id]/power-stability.tsx
+++ b/src/pages/sunshine/[entity]/[id]/power-stability.tsx
@@ -222,7 +222,7 @@ const Saidi = (props: Extract<Props, { status: "found" }>) => {
             message: "Average Power Outage Duration (SAIDI)",
           })}
           infoDialogProps={{
-            slug: "sunshine.power-stability.saidi.info-dialog",
+            slug: "help-saidi",
             label: t({
               id: "sunshine.power-stability.saidi.info-dialog-label",
               message: "Total Outage Duration",
@@ -341,7 +341,7 @@ const Saifi = (props: Extract<Props, { status: "found" }>) => {
             message: "Average Power Outage Frequency (SAIFI)",
           })}
           infoDialogProps={{
-            slug: "sunshine.power-stability.saifi.info-dialog",
+            slug: "help-saifi",
             label: t({
               id: "sunshine.power-stability.saifi.info-dialog-label",
               message: "Total Outage Frequency",

--- a/src/pages/sunshine/[entity]/[id]/power-stability.tsx
+++ b/src/pages/sunshine/[entity]/[id]/power-stability.tsx
@@ -163,6 +163,7 @@ const Saidi = (props: Extract<Props, { status: "found" }>) => {
           unit: MIN_PER_YEAR,
           // TODO Compute the trend
           trend: Trend.Down,
+          round: 2,
         },
       },
       {
@@ -176,6 +177,7 @@ const Saidi = (props: Extract<Props, { status: "found" }>) => {
           unit: MIN_PER_YEAR,
           // TODO Compute the trend
           trend: Trend.Stable,
+          round: 2,
         },
       },
     ],
@@ -278,6 +280,7 @@ const Saifi = (props: Extract<Props, { status: "found" }>) => {
         value: {
           value: data.saifi.operatorTotal,
           unit: MIN_PER_YEAR,
+          round: 2,
           // TODO Compute the trend
           trend: Trend.Down,
         },
@@ -291,6 +294,7 @@ const Saifi = (props: Extract<Props, { status: "found" }>) => {
         value: {
           value: data.saifi.peerGroupTotal,
           unit: MIN_PER_YEAR,
+          round: 2,
           // TODO Compute the trend
           trend: Trend.Stable,
         },

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -3,6 +3,10 @@ import { createComponents, createHooks } from "src/flags";
 const specs = {
   /** Activates flag control in top bar */
   debug: {},
+
+  /** Activates flag control in top bar */
+  debugInfoDialog: {},
+
   /** Show sunshine specific UI */
   sunshine: {},
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7456,6 +7456,14 @@
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
   integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
 
+"@types/jscodeshift@^17.3.0":
+  version "17.3.0"
+  resolved "https://registry.yarnpkg.com/@types/jscodeshift/-/jscodeshift-17.3.0.tgz#f54cb4e165742e78980cd0973c07ac3785ac7bc4"
+  integrity sha512-ogvGG8VQQqAQQ096uRh+d6tBHrYuZjsumHirKtvBa5qEyTMN3IQJ7apo+sw9lxaB/iKWIhbbLlF3zmAWk9XQIg==
+  dependencies:
+    ast-types "^0.16.1"
+    recast "^0.23.11"
+
 "@types/jsdom@^21.1.7":
   version "21.1.7"
   resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-21.1.7.tgz#9edcb09e0b07ce876e7833922d3274149c898cfa"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11172,6 +11172,11 @@ dotenv@^16.0.0, dotenv@^16.3.1, dotenv@^16.5.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.5.0.tgz#092b49f25f808f020050051d1ff258e404c78692"
   integrity sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==
 
+dotenv@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.0.1.tgz#79bc4d232fadb42a4092685ff1206d31b2a43f95"
+  integrity sha512-GLjkduuAL7IMJg/ZnOPm9AnWKJ82mSE2tzXLaJ/6hD6DhwGfZaXG77oB8qbReyiczNxnbxQKyh0OE5mXq0bAHA==
+
 dset@^3.1.2, dset@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.4.tgz#f8eaf5f023f068a036d08cd07dc9ffb7d0065248"


### PR DESCRIPTION

## Description

- Add types for wiki pages
- Add way to update those types automatically by listing pages from wiki
- Add flag to show which wiki page slug is behind which button. flag__debugInfoDialog=true
- Fix some of the slug used 

## Notes for Reviewers

Should open a new issue for @mevionfamos with pages that are not in wiki yet.

```
  missing: [
    // costs and tariffs page, net tariff tab
    "help-net-tariffs",
    "help-net-tariff-category",
    // costs and tariffs page, energy tariff tab
    "help-energy-tariff-category",

    // map page, selector panel
    "help-indicator",
    "help-typology",
    "help-network-level",
    
    // To check later, page is being improvedv
    "help-operational-standards",D
  ],
```

### Configuration Required

- Feature flags: flag__debugInfoDialog


### Future Improvements

Missing pages should be added to wiki
