### PR TITLE
Scroll zoom on map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You can also check the
 - Features
 
   - Map page: Same hover style on Energy Prices vs Sunshine Map
+  - Map page: Scroll is disabled on map unless user holds ctrl or cmd key
 
 - Fix
 

--- a/src/components/generic-map.tsx
+++ b/src/components/generic-map.tsx
@@ -307,7 +307,8 @@ export const GenericMap = ({
             </MapTooltip>
           )}
 
-        <WithClassName downloadId={downloadId || "map"} isFetching={isLoading}>
+        <div
+          className={isLoading ? "" : downloadId || "map"}
           {legend && (
             <Box
               sx={{
@@ -335,7 +336,7 @@ export const GenericMap = ({
             onClick={onLayerClick}
             ref={deckRef}
           />
-        </WithClassName>
+        </div>
 
         {screenshotting ? (
           <Box

--- a/src/locales/aa/messages.po
+++ b/src/locales/aa/messages.po
@@ -557,6 +557,10 @@ msgstr "map.details-sidebar-panel.next-button.service-quality"
 msgid "map.details-sidebar-panel.next-button.sunshine-overview"
 msgstr "map.details-sidebar-panel.next-button.sunshine-overview"
 
+#: src/components/generic-map.tsx
+msgid "map.scrollzoom.hint"
+msgstr "map.scrollzoom.hint"
+
 #: src/components/share-button.tsx
 msgid "map.share"
 msgstr "map.share"
@@ -570,7 +574,6 @@ msgid "municipality"
 msgstr "municipality"
 
 #: src/components/tariffs-trend-chart.tsx
-#: src/components/tariffs-trend-chart.tsx
 msgid "net-tariffs-trend-chart.legend-item.other-operators"
 msgstr "net-tariffs-trend-chart.legend-item.other-operators"
 
@@ -579,8 +582,6 @@ msgid "net-tariffs-trend-chart.legend-item.peer-group-median"
 msgstr "net-tariffs-trend-chart.legend-item.peer-group-median"
 
 #: src/components/network-cost-trend-chart.tsx
-#: src/components/network-cost-trend-chart.tsx
-#: src/components/power-stability-chart.tsx
 msgid "network-cost-trend-chart.legend-item.other-operators"
 msgstr "network-cost-trend-chart.legend-item.other-operators"
 
@@ -723,6 +724,10 @@ msgstr "priceComponents.view.expanded.municipalities"
 #: src/domain/translation.tsx
 msgid "priceComponents.view.expanded.operators"
 msgstr "priceComponents.view.expanded.operators"
+
+#: src/components/charts-generic/progress-overtime-chart.tsx
+msgid "progress-overtime-chart.legend-item.other-operators"
+msgstr "progress-overtime-chart.legend-item.other-operators"
 
 #: src/components/detail-page/cantons-comparison-range.tsx
 msgid "rangeplot.select.order.hint"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -564,6 +564,10 @@ msgstr "Servicequalität im Detail"
 msgid "map.details-sidebar-panel.next-button.sunshine-overview"
 msgstr "Alle Sonnenschein-Indikatoren anzeigen"
 
+#: src/components/generic-map.tsx
+msgid "map.scrollzoom.hint"
+msgstr "Halten Sie {key} gedrückt und blättern Sie zum Zoomen"
+
 #: src/components/share-button.tsx
 msgid "map.share"
 msgstr "Teilen"
@@ -577,7 +581,6 @@ msgid "municipality"
 msgstr "Gemeinde"
 
 #: src/components/tariffs-trend-chart.tsx
-#: src/components/tariffs-trend-chart.tsx
 msgid "net-tariffs-trend-chart.legend-item.other-operators"
 msgstr "Andere Netzbetreiber"
 
@@ -586,8 +589,6 @@ msgid "net-tariffs-trend-chart.legend-item.peer-group-median"
 msgstr "Peer Group Median"
 
 #: src/components/network-cost-trend-chart.tsx
-#: src/components/network-cost-trend-chart.tsx
-#: src/components/power-stability-chart.tsx
 msgid "network-cost-trend-chart.legend-item.other-operators"
 msgstr "Andere Netzbetreiber"
 
@@ -730,6 +731,10 @@ msgstr "Einzelne Gemeinden anzeigen"
 #: src/domain/translation.tsx
 msgid "priceComponents.view.expanded.operators"
 msgstr "Einzelne Netzbetreiber anzeigen"
+
+#: src/components/charts-generic/progress-overtime-chart.tsx
+msgid "progress-overtime-chart.legend-item.other-operators"
+msgstr "Andere Betreiber"
 
 #: src/components/detail-page/cantons-comparison-range.tsx
 msgid "rangeplot.select.order.hint"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -557,6 +557,10 @@ msgstr "Service Quality in detail"
 msgid "map.details-sidebar-panel.next-button.sunshine-overview"
 msgstr "Show all Sunshine Indicators"
 
+#: src/components/generic-map.tsx
+msgid "map.scrollzoom.hint"
+msgstr "Hold {key} and scroll to zoom"
+
 #: src/components/share-button.tsx
 msgid "map.share"
 msgstr "Share"
@@ -570,7 +574,6 @@ msgid "municipality"
 msgstr "Municipality"
 
 #: src/components/tariffs-trend-chart.tsx
-#: src/components/tariffs-trend-chart.tsx
 msgid "net-tariffs-trend-chart.legend-item.other-operators"
 msgstr "Other operators"
 
@@ -579,8 +582,6 @@ msgid "net-tariffs-trend-chart.legend-item.peer-group-median"
 msgstr "Peer Group Median"
 
 #: src/components/network-cost-trend-chart.tsx
-#: src/components/network-cost-trend-chart.tsx
-#: src/components/power-stability-chart.tsx
 msgid "network-cost-trend-chart.legend-item.other-operators"
 msgstr "Other operators"
 
@@ -723,6 +724,10 @@ msgstr "Show individual municipalities"
 #: src/domain/translation.tsx
 msgid "priceComponents.view.expanded.operators"
 msgstr "Show individual network operators"
+
+#: src/components/charts-generic/progress-overtime-chart.tsx
+msgid "progress-overtime-chart.legend-item.other-operators"
+msgstr "Other operators"
 
 #: src/components/detail-page/cantons-comparison-range.tsx
 msgid "rangeplot.select.order.hint"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -557,6 +557,10 @@ msgstr "Voir le détail de la qualité de service"
 msgid "map.details-sidebar-panel.next-button.sunshine-overview"
 msgstr "Afficher tous les indicateurs d'ensoleillement"
 
+#: src/components/generic-map.tsx
+msgid "map.scrollzoom.hint"
+msgstr "Maintenir {key} et faire défiler pour zoomer"
+
 #: src/components/share-button.tsx
 msgid "map.share"
 msgstr "Partager"
@@ -570,7 +574,6 @@ msgid "municipality"
 msgstr "Commune"
 
 #: src/components/tariffs-trend-chart.tsx
-#: src/components/tariffs-trend-chart.tsx
 msgid "net-tariffs-trend-chart.legend-item.other-operators"
 msgstr "Autres opérateurs"
 
@@ -579,8 +582,6 @@ msgid "net-tariffs-trend-chart.legend-item.peer-group-median"
 msgstr "Médiane du groupe de référence"
 
 #: src/components/network-cost-trend-chart.tsx
-#: src/components/network-cost-trend-chart.tsx
-#: src/components/power-stability-chart.tsx
 msgid "network-cost-trend-chart.legend-item.other-operators"
 msgstr "Autres opérateurs"
 
@@ -723,6 +724,10 @@ msgstr "Montrer toutes les municipalités"
 #: src/domain/translation.tsx
 msgid "priceComponents.view.expanded.operators"
 msgstr "Montrer tous les gestionnaires"
+
+#: src/components/charts-generic/progress-overtime-chart.tsx
+msgid "progress-overtime-chart.legend-item.other-operators"
+msgstr "Autres opérateurs"
 
 #: src/components/detail-page/cantons-comparison-range.tsx
 msgid "rangeplot.select.order.hint"

--- a/src/locales/it/messages.po
+++ b/src/locales/it/messages.po
@@ -557,6 +557,10 @@ msgstr "La qualità del servizio in dettaglio"
 msgid "map.details-sidebar-panel.next-button.sunshine-overview"
 msgstr "Mostra tutti gli indicatori di luce solare"
 
+#: src/components/generic-map.tsx
+msgid "map.scrollzoom.hint"
+msgstr "Tenere premuto {key} e scorrere per zoomare"
+
 #: src/components/share-button.tsx
 msgid "map.share"
 msgstr "Condividi"
@@ -570,7 +574,6 @@ msgid "municipality"
 msgstr "Comune"
 
 #: src/components/tariffs-trend-chart.tsx
-#: src/components/tariffs-trend-chart.tsx
 msgid "net-tariffs-trend-chart.legend-item.other-operators"
 msgstr "Altri operatori"
 
@@ -579,8 +582,6 @@ msgid "net-tariffs-trend-chart.legend-item.peer-group-median"
 msgstr "Mediana del gruppo di riferimento"
 
 #: src/components/network-cost-trend-chart.tsx
-#: src/components/network-cost-trend-chart.tsx
-#: src/components/power-stability-chart.tsx
 msgid "network-cost-trend-chart.legend-item.other-operators"
 msgstr "Altri operatori"
 
@@ -723,6 +724,10 @@ msgstr "Mostrare tutti i comuni"
 #: src/domain/translation.tsx
 msgid "priceComponents.view.expanded.operators"
 msgstr "Mostrare tutti i gestori di rete"
+
+#: src/components/charts-generic/progress-overtime-chart.tsx
+msgid "progress-overtime-chart.legend-item.other-operators"
+msgstr "Altri operatori"
 
 #: src/components/detail-page/cantons-comparison-range.tsx
 msgid "rangeplot.select.order.hint"


### PR DESCRIPTION
On the sunshine map, the map is hijacking the scroll from the user.
It is an annoying behavior. The usual behavior for this type of maps is
to only allow scrolling if the user is holding some key.
This is what's implemented here.

## How to test

1. Go to the map
2. Scroll the page, see how the scroll is not taken by the map
3. See the help
4. Follow the help and see that you can scroll the map

Additionally, the scroll to zoom is not that interesting when users can
zoom to their municipality or canton via the list.

## Resources

Google Map documentation: they allow to opt out of this behavior via
gestureHandling: greedy.

https://developers.google.com/maps/documentation/javascript/interaction


