### PR TITLE
feat: Server side flags to allow for changing runtime flags

### DIFF
--- a/src/env/client.ts
+++ b/src/env/client.ts
@@ -13,7 +13,7 @@ const clientSchema = z.object({
         return FlagSchema.parse(JSON.parse(flags));
       } catch (error) {
         console.error("Failed to parse NEXT_PUBLIC_FLAGS:", error);
-        return;
+        return [];
       }
     }),
 });

--- a/src/env/schema.ts
+++ b/src/env/schema.ts
@@ -11,6 +11,20 @@ export const buildSchema = z.object({
 
 // Define the schema for server-side variables
 export const serverSchema = z.object({
+  // Runtime flags configuration
+  FLAGS: z
+    .string()
+    .optional()
+    .transform((flags) => {
+      if (!flags) return [];
+      try {
+        return z.array(z.string()).parse(JSON.parse(flags));
+      } catch (error) {
+        console.error("Failed to parse FLAGS:", error);
+        return [];
+      }
+    }),
+
   // Gever document download
   EIAM_CERTIFICATE_CONTENT: z.string().optional(),
   EIAM_CERTIFICATE_PASSWORD: z.string().optional(),

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,6 +15,7 @@ import { LocaleProvider } from "src/lib/use-locale";
 import { useNProgress } from "src/lib/use-nprogress";
 import { i18n, parseLocaleString } from "src/locales/locales";
 import { preloadFonts, theme } from "src/themes/elcom";
+import { useRuntimeFlags } from "src/utils/flags";
 
 import "src/styles/nprogress.css";
 
@@ -28,6 +29,8 @@ export default function App(props: AppProps & { emotionCache?: EmotionCache }) {
   const matomoId = useMatomo();
 
   useNProgress();
+  // Load runtime flags from server early in app lifecycle
+  useRuntimeFlags();
 
   // Immediately activate locale to avoid re-render
   if (i18n.locale !== locale) {

--- a/src/pages/api/flags.ts
+++ b/src/pages/api/flags.ts
@@ -1,0 +1,17 @@
+import serverEnv from "src/env/server";
+
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    // Return the runtime flags from server environment
+    res.status(200).json({ flags: serverEnv.FLAGS });
+  } catch (error) {
+    console.error("Error getting flags:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+}

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -1,3 +1,20 @@
+/**
+ * Flags System Overview:
+ *
+ * Flags can be set in multiple ways with the following priority (highest to lowest):
+ * 1. URL search parameters (e.g., ?flag.debug=true)
+ * 2. Runtime environment variables (process.env.FLAGS on server, fetched via /api/flags)
+ * 3. Build-time environment variables (process.env.NEXT_PUBLIC_FLAGS)
+ * 4. Programmatic defaults (development/preview environments)
+ *
+ * For runtime configuration, use process.env.FLAGS with a JSON array of flag names:
+ * FLAGS='["debug", "sunshine"]'
+ *
+ * Runtime flags are automatically loaded via useRuntimeFlags() hook called in _app.tsx.
+ */
+
+import { useEffect } from "react";
+
 import clientEnv from "src/env/client";
 import { createComponents, createHooks } from "src/flags";
 
@@ -34,6 +51,43 @@ export type StrompreiseFlag = keyof typeof F;
 const flagHooks = createHooks<StrompreiseFlag>("strompreise");
 const { flag, useFlag, useFlags } = flagHooks;
 const { FlagList } = createComponents(flagHooks);
+
+/**
+ * Custom hook to load runtime flags from the server.
+ * Should be called early in the application lifecycle (e.g., in _app.tsx).
+ */
+const useRuntimeFlags = () => {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const fetchRuntimeFlags = async () => {
+      try {
+        const response = await fetch("/api/flags");
+        if (response.ok) {
+          const data = await response.json();
+          const runtimeFlags = data.flags || [];
+
+          const toEnable = runtimeFlags.filter((x: string) => {
+            return flag(x) === null;
+          });
+
+          if (toEnable.length > 0) {
+            console.info(
+              `Enabling runtime flags ${toEnable.join(
+                ", "
+              )} from server environment (skipped already enabled flags)`
+            );
+            flag.enable(toEnable.map((envFlag: string) => [envFlag, true]));
+          }
+        }
+      } catch (error) {
+        console.error("Failed to fetch runtime flags:", error);
+      }
+    };
+
+    fetchRuntimeFlags();
+  }, []);
+};
 
 if (typeof window !== "undefined" && window.location) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -80,4 +134,4 @@ if (typeof window !== "undefined" && window.location) {
 /** @knipignore */
 export { flag, useFlags };
 
-export { FlagList, useFlag };
+export { FlagList, useFlag, useRuntimeFlags };


### PR DESCRIPTION
I had made a logic mistake before: in order for the flags to be set at runtime
through process.env, they should not be set via NEXT_PUBLIC (as those are
compiled through webpack, and then they cannot be changed directly at runtime).
Here, I add an /api route serving the runtime flags, and the flags are set
if they do not already have a value.
