### PR TITLE
Fix map zoom

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -32,8 +32,6 @@ const config: KnipConfig = {
     "open",
     // Used for managing mock data, available via nix
     "duckdb",
-    // Used to run scripts
-    "tsx",
   ],
   ignoreUnresolved: [
     // Used in package.json:scripts:start to configure HTTP_PROXY.
@@ -61,12 +59,6 @@ const config: KnipConfig = {
 
     // global library to auto translate po files
     "tpo-deepl",
-
-    // Used in codemods
-    "jscodeshift",
-
-    // Used in populating aa translations
-    "@types/gettext-parser",
   ],
 };
 export default config;

--- a/src/components/generic-map.tsx
+++ b/src/components/generic-map.tsx
@@ -170,11 +170,21 @@ export const GenericMap = ({
   // Resize handler
   const onResize = useCallback(
     ({ width, height }: { width: number; height: number }) => {
-      setViewState((viewState) =>
-        constrainZoom({ ...viewState, width, height }, initialBBox, {
-          padding: mapZoomPadding,
-        })
-      );
+      setViewState((viewState) => {
+        const constrained = constrainZoom(
+          { ...viewState, width, height },
+          initialBBox,
+          {
+            padding: mapZoomPadding,
+          }
+        );
+        return {
+          ...viewState,
+          zoom: constrained.zoom,
+          longitude: constrained.longitude,
+          latitude: constrained.latitude,
+        };
+      });
     },
     [setViewState, mapZoomPadding, initialBBox]
   );
@@ -229,7 +239,14 @@ export const GenericMap = ({
             }
           );
 
-          setViewState(newViewState);
+          if (newViewState) {
+            setViewState({
+              ...viewState,
+              zoom: newViewState.zoom,
+              longitude: newViewState.longitude,
+              latitude: newViewState.latitude,
+            });
+          }
         },
         zoomOut: () => {
           const newViewState = getZoomedViewState(
@@ -240,7 +257,15 @@ export const GenericMap = ({
               transitionDuration: 1000,
             }
           );
-          setViewState(newViewState);
+
+          if (newViewState) {
+            setViewState({
+              ...viewState,
+              zoom: newViewState.zoom,
+              longitude: newViewState.longitude,
+              latitude: newViewState.latitude,
+            });
+          }
         },
       };
     }

--- a/src/components/map-helpers.spec.ts
+++ b/src/components/map-helpers.spec.ts
@@ -1,0 +1,58 @@
+import { BBox as GeoJsonBBox } from "geojson";
+import { describe, test, expect } from "vitest";
+
+import { getZoomedViewState } from "src/components/map-helpers";
+import assert from "src/lib/assert";
+
+describe("getZoomedViewState", () => {
+  test("should return zoomed view state for given bbox", () => {
+    const currentViewState = {
+      latitude: 46.8182,
+      longitude: 8.2275,
+      zoom: 2,
+      bearing: 0,
+      pitch: 0,
+      width: 200,
+      height: 200,
+      maxZoom: 16,
+      minZoom: 2,
+    };
+
+    const bbox: GeoJsonBBox = [
+      5.956800664952974, 45.81912371940225, 10.493446773955753,
+      47.80741209797084,
+    ];
+
+    const result = getZoomedViewState(currentViewState, bbox, {});
+
+    assert(result !== undefined, "assert should be defined");
+    expect(result.latitude).toBeTypeOf("number");
+    expect(result.longitude).toBeTypeOf("number");
+    expect(result.zoom).toBeTypeOf("number");
+    expect(result.zoom).toBeGreaterThan(currentViewState.zoom);
+  });
+
+  test("should respect zoom constraints", () => {
+    const currentViewState = {
+      latitude: 46.8182,
+      longitude: 8.2275,
+      zoom: 15,
+      bearing: 0,
+      pitch: 0,
+      width: 200,
+      height: 200,
+      maxZoom: 16,
+      minZoom: 2,
+    };
+
+    const bbox: GeoJsonBBox = [
+      5.956800664952974, 45.81912371940225, 10.493446773955753,
+      47.80741209797084,
+    ];
+
+    const result = getZoomedViewState(currentViewState, bbox, {});
+    assert(result !== undefined, "assert should be defined");
+    expect(result.zoom).toBeLessThanOrEqual(currentViewState.maxZoom);
+    expect(result.zoom).toBeGreaterThanOrEqual(currentViewState.minZoom);
+  });
+});

--- a/src/flags/index.ts
+++ b/src/flags/index.ts
@@ -2,5 +2,6 @@ export { default as createHooks } from "./hooks";
 /** @knipignore */
 export { default as createAPI } from "./api";
 export { default as createComponents } from "./components";
+export type { FlagValue } from "./types";
 /** @knipignore */
-export type { FlagName, FlagValue } from "./types";
+export type { FlagName } from "./types";

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -206,10 +206,14 @@ const IndexPageContent = ({
 
   useEffect(() => {
     if (isSunshine) {
-      if (activeId) {
-        controlsRef.current?.zoomOn(activeId);
-      } else {
-        controlsRef.current?.zoomOut();
+      try {
+        if (activeId) {
+          controlsRef.current?.zoomOn(activeId);
+        } else {
+          controlsRef.current?.zoomOut();
+        }
+      } catch (e) {
+        console.error("Error zooming on map:", e);
       }
     }
   }, [activeId, isSunshine]);


### PR DESCRIPTION
Fix an annoying application error that would trigger sometimes on page change.

Added defensive code around map zoom and also made the code to fit bounds a bit more robust by decreasing padding step by step.