### PR TITLE
Overview improvements

### DIFF
--- a/src/components/charts-generic/progress-overtime-chart.tsx
+++ b/src/components/charts-generic/progress-overtime-chart.tsx
@@ -35,12 +35,6 @@ interface ProgressOvertimeChartProps<
   entityField?: string;
   // Palette configuration
   paletteType?: "monochrome" | "elcom2";
-  // Interaction configuration
-  showInteractionsWhenComparing?: boolean;
-  // Legend configuration
-  showOtherOperatorsLegend?:
-    | boolean
-    | ((operatorsNames: Set<string>, compareWith: string[]) => boolean);
 }
 
 export const ProgressOvertimeChart = <T extends GenericObservation>(
@@ -57,17 +51,13 @@ export const ProgressOvertimeChart = <T extends GenericObservation>(
     yAxisLabel,
     entityField = "operator_id",
     paletteType = "monochrome",
-    showInteractionsWhenComparing = true,
-    showOtherOperatorsLegend = true,
   } = props;
 
   const formatCurrency = useFormatCurrency();
 
   // Determine if we should show interactions
   const hasNotSelectedAll = !compareWith.includes("sunshine.select-all");
-  const showInteractions = showInteractionsWhenComparing
-    ? hasNotSelectedAll
-    : true;
+  const showInteractions = hasNotSelectedAll;
 
   // Determine palette based on comparison selection
   const palette = compareWith.includes("sunshine.select-all")
@@ -75,15 +65,7 @@ export const ProgressOvertimeChart = <T extends GenericObservation>(
     : paletteType;
 
   // Determine if we should show the "Other operators" legend item
-  const shouldShowOtherOperatorsLegend = useMemo(() => {
-    if (typeof showOtherOperatorsLegend === "function") {
-      return showOtherOperatorsLegend(operatorsNames, compareWith);
-    }
-    if (typeof showOtherOperatorsLegend === "boolean") {
-      return showOtherOperatorsLegend && compareWith.length > 0;
-    }
-    return compareWith.length > 0;
-  }, [showOtherOperatorsLegend, operatorsNames, compareWith]);
+  const shouldShowOtherOperatorsLegend = compareWith.length > 0;
 
   // Put currently selected operatorLabel at the end of the list
   // This is a trick to ensure the selected operator is always on top of other operators

--- a/src/components/network-cost-trend-chart.tsx
+++ b/src/components/network-cost-trend-chart.tsx
@@ -195,8 +195,6 @@ const ProgressOvertimeChartView = (
       paletteType={
         compareWith.includes("sunshine.select-all") ? "monochrome" : "elcom2"
       }
-      showInteractionsWhenComparing={true}
-      showOtherOperatorsLegend={(_, compareWith) => compareWith.length > 0}
     />
   );
 };

--- a/src/components/operator-documents.stories.tsx
+++ b/src/components/operator-documents.stories.tsx
@@ -1,0 +1,111 @@
+import {
+  OperatorDocument,
+  OperatorDocumentCategory,
+} from "src/graphql/queries";
+
+import {
+  groupByCategory,
+  OperatorDocumentsPopoverContent,
+} from "./operator-documents";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof OperatorDocumentsPopoverContent> = {
+  title: "Components/OperatorPopoverContent",
+  component: OperatorDocumentsPopoverContent,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OperatorDocumentsPopoverContent>;
+
+// Mock data for stories
+const mockDocuments: OperatorDocument[] = [
+  {
+    __typename: "OperatorDocument",
+    id: "tariff-2024",
+    name: "Tariff Sheet 2024",
+    url: "#",
+    year: "2024",
+    category: OperatorDocumentCategory.Tariffs,
+  },
+  {
+    __typename: "OperatorDocument",
+    id: "tariff-2023",
+    name: "Tariff Sheet 2023",
+    url: "#",
+    year: "2023",
+    category: OperatorDocumentCategory.Tariffs,
+  },
+  {
+    __typename: "OperatorDocument",
+    id: "annual-2023",
+    name: "Annual Report 2023",
+    url: "#",
+    year: "2023",
+    category: OperatorDocumentCategory.AnnualReport,
+  },
+  {
+    __typename: "OperatorDocument",
+    id: "annual-2022",
+    name: "Annual Report 2022",
+    url: "#",
+    year: "2022",
+    category: OperatorDocumentCategory.AnnualReport,
+  },
+  {
+    __typename: "OperatorDocument",
+    id: "financial-2023",
+    name: "Financial Statement 2023",
+    url: "#",
+    year: "2023",
+    category: OperatorDocumentCategory.FinancialStatement,
+  },
+];
+
+export const Default: Story = {
+  args: {
+    id: "CH-123456",
+    documentsByCategory: groupByCategory(mockDocuments),
+  },
+};
+
+export const WithOnlyTariffs: Story = {
+  args: {
+    id: "CH-789012",
+    documentsByCategory: groupByCategory(
+      mockDocuments.filter(
+        (doc) => doc.category === OperatorDocumentCategory.Tariffs
+      )
+    ),
+  },
+};
+
+export const WithOnlyAnnualReports: Story = {
+  args: {
+    id: "CH-345678",
+    documentsByCategory: groupByCategory(
+      mockDocuments.filter(
+        (doc) => doc.category === OperatorDocumentCategory.AnnualReport
+      )
+    ),
+  },
+};
+
+export const EmptyState: Story = {
+  args: {
+    id: "CH-000000",
+    documentsByCategory: new Map(),
+  },
+};
+
+export const SingleDocument: Story = {
+  args: {
+    id: "CH-111111",
+    documentsByCategory: groupByCategory([mockDocuments[0]]),
+  },
+};

--- a/src/components/operator-documents.stories.tsx
+++ b/src/components/operator-documents.stories.tsx
@@ -69,14 +69,12 @@ const mockDocuments: OperatorDocument[] = [
 
 export const Default: Story = {
   args: {
-    id: "CH-123456",
     documentsByCategory: groupByCategory(mockDocuments),
   },
 };
 
 export const WithOnlyTariffs: Story = {
   args: {
-    id: "CH-789012",
     documentsByCategory: groupByCategory(
       mockDocuments.filter(
         (doc) => doc.category === OperatorDocumentCategory.Tariffs
@@ -87,7 +85,6 @@ export const WithOnlyTariffs: Story = {
 
 export const WithOnlyAnnualReports: Story = {
   args: {
-    id: "CH-345678",
     documentsByCategory: groupByCategory(
       mockDocuments.filter(
         (doc) => doc.category === OperatorDocumentCategory.AnnualReport
@@ -98,14 +95,12 @@ export const WithOnlyAnnualReports: Story = {
 
 export const EmptyState: Story = {
   args: {
-    id: "CH-000000",
     documentsByCategory: new Map(),
   },
 };
 
 export const SingleDocument: Story = {
   args: {
-    id: "CH-111111",
     documentsByCategory: groupByCategory([mockDocuments[0]]),
   },
 };

--- a/src/components/operator-documents.tsx
+++ b/src/components/operator-documents.tsx
@@ -220,6 +220,7 @@ export const OperatorDocuments = ({ id }: { id: string }) => {
         open={!!anchorEl}
         anchorEl={anchorEl}
         onClose={handleClose}
+        disableScrollLock
         anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
         slotProps={{
           paper: {

--- a/src/components/operator-documents.tsx
+++ b/src/components/operator-documents.tsx
@@ -104,10 +104,8 @@ const DocumentList = ({
 };
 
 export const OperatorDocumentsPopoverContent = ({
-  id,
   documentsByCategory,
 }: {
-  id: string;
   documentsByCategory:
     | Map<OperatorDocumentCategory, OperatorDocument[]>
     | Map<OperatorDocumentCategory | null | undefined, OperatorDocument[]>;
@@ -117,11 +115,9 @@ export const OperatorDocumentsPopoverContent = ({
   return (
     <>
       <Stack direction={"column"} spacing={2} py={8} px={10}>
-        <Typography variant="h5" fontWeight={700}>
+        <Typography variant="h4" fontWeight={700}>
           <Trans id="download.reports">Download reports</Trans>
         </Typography>
-
-        <Typography variant="h2">{id}</Typography>
       </Stack>
 
       {CATEGORIES.map((category) => {
@@ -235,7 +231,6 @@ export const OperatorDocuments = ({ id }: { id: string }) => {
         }}
       >
         <OperatorDocumentsPopoverContent
-          id={id}
           documentsByCategory={documentsByCategory}
         />
       </Popover>

--- a/src/components/power-stability-chart.tsx
+++ b/src/components/power-stability-chart.tsx
@@ -308,8 +308,6 @@ const ProgressOvertimeChartView = (
       yField={duration}
       entityField="operator"
       paletteType="monochrome"
-      showInteractionsWhenComparing={false}
-      showOtherOperatorsLegend={(_, compareWith) => compareWith.length > 0}
     />
   );
 };

--- a/src/components/sunshine-tabs.tsx
+++ b/src/components/sunshine-tabs.tsx
@@ -1,5 +1,5 @@
 import { Trans } from "@lingui/macro";
-import { Tab, Tabs } from "@mui/material";
+import { Tab, Tabs, TabsProps } from "@mui/material";
 import React from "react";
 
 export type CostAndTariffsTab = "networkCosts" | "netTariffs" | "energyTariffs";
@@ -115,15 +115,14 @@ export type YearlyNavigationProps = {
   handleTabChange: (event: React.SyntheticEvent, newValue: YearlyTab) => void;
 };
 
-export const YearlyNavigation: React.FC<YearlyNavigationProps> = ({
-  activeTab,
-  handleTabChange,
-}) => {
+export const YearlyNavigation: React.FC<
+  YearlyNavigationProps & Omit<TabsProps, "onChange">
+> = ({ activeTab, handleTabChange, ...props }) => {
   const currentYear = new Date().getFullYear();
   const years = [currentYear - 2, currentYear - 1, currentYear];
 
   return (
-    <Tabs value={activeTab} onChange={handleTabChange}>
+    <Tabs value={activeTab} onChange={handleTabChange} {...props}>
       {years.map((year) => (
         <Tab
           key={year}

--- a/src/components/sunshine-tabs.tsx
+++ b/src/components/sunshine-tabs.tsx
@@ -110,7 +110,7 @@ export const OperationalStandardsNavigation: React.FC<{
 
 type YearlyTab = `${number}`;
 
-export type YearlyNavigationProps = {
+type YearlyNavigationProps = {
   activeTab: string;
   handleTabChange: (event: React.SyntheticEvent, newValue: YearlyTab) => void;
 };

--- a/src/components/table-comparison-card.tsx
+++ b/src/components/table-comparison-card.tsx
@@ -14,12 +14,11 @@ import ComparisonTable from "src/components/comparison-table";
 import UnitValueWithTrend from "src/components/unit-value-with-trend";
 import { Trend } from "src/graphql/resolver-types";
 
-import { YearlyNavigation, YearlyNavigationProps } from "./sunshine-tabs";
-
 const TableComparisonCard: React.FC<
   {
     title: React.ReactNode;
     subtitle: React.ReactNode;
+    description?: React.ReactNode;
 
     linkContent?: React.ReactNode;
     rows: {
@@ -33,33 +32,19 @@ const TableComparisonCard: React.FC<
           }
         | { value: React.ReactElement | string };
     }[];
-  } & Omit<CardProps, "title" | "subtitle" | "rows"> &
-    Partial<YearlyNavigationProps>
-> = ({
-  title,
-  subtitle,
-  rows,
-  linkContent,
-  activeTab,
-  handleTabChange,
-  ...props
-}) => (
+  } & Omit<CardProps, "title" | "subtitle" | "rows">
+> = ({ title, subtitle, rows, linkContent, description, ...props }) => (
   <Card {...props}>
     <CardContent>
       <Typography variant="h3" gutterBottom>
         {title}
       </Typography>
-      {(!activeTab || !handleTabChange) && (
+      {subtitle && (
         <Typography variant="subtitle2" color="text.secondary" gutterBottom>
           {subtitle}
         </Typography>
       )}
-      {activeTab && handleTabChange && (
-        <YearlyNavigation
-          activeTab={activeTab}
-          handleTabChange={handleTabChange}
-        />
-      )}
+      {description}
       <ComparisonTable size="small">
         <TableBody>
           {rows.map((row, index) => (

--- a/src/components/tariffs-trend-chart.tsx
+++ b/src/components/tariffs-trend-chart.tsx
@@ -168,8 +168,6 @@ const ProgressOvertimeChartView = (
       yAxisLabel={RP_PER_KM}
       entityField="operator_id"
       paletteType="monochrome"
-      showInteractionsWhenComparing={true}
-      showOtherOperatorsLegend={(_, compareWith) => compareWith.length > 0}
     />
   );
 };

--- a/src/graphql/queries.graphql
+++ b/src/graphql/queries.graphql
@@ -273,3 +273,43 @@ query SunshineTariffByIndicator(
     value
   }
 }
+
+query OperationalStandards($filter: OperationalStandardsFilter!) {
+  operationalStandards(filter: $filter) {
+    latestYear
+    operator {
+      peerGroup {
+        settlementDensity
+        energyDensity
+      }
+    }
+    productVariety {
+      ecoFriendlyProductsOffered
+      productCombinationsOptions
+      operatorsProductsOffered {
+        operatorId
+        ecoFriendlyProductsOffered
+        year
+      }
+    }
+    serviceQuality {
+      notificationPeriodDays
+      informingCustomersOfOutage
+      operatorsNotificationPeriodDays {
+        operatorId
+        days
+        year
+      }
+    }
+    compliance {
+      francsRule
+      timelyPaperSubmission
+      operatorsFrancsPerInvoice {
+        operatorId
+        francsPerInvoice
+        year
+      }
+    }
+    updateDate
+  }
+}

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -135,6 +135,68 @@ export enum ObservationKind {
   Municipality = "Municipality",
 }
 
+export type OperationalStandardsCompliance = {
+  __typename: "OperationalStandardsCompliance";
+  francsRule: Scalars["String"]["output"];
+  operatorsFrancsPerInvoice: Array<OperationalStandardsOperatorFrancs>;
+  timelyPaperSubmission: Scalars["Boolean"]["output"];
+};
+
+export type OperationalStandardsData = {
+  __typename: "OperationalStandardsData";
+  compliance: OperationalStandardsCompliance;
+  latestYear: Scalars["String"]["output"];
+  operator: OperationalStandardsOperator;
+  productVariety: OperationalStandardsProductVariety;
+  serviceQuality: OperationalStandardsServiceQuality;
+  updateDate: Scalars["String"]["output"];
+};
+
+export type OperationalStandardsFilter = {
+  operatorId: Scalars["Int"]["input"];
+  period: Scalars["Int"]["input"];
+};
+
+export type OperationalStandardsOperator = {
+  __typename: "OperationalStandardsOperator";
+  peerGroup: PeerGroup;
+};
+
+export type OperationalStandardsOperatorFrancs = {
+  __typename: "OperationalStandardsOperatorFrancs";
+  francsPerInvoice: Scalars["Float"]["output"];
+  operatorId: Scalars["String"]["output"];
+  year: Scalars["String"]["output"];
+};
+
+export type OperationalStandardsOperatorNotification = {
+  __typename: "OperationalStandardsOperatorNotification";
+  days: Scalars["Int"]["output"];
+  operatorId: Scalars["String"]["output"];
+  year: Scalars["String"]["output"];
+};
+
+export type OperationalStandardsOperatorProduct = {
+  __typename: "OperationalStandardsOperatorProduct";
+  ecoFriendlyProductsOffered: Scalars["Int"]["output"];
+  operatorId: Scalars["String"]["output"];
+  year: Scalars["String"]["output"];
+};
+
+export type OperationalStandardsProductVariety = {
+  __typename: "OperationalStandardsProductVariety";
+  ecoFriendlyProductsOffered: Scalars["Int"]["output"];
+  operatorsProductsOffered: Array<OperationalStandardsOperatorProduct>;
+  productCombinationsOptions: Scalars["Boolean"]["output"];
+};
+
+export type OperationalStandardsServiceQuality = {
+  __typename: "OperationalStandardsServiceQuality";
+  informingCustomersOfOutage: Scalars["Boolean"]["output"];
+  notificationPeriodDays: Scalars["Int"]["output"];
+  operatorsNotificationPeriodDays: Array<OperationalStandardsOperatorNotification>;
+};
+
 export type Operator = {
   __typename: "Operator";
   cantons: Array<Canton>;
@@ -214,6 +276,7 @@ export type Query = {
   netTariffs: TariffsData;
   networkCosts: NetworkCostsData;
   observations?: Maybe<Array<OperatorObservation>>;
+  operationalStandards: OperationalStandardsData;
   operator?: Maybe<Operator>;
   operators: Array<Operator>;
   saidi: StabilityData;
@@ -279,6 +342,10 @@ export type QueryObservationsArgs = {
   filters?: InputMaybe<ObservationFilters>;
   locale?: InputMaybe<Scalars["String"]["input"]>;
   observationKind?: InputMaybe<ObservationKind>;
+};
+
+export type QueryOperationalStandardsArgs = {
+  filter: OperationalStandardsFilter;
 };
 
 export type QueryOperatorArgs = {
@@ -876,6 +943,60 @@ export type SunshineTariffByIndicatorQuery = {
   }>;
 };
 
+export type OperationalStandardsQueryVariables = Exact<{
+  filter: OperationalStandardsFilter;
+}>;
+
+export type OperationalStandardsQuery = {
+  __typename: "Query";
+  operationalStandards: {
+    __typename: "OperationalStandardsData";
+    latestYear: string;
+    updateDate: string;
+    operator: {
+      __typename: "OperationalStandardsOperator";
+      peerGroup: {
+        __typename: "PeerGroup";
+        settlementDensity?: string | null;
+        energyDensity?: string | null;
+      };
+    };
+    productVariety: {
+      __typename: "OperationalStandardsProductVariety";
+      ecoFriendlyProductsOffered: number;
+      productCombinationsOptions: boolean;
+      operatorsProductsOffered: Array<{
+        __typename: "OperationalStandardsOperatorProduct";
+        operatorId: string;
+        ecoFriendlyProductsOffered: number;
+        year: string;
+      }>;
+    };
+    serviceQuality: {
+      __typename: "OperationalStandardsServiceQuality";
+      notificationPeriodDays: number;
+      informingCustomersOfOutage: boolean;
+      operatorsNotificationPeriodDays: Array<{
+        __typename: "OperationalStandardsOperatorNotification";
+        operatorId: string;
+        days: number;
+        year: string;
+      }>;
+    };
+    compliance: {
+      __typename: "OperationalStandardsCompliance";
+      francsRule: string;
+      timelyPaperSubmission: boolean;
+      operatorsFrancsPerInvoice: Array<{
+        __typename: "OperationalStandardsOperatorFrancs";
+        operatorId: string;
+        francsPerInvoice: number;
+        year: string;
+      }>;
+    };
+  };
+};
+
 export type NetworkCostsQueryVariables = Exact<{
   filter: NetworkCostsFilter;
 }>;
@@ -1426,6 +1547,56 @@ export function useSunshineTariffByIndicatorQuery(
     SunshineTariffByIndicatorQuery,
     SunshineTariffByIndicatorQueryVariables
   >({ query: SunshineTariffByIndicatorDocument, ...options });
+}
+export const OperationalStandardsDocument = gql`
+  query OperationalStandards($filter: OperationalStandardsFilter!) {
+    operationalStandards(filter: $filter) {
+      latestYear
+      operator {
+        peerGroup {
+          settlementDensity
+          energyDensity
+        }
+      }
+      productVariety {
+        ecoFriendlyProductsOffered
+        productCombinationsOptions
+        operatorsProductsOffered {
+          operatorId
+          ecoFriendlyProductsOffered
+          year
+        }
+      }
+      serviceQuality {
+        notificationPeriodDays
+        informingCustomersOfOutage
+        operatorsNotificationPeriodDays {
+          operatorId
+          days
+          year
+        }
+      }
+      compliance {
+        francsRule
+        timelyPaperSubmission
+        operatorsFrancsPerInvoice {
+          operatorId
+          francsPerInvoice
+          year
+        }
+      }
+      updateDate
+    }
+  }
+`;
+
+export function useOperationalStandardsQuery(
+  options: Omit<Urql.UseQueryArgs<OperationalStandardsQueryVariables>, "query">
+) {
+  return Urql.useQuery<
+    OperationalStandardsQuery,
+    OperationalStandardsQueryVariables
+  >({ query: OperationalStandardsDocument, ...options });
 }
 export const NetworkCostsDocument = gql`
   query NetworkCosts($filter: NetworkCostsFilter!) {

--- a/src/graphql/resolver-types.ts
+++ b/src/graphql/resolver-types.ts
@@ -151,6 +151,68 @@ export enum ObservationKind {
   Municipality = "Municipality",
 }
 
+export type OperationalStandardsCompliance = {
+  __typename?: "OperationalStandardsCompliance";
+  francsRule: Scalars["String"]["output"];
+  operatorsFrancsPerInvoice: Array<OperationalStandardsOperatorFrancs>;
+  timelyPaperSubmission: Scalars["Boolean"]["output"];
+};
+
+export type OperationalStandardsData = {
+  __typename?: "OperationalStandardsData";
+  compliance: OperationalStandardsCompliance;
+  latestYear: Scalars["String"]["output"];
+  operator: OperationalStandardsOperator;
+  productVariety: OperationalStandardsProductVariety;
+  serviceQuality: OperationalStandardsServiceQuality;
+  updateDate: Scalars["String"]["output"];
+};
+
+export type OperationalStandardsFilter = {
+  operatorId: Scalars["Int"]["input"];
+  period: Scalars["Int"]["input"];
+};
+
+export type OperationalStandardsOperator = {
+  __typename?: "OperationalStandardsOperator";
+  peerGroup: PeerGroup;
+};
+
+export type OperationalStandardsOperatorFrancs = {
+  __typename?: "OperationalStandardsOperatorFrancs";
+  francsPerInvoice: Scalars["Float"]["output"];
+  operatorId: Scalars["String"]["output"];
+  year: Scalars["String"]["output"];
+};
+
+export type OperationalStandardsOperatorNotification = {
+  __typename?: "OperationalStandardsOperatorNotification";
+  days: Scalars["Int"]["output"];
+  operatorId: Scalars["String"]["output"];
+  year: Scalars["String"]["output"];
+};
+
+export type OperationalStandardsOperatorProduct = {
+  __typename?: "OperationalStandardsOperatorProduct";
+  ecoFriendlyProductsOffered: Scalars["Int"]["output"];
+  operatorId: Scalars["String"]["output"];
+  year: Scalars["String"]["output"];
+};
+
+export type OperationalStandardsProductVariety = {
+  __typename?: "OperationalStandardsProductVariety";
+  ecoFriendlyProductsOffered: Scalars["Int"]["output"];
+  operatorsProductsOffered: Array<OperationalStandardsOperatorProduct>;
+  productCombinationsOptions: Scalars["Boolean"]["output"];
+};
+
+export type OperationalStandardsServiceQuality = {
+  __typename?: "OperationalStandardsServiceQuality";
+  informingCustomersOfOutage: Scalars["Boolean"]["output"];
+  notificationPeriodDays: Scalars["Int"]["output"];
+  operatorsNotificationPeriodDays: Array<OperationalStandardsOperatorNotification>;
+};
+
 export type Operator = {
   __typename?: "Operator";
   cantons: Array<Canton>;
@@ -230,6 +292,7 @@ export type Query = {
   netTariffs: TariffsData;
   networkCosts: NetworkCostsData;
   observations?: Maybe<Array<OperatorObservation>>;
+  operationalStandards: OperationalStandardsData;
   operator?: Maybe<Operator>;
   operators: Array<Operator>;
   saidi: StabilityData;
@@ -295,6 +358,10 @@ export type QueryObservationsArgs = {
   filters?: InputMaybe<ObservationFilters>;
   locale?: InputMaybe<Scalars["String"]["input"]>;
   observationKind?: InputMaybe<ObservationKind>;
+};
+
+export type QueryOperationalStandardsArgs = {
+  filter: OperationalStandardsFilter;
 };
 
 export type QueryOperatorArgs = {
@@ -645,6 +712,15 @@ export type ResolversTypes = ResolversObject<{
   Observation: ResolverTypeWrapper<ResolvedObservation>;
   ObservationFilters: ObservationFilters;
   ObservationKind: ObservationKind;
+  OperationalStandardsCompliance: ResolverTypeWrapper<OperationalStandardsCompliance>;
+  OperationalStandardsData: ResolverTypeWrapper<OperationalStandardsData>;
+  OperationalStandardsFilter: OperationalStandardsFilter;
+  OperationalStandardsOperator: ResolverTypeWrapper<OperationalStandardsOperator>;
+  OperationalStandardsOperatorFrancs: ResolverTypeWrapper<OperationalStandardsOperatorFrancs>;
+  OperationalStandardsOperatorNotification: ResolverTypeWrapper<OperationalStandardsOperatorNotification>;
+  OperationalStandardsOperatorProduct: ResolverTypeWrapper<OperationalStandardsOperatorProduct>;
+  OperationalStandardsProductVariety: ResolverTypeWrapper<OperationalStandardsProductVariety>;
+  OperationalStandardsServiceQuality: ResolverTypeWrapper<OperationalStandardsServiceQuality>;
   Operator: ResolverTypeWrapper<ResolvedOperator>;
   OperatorDocument: ResolverTypeWrapper<OperatorDocument>;
   OperatorDocumentCategory: OperatorDocumentCategory;
@@ -692,6 +768,15 @@ export type ResolversParentTypes = ResolversObject<{
   NetworkLevel: NetworkLevel;
   Observation: ResolvedObservation;
   ObservationFilters: ObservationFilters;
+  OperationalStandardsCompliance: OperationalStandardsCompliance;
+  OperationalStandardsData: OperationalStandardsData;
+  OperationalStandardsFilter: OperationalStandardsFilter;
+  OperationalStandardsOperator: OperationalStandardsOperator;
+  OperationalStandardsOperatorFrancs: OperationalStandardsOperatorFrancs;
+  OperationalStandardsOperatorNotification: OperationalStandardsOperatorNotification;
+  OperationalStandardsOperatorProduct: OperationalStandardsOperatorProduct;
+  OperationalStandardsProductVariety: OperationalStandardsProductVariety;
+  OperationalStandardsServiceQuality: OperationalStandardsServiceQuality;
   Operator: ResolvedOperator;
   OperatorDocument: OperatorDocument;
   OperatorObservation: ResolvedOperatorObservation;
@@ -895,6 +980,139 @@ export type ObservationResolvers<
   >;
 }>;
 
+export type OperationalStandardsComplianceResolvers<
+  ContextType = ServerContext,
+  ParentType extends ResolversParentTypes["OperationalStandardsCompliance"] = ResolversParentTypes["OperationalStandardsCompliance"]
+> = ResolversObject<{
+  francsRule?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  operatorsFrancsPerInvoice?: Resolver<
+    Array<ResolversTypes["OperationalStandardsOperatorFrancs"]>,
+    ParentType,
+    ContextType
+  >;
+  timelyPaperSubmission?: Resolver<
+    ResolversTypes["Boolean"],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type OperationalStandardsDataResolvers<
+  ContextType = ServerContext,
+  ParentType extends ResolversParentTypes["OperationalStandardsData"] = ResolversParentTypes["OperationalStandardsData"]
+> = ResolversObject<{
+  compliance?: Resolver<
+    ResolversTypes["OperationalStandardsCompliance"],
+    ParentType,
+    ContextType
+  >;
+  latestYear?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  operator?: Resolver<
+    ResolversTypes["OperationalStandardsOperator"],
+    ParentType,
+    ContextType
+  >;
+  productVariety?: Resolver<
+    ResolversTypes["OperationalStandardsProductVariety"],
+    ParentType,
+    ContextType
+  >;
+  serviceQuality?: Resolver<
+    ResolversTypes["OperationalStandardsServiceQuality"],
+    ParentType,
+    ContextType
+  >;
+  updateDate?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type OperationalStandardsOperatorResolvers<
+  ContextType = ServerContext,
+  ParentType extends ResolversParentTypes["OperationalStandardsOperator"] = ResolversParentTypes["OperationalStandardsOperator"]
+> = ResolversObject<{
+  peerGroup?: Resolver<ResolversTypes["PeerGroup"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type OperationalStandardsOperatorFrancsResolvers<
+  ContextType = ServerContext,
+  ParentType extends ResolversParentTypes["OperationalStandardsOperatorFrancs"] = ResolversParentTypes["OperationalStandardsOperatorFrancs"]
+> = ResolversObject<{
+  francsPerInvoice?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
+  operatorId?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  year?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type OperationalStandardsOperatorNotificationResolvers<
+  ContextType = ServerContext,
+  ParentType extends ResolversParentTypes["OperationalStandardsOperatorNotification"] = ResolversParentTypes["OperationalStandardsOperatorNotification"]
+> = ResolversObject<{
+  days?: Resolver<ResolversTypes["Int"], ParentType, ContextType>;
+  operatorId?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  year?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type OperationalStandardsOperatorProductResolvers<
+  ContextType = ServerContext,
+  ParentType extends ResolversParentTypes["OperationalStandardsOperatorProduct"] = ResolversParentTypes["OperationalStandardsOperatorProduct"]
+> = ResolversObject<{
+  ecoFriendlyProductsOffered?: Resolver<
+    ResolversTypes["Int"],
+    ParentType,
+    ContextType
+  >;
+  operatorId?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  year?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type OperationalStandardsProductVarietyResolvers<
+  ContextType = ServerContext,
+  ParentType extends ResolversParentTypes["OperationalStandardsProductVariety"] = ResolversParentTypes["OperationalStandardsProductVariety"]
+> = ResolversObject<{
+  ecoFriendlyProductsOffered?: Resolver<
+    ResolversTypes["Int"],
+    ParentType,
+    ContextType
+  >;
+  operatorsProductsOffered?: Resolver<
+    Array<ResolversTypes["OperationalStandardsOperatorProduct"]>,
+    ParentType,
+    ContextType
+  >;
+  productCombinationsOptions?: Resolver<
+    ResolversTypes["Boolean"],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type OperationalStandardsServiceQualityResolvers<
+  ContextType = ServerContext,
+  ParentType extends ResolversParentTypes["OperationalStandardsServiceQuality"] = ResolversParentTypes["OperationalStandardsServiceQuality"]
+> = ResolversObject<{
+  informingCustomersOfOutage?: Resolver<
+    ResolversTypes["Boolean"],
+    ParentType,
+    ContextType
+  >;
+  notificationPeriodDays?: Resolver<
+    ResolversTypes["Int"],
+    ParentType,
+    ContextType
+  >;
+  operatorsNotificationPeriodDays?: Resolver<
+    Array<ResolversTypes["OperationalStandardsOperatorNotification"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type OperatorResolvers<
   ContextType = ServerContext,
   ParentType extends ResolversParentTypes["Operator"] = ResolversParentTypes["Operator"]
@@ -1069,6 +1287,12 @@ export type QueryResolvers<
     ParentType,
     ContextType,
     Partial<QueryObservationsArgs>
+  >;
+  operationalStandards?: Resolver<
+    ResolversTypes["OperationalStandardsData"],
+    ParentType,
+    ContextType,
+    RequireFields<QueryOperationalStandardsArgs, "filter">
   >;
   operator?: Resolver<
     Maybe<ResolversTypes["Operator"]>,
@@ -1400,6 +1624,14 @@ export type Resolvers<ContextType = ServerContext> = ResolversObject<{
   NetworkCostsData?: NetworkCostsDataResolvers<ContextType>;
   NetworkLevel?: NetworkLevelResolvers<ContextType>;
   Observation?: ObservationResolvers<ContextType>;
+  OperationalStandardsCompliance?: OperationalStandardsComplianceResolvers<ContextType>;
+  OperationalStandardsData?: OperationalStandardsDataResolvers<ContextType>;
+  OperationalStandardsOperator?: OperationalStandardsOperatorResolvers<ContextType>;
+  OperationalStandardsOperatorFrancs?: OperationalStandardsOperatorFrancsResolvers<ContextType>;
+  OperationalStandardsOperatorNotification?: OperationalStandardsOperatorNotificationResolvers<ContextType>;
+  OperationalStandardsOperatorProduct?: OperationalStandardsOperatorProductResolvers<ContextType>;
+  OperationalStandardsProductVariety?: OperationalStandardsProductVarietyResolvers<ContextType>;
+  OperationalStandardsServiceQuality?: OperationalStandardsServiceQualityResolvers<ContextType>;
   Operator?: OperatorResolvers<ContextType>;
   OperatorDocument?: OperatorDocumentResolvers<ContextType>;
   OperatorObservation?: OperatorObservationResolvers<ContextType>;

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -29,6 +29,7 @@ import {
   fetchEnergyTariffsData,
   fetchNetTariffsData,
   fetchNetworkCostsData,
+  fetchOperationalStandards,
   fetchSaidi,
   fetchSaifi,
 } from "src/lib/sunshine-data";
@@ -505,6 +506,12 @@ const Query: QueryResolvers = {
     return await fetchSaifi(context.sunshineDataService, {
       operatorId: filter.operatorId,
       period: filter.year,
+    });
+  },
+  operationalStandards: async (_, { filter }, context) => {
+    return await fetchOperationalStandards(context.sunshineDataService, {
+      operatorId: filter.operatorId.toString(),
+      period: filter.period,
     });
   },
 };

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -100,7 +100,9 @@ const Query: QueryResolvers = {
       const medianParams = createIndicatorMedianParams(filter);
       if (medianParams) {
         const medianRows = sortBy(
-          await context.sunshineDataService.getIndicatorMedian(medianParams),
+          await context.sunshineDataService.getYearlyIndicatorMedians(
+            medianParams
+          ),
           (x) => x.period
         );
         const medianResult = filter.period

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -340,6 +340,60 @@ input StabilityFilter {
   year: Int!
 }
 
+type OperationalStandardsProductVariety {
+  ecoFriendlyProductsOffered: Int!
+  productCombinationsOptions: Boolean!
+  operatorsProductsOffered: [OperationalStandardsOperatorProduct!]!
+}
+
+type OperationalStandardsOperatorProduct {
+  operatorId: String!
+  ecoFriendlyProductsOffered: Int!
+  year: String!
+}
+
+type OperationalStandardsServiceQuality {
+  notificationPeriodDays: Int!
+  informingCustomersOfOutage: Boolean!
+  operatorsNotificationPeriodDays: [OperationalStandardsOperatorNotification!]!
+}
+
+type OperationalStandardsOperatorNotification {
+  operatorId: String!
+  days: Int!
+  year: String!
+}
+
+type OperationalStandardsCompliance {
+  francsRule: String!
+  timelyPaperSubmission: Boolean!
+  operatorsFrancsPerInvoice: [OperationalStandardsOperatorFrancs!]!
+}
+
+type OperationalStandardsOperatorFrancs {
+  operatorId: String!
+  francsPerInvoice: Float!
+  year: String!
+}
+
+type OperationalStandardsOperator {
+  peerGroup: PeerGroup!
+}
+
+type OperationalStandardsData {
+  latestYear: String!
+  operator: OperationalStandardsOperator!
+  productVariety: OperationalStandardsProductVariety!
+  serviceQuality: OperationalStandardsServiceQuality!
+  compliance: OperationalStandardsCompliance!
+  updateDate: String!
+}
+
+input OperationalStandardsFilter {
+  operatorId: Int!
+  period: Int!
+}
+
 type Query {
   sunshineData(filter: SunshineDataFilter!): [SunshineDataRow!]!
   sunshineTariffs(filter: SunshineDataFilter!): [SunshineDataRow!]!
@@ -357,4 +411,7 @@ type Query {
 
   saidi(filter: StabilityFilter!): StabilityData!
   saifi(filter: StabilityFilter!): StabilityData!
+  operationalStandards(
+    filter: OperationalStandardsFilter!
+  ): OperationalStandardsData!
 }

--- a/src/lib/db/sparql.integration.spec.ts
+++ b/src/lib/db/sparql.integration.spec.ts
@@ -309,9 +309,9 @@ describe("SPARQL Sunshine Data Service", () => {
     });
   });
 
-  describe("getIndicatorMedian", () => {
+  describe("getYearlyIndicatorMedians", () => {
     it("should return median network costs for a peer group", async () => {
-      const result = await sunshineDataServiceSparql.getIndicatorMedian({
+      const result = await sunshineDataServiceSparql.getYearlyIndicatorMedians({
         // TODO To review, how to get peer groups correctly
         peerGroup: "A",
         metric: "network_costs",
@@ -328,7 +328,7 @@ describe("SPARQL Sunshine Data Service", () => {
     });
 
     it("should return median stability metrics for a peer group", async () => {
-      const result = await sunshineDataServiceSparql.getIndicatorMedian({
+      const result = await sunshineDataServiceSparql.getYearlyIndicatorMedians({
         peerGroup: "A",
         metric: "stability",
         period: 2025,
@@ -345,7 +345,7 @@ describe("SPARQL Sunshine Data Service", () => {
     });
 
     it("should return median operational standards for a peer group", async () => {
-      const result = await sunshineDataServiceSparql.getIndicatorMedian({
+      const result = await sunshineDataServiceSparql.getYearlyIndicatorMedians({
         peerGroup: "A",
         metric: "operational",
         period: 2025,
@@ -361,7 +361,7 @@ describe("SPARQL Sunshine Data Service", () => {
     });
 
     it("should return median energy tariffs for a peer group", async () => {
-      const result = await sunshineDataServiceSparql.getIndicatorMedian({
+      const result = await sunshineDataServiceSparql.getYearlyIndicatorMedians({
         peerGroup: "A",
         metric: "energy-tariffs",
         category: "C2",
@@ -377,7 +377,7 @@ describe("SPARQL Sunshine Data Service", () => {
     });
 
     it("should return median net tariffs for a peer group", async () => {
-      const result = await sunshineDataServiceSparql.getIndicatorMedian({
+      const result = await sunshineDataServiceSparql.getYearlyIndicatorMedians({
         peerGroup: "A",
         metric: "net-tariffs",
         category: "C2",

--- a/src/lib/db/sparql.ts
+++ b/src/lib/db/sparql.ts
@@ -498,7 +498,7 @@ const getOperatorData = async (
   };
 };
 
-const getIndicatorMedian = async <
+const getYearlyIndicatorMedians = async <
   Metric extends IndicatorMedianParams["metric"]
 >(
   params: IndicatorMedianParams
@@ -1085,7 +1085,7 @@ export const sunshineDataServiceSparql = {
   getStabilityMetrics,
   getTariffs,
   getOperatorData,
-  getIndicatorMedian,
+  getYearlyIndicatorMedians,
   getLatestYearSunshine,
   getLatestYearPowerStability,
   getPeerGroup,

--- a/src/lib/db/sql.ts
+++ b/src/lib/db/sql.ts
@@ -244,7 +244,7 @@ const getPeerGroupIdFromSettlementAndEnergyDensity = (
   return peerGroup[0]; // Return the key (peer group letter)
 };
 
-const getIndicatorMedian = async <
+const getYearlyIndicatorMedians = async <
   Metric extends IndicatorMedianParams["metric"]
 >(
   params: IndicatorMedianParams
@@ -563,7 +563,7 @@ export const sunshineDataServiceSql = {
   getStabilityMetrics,
   getTariffs,
   getOperatorData,
-  getIndicatorMedian,
+  getYearlyIndicatorMedians,
   getLatestYearSunshine,
   getLatestYearPowerStability,
   getPeerGroup,

--- a/src/lib/db/sql.ts
+++ b/src/lib/db/sql.ts
@@ -24,26 +24,28 @@ import type {
 const getNetworkCosts = async ({
   operatorId,
   period,
-  settlementDensity,
-  energyDensity,
+  peerGroup,
   networkLevel,
 }: {
   operatorId?: number;
   period?: number;
-  settlementDensity?: string;
-  energyDensity?: string;
+  peerGroup?: string;
   networkLevel?: NetworkLevel["id"];
 } = {}): Promise<NetworkCostRecord[]> => {
   const operatorFilter = operatorId ? `operator_id = ${operatorId}` : "1=1"; // Default to all operators
 
   // Instead of querying sunshine_all with filters
   const periodFilter = period ? `AND period = ${period}` : "";
-  const settlementDensityFilter = settlementDensity
-    ? `AND settlement_density = '${settlementDensity}'`
-    : "";
-  const energyDensityFilter = energyDensity
-    ? `AND energy_density = '${energyDensity}'`
-    : "";
+
+  let peerGroupFilter = ""; // Default to no filter (all data)
+  if (peerGroup) {
+    const { settlementDensity, energyDensity } =
+      getSettlementAndEnergyDensity(peerGroup);
+    peerGroupFilter = `
+      AND settlement_density = '${settlementDensity}'
+      AND energy_density = '${energyDensity}'
+    `;
+  }
   const networkLevelFilter = networkLevel
     ? `AND network_level = '${networkLevel}'`
     : "";
@@ -55,7 +57,7 @@ const getNetworkCosts = async ({
         network_level,
         cost as rate, -- TODO
       FROM network_costs
-      WHERE ${operatorFilter} ${periodFilter} ${settlementDensityFilter} ${energyDensityFilter} ${networkLevelFilter}
+      WHERE ${operatorFilter} ${periodFilter} ${peerGroupFilter} ${networkLevelFilter}
       ORDER BY period DESC, operator_id, network_level
     `;
 
@@ -95,22 +97,24 @@ const getOperationalStandards = async ({
 const getStabilityMetrics = async ({
   operatorId,
   period,
-  settlement_density,
-  energy_density,
+  peerGroup,
 }: {
   operatorId?: number;
   period?: number;
-  settlement_density?: string;
-  energy_density?: string;
+  peerGroup?: string;
 }): Promise<StabilityMetricRecord[]> => {
   const operatorFilter = operatorId ? `operator_id = ${operatorId}` : "1=1"; // Default to all operators
   const periodFilter = period ? `AND period = ${period}` : "";
-  const settlementDensityFilter = settlement_density
-    ? `AND settlement_density = '${settlement_density}'`
-    : "";
-  const energyDensityFilter = energy_density
-    ? `AND energy_density = '${energy_density}'`
-    : "";
+
+  let peerGroupFilter = ""; // Default to no filter (all data)
+  if (peerGroup) {
+    const { settlementDensity, energyDensity } =
+      getSettlementAndEnergyDensity(peerGroup);
+    peerGroupFilter = `
+      AND settlement_density = '${settlementDensity}'
+      AND energy_density = '${energyDensity}'
+    `;
+  }
 
   const sql = `
       SELECT
@@ -122,7 +126,7 @@ const getStabilityMetrics = async ({
         saifi_total,
         saifi_unplanned
       FROM stability_metrics
-      WHERE ${operatorFilter} ${periodFilter} ${settlementDensityFilter} ${energyDensityFilter} 
+      WHERE ${operatorFilter} ${periodFilter} ${peerGroupFilter} 
       ORDER BY period DESC, operator_id
     `;
 
@@ -134,25 +138,26 @@ const getTariffs = async ({
   period,
   category,
   tariffType,
-  settlementDensity,
-  energyDensity,
+  peerGroup,
 }: {
   operatorId?: number;
   period?: number;
   category?: string;
   tariffType?: "network" | "energy";
-  settlementDensity?: string;
-  energyDensity?: string;
+  peerGroup?: string;
 } = {}): Promise<TariffRecord[]> => {
+  let peerGroupFilter = ""; // Default to no filter (all data)
+  if (peerGroup) {
+    const { settlementDensity, energyDensity } =
+      getSettlementAndEnergyDensity(peerGroup);
+    peerGroupFilter = `
+      AND settlement_density = '${settlementDensity}'
+      AND energy_density = '${energyDensity}'
+    `;
+  }
   const operatorFilter = operatorId ? `operator_id = ${operatorId}` : "1=1"; // Default to all operators
   const periodFilter = period ? `AND period = ${period}` : "";
   const categoryFilter = category ? `AND category = '${category}'` : "";
-  const settlementDensityFilter = settlementDensity
-    ? `AND settlement_density = '${settlementDensity}'`
-    : "";
-  const energyDensityFilter = energyDensity
-    ? `AND energy_density = '${energyDensity}'`
-    : "";
   const tariffTypeFilter = tariffType
     ? `AND tariff_type = '${tariffType}'`
     : "";
@@ -166,7 +171,7 @@ const getTariffs = async ({
         tariff_type,
         rate
       FROM tariffs
-      WHERE ${operatorFilter} ${periodFilter} ${categoryFilter} ${tariffTypeFilter} ${settlementDensityFilter} ${energyDensityFilter}
+      WHERE ${operatorFilter} ${periodFilter} ${categoryFilter} ${tariffTypeFilter} ${peerGroupFilter}
       ORDER BY period DESC, operator_id, category, tariff_type
     `;
 

--- a/src/lib/sunshine-data-service.ts
+++ b/src/lib/sunshine-data-service.ts
@@ -126,7 +126,7 @@ export interface SunshineDataService {
     period?: number
   ): Promise<OperatorDataRecord>;
 
-  getIndicatorMedian<Metric extends IndicatorMedianParams["metric"]>(
+  getYearlyIndicatorMedians<Metric extends IndicatorMedianParams["metric"]>(
     params: IndicatorMedianParams
   ): Promise<PeerGroupRecord<Metric>[]>;
 

--- a/src/lib/sunshine-data.ts
+++ b/src/lib/sunshine-data.ts
@@ -476,10 +476,6 @@ export const fetchSaidi = async (
     peerGroup: operatorData.peer_group,
     operatorId: operatorOnly ? operatorId : undefined,
   });
-
-  console.log({
-    peerGroupYearlyStability: peerGroupYearlyStability,
-  });
   // Concatenate peer group median data into yearlyData with special operator_id and name
   const peerGroupMedianAsYearlyData = yearlyPeerGroupMedianStability.map(
     (item) => ({
@@ -641,13 +637,22 @@ export const fetchOperationalStandards = async (
   db: SunshineDataService,
   {
     operatorId: operatorId_,
+    period: periodParam,
   }: {
     operatorId: string;
+    period?: number;
   }
 ): Promise<SunshineOperationalStandardsData> => {
   const operatorId = parseInt(operatorId_, 10);
   const operatorData = await db.getOperatorData(operatorId);
-  const period = await db.getLatestYearSunshine(operatorId);
+
+  // Use provided period or get the latest year
+  let period: number;
+  if (periodParam !== undefined) {
+    period = periodParam;
+  } else {
+    period = await db.getLatestYearSunshine(operatorId);
+  }
   const operationalData = await db.getOperationalStandards({
     operatorId: operatorId,
     period: period,
@@ -696,7 +701,9 @@ export const fetchOperationalStandards = async (
       ],
     },
     compliance: {
-      francsRule: `CHF ${data.franc_rule.toFixed(2)}`,
+      francsRule: Number.isFinite(data.franc_rule)
+        ? `CHF ${data.franc_rule.toFixed(2)}`
+        : "N/A",
       timelyPaperSubmission,
       operatorsFrancsPerInvoice: [
         {

--- a/src/lib/sunshine-data.ts
+++ b/src/lib/sunshine-data.ts
@@ -141,7 +141,7 @@ export const fetchNetworkCostsData = async (
   }
 
   const yearlyPeerGroupMedianNetworkCosts =
-    await db.getIndicatorMedian<"network_costs">({
+    await db.getYearlyIndicatorMedians<"network_costs">({
       peerGroup: operatorData.peer_group,
       metric: "network_costs",
       networkLevel: networkLevel,
@@ -236,7 +236,7 @@ export const fetchNetTariffsData = async (
   const operatorData = await db.getOperatorData(operatorId);
 
   const yearlyPeerGroupMedianNetTariffs =
-    await db.getIndicatorMedian<"net-tariffs">({
+    await db.getYearlyIndicatorMedians<"net-tariffs">({
       peerGroup: operatorData.peer_group,
       metric: "net-tariffs",
       category: category,
@@ -305,7 +305,7 @@ export const fetchEnergyTariffsData = async (
   const operatorData = await db.getOperatorData(operatorId);
 
   const yearlyPeerGroupMedianEnergyTariffs =
-    await db.getIndicatorMedian<"energy-tariffs">({
+    await db.getYearlyIndicatorMedians<"energy-tariffs">({
       peerGroup: operatorData.peer_group,
       metric: "energy-tariffs",
       category: category,
@@ -447,7 +447,7 @@ export const fetchSaidi = async (
 
   // Get peer group median SAIDI
   const yearlyPeerGroupMedianStability =
-    await db.getIndicatorMedian<"stability">({
+    await db.getYearlyIndicatorMedians<"stability">({
       peerGroup: operatorData.peer_group,
       metric: "stability",
     });
@@ -504,7 +504,7 @@ export const fetchSaifi = async (
   }
 
   const yearlyPeerGroupMedianStability =
-    await service.getIndicatorMedian<"stability">({
+    await service.getYearlyIndicatorMedians<"stability">({
       peerGroup: operatorData.peer_group,
       metric: "stability",
     });

--- a/src/pages/sunshine/[entity]/[id]/operational-standards.tsx
+++ b/src/pages/sunshine/[entity]/[id]/operational-standards.tsx
@@ -93,20 +93,24 @@ export const getServerSideProps: GetServerSideProps<Props, PageParams> = async (
 };
 
 export const prepServiceQualityCardProps = (
-  props: Extract<Props, { status: "found" }>
+  serviceQuality: Extract<
+    Props,
+    { status: "found" }
+  >["operationalStandards"]["serviceQuality"],
+  year: number,
+  isLatestYear: boolean = true
 ) => {
-  const { latestYear, serviceQuality } = props.operationalStandards;
   return {
     title: (
       <Trans id="sunshine.operational-standards.service-quality.comparison-card-title">
         Service Quality
       </Trans>
     ),
-    subtitle: (
+    subtitle: isLatestYear ? (
       <Trans id="sunshine.service-quality.latest-year">
-        Latest year ({latestYear})
+        Latest year ({year})
       </Trans>
-    ),
+    ) : null,
     rows: [
       {
         label: (
@@ -177,7 +181,11 @@ const ServiceQuality = (props: Extract<Props, { status: "found" }>) => {
         />
 
         <TableComparisonCard
-          {...prepServiceQualityCardProps(props)}
+          {...prepServiceQualityCardProps(
+            props.operationalStandards.serviceQuality,
+            Number(props.operationalStandards.latestYear),
+            true
+          )}
           sx={{ gridArea: "comparison" }}
         />
 
@@ -196,20 +204,22 @@ const ServiceQuality = (props: Extract<Props, { status: "found" }>) => {
 };
 
 export const prepComplianceCardProps = (
-  props: Extract<Props, { status: "found" }>
+  compliance: Extract<
+    Props,
+    { status: "found" }
+  >["operationalStandards"]["compliance"],
+  year: number,
+  isLatestYear: boolean = true
 ) => {
-  const { latestYear, compliance } = props.operationalStandards;
   return {
     title: (
       <Trans id="sunshine.operational-standards.compliance.comparison-card-title">
         Compliance
       </Trans>
     ),
-    subtitle: (
-      <Trans id="sunshine.compliance.latest-year">
-        Latest year ({latestYear})
-      </Trans>
-    ),
+    subtitle: isLatestYear ? (
+      <Trans id="sunshine.compliance.latest-year">Latest year ({year})</Trans>
+    ) : null,
     rows: [
       {
         label: (
@@ -281,7 +291,11 @@ const Compliance = (props: Extract<Props, { status: "found" }>) => {
         />
 
         <TableComparisonCard
-          {...prepComplianceCardProps(props)}
+          {...prepComplianceCardProps(
+            props.operationalStandards.compliance,
+            Number(props.operationalStandards.latestYear),
+            true
+          )}
           sx={{ gridArea: "comparison" }}
         />
 

--- a/src/pages/sunshine/[entity]/[id]/operational-standards.tsx
+++ b/src/pages/sunshine/[entity]/[id]/operational-standards.tsx
@@ -201,6 +201,7 @@ export const prepComplianceCardProps = (
 ) => {
   const { latestYear } = props.operationalStandards;
   const data = props.operationalStandards;
+  console.log("compliance", data.compliance);
   return {
     title: (
       <Trans id="sunshine.operational-standards.compliance.comparison-card-title">
@@ -231,7 +232,7 @@ export const prepComplianceCardProps = (
           </Trans>
         ),
         value: {
-          value: `${data.compliance.timelyPaperSubmission}` ? (
+          value: data.compliance.timelyPaperSubmission ? (
             <Trans id="sunshine.compliance.timely-paper-submission.yes">
               Yes
             </Trans>

--- a/src/pages/sunshine/[entity]/[id]/operational-standards.tsx
+++ b/src/pages/sunshine/[entity]/[id]/operational-standards.tsx
@@ -119,7 +119,7 @@ export const prepServiceQualityCardProps = (
           </Trans>
         ),
         value: {
-          value: `${serviceQuality.informingCustomersOfOutage}` ? (
+          value: serviceQuality.informingCustomersOfOutage ? (
             <Trans id="sunshine.service-quality.informing-customers-outage.yes">
               Yes
             </Trans>

--- a/src/pages/sunshine/[entity]/[id]/operational-standards.tsx
+++ b/src/pages/sunshine/[entity]/[id]/operational-standards.tsx
@@ -95,8 +95,7 @@ export const getServerSideProps: GetServerSideProps<Props, PageParams> = async (
 export const prepServiceQualityCardProps = (
   props: Extract<Props, { status: "found" }>
 ) => {
-  const { latestYear } = props.operationalStandards;
-  const data = props.operationalStandards;
+  const { latestYear, serviceQuality } = props.operationalStandards;
   return {
     title: (
       <Trans id="sunshine.operational-standards.service-quality.comparison-card-title">
@@ -116,7 +115,7 @@ export const prepServiceQualityCardProps = (
           </Trans>
         ),
         value: {
-          value: `${data.serviceQuality.informingCustomersOfOutage}` ? (
+          value: `${serviceQuality.informingCustomersOfOutage}` ? (
             <Trans id="sunshine.service-quality.informing-customers-outage.yes">
               Yes
             </Trans>
@@ -134,7 +133,7 @@ export const prepServiceQualityCardProps = (
           </Trans>
         ),
         value: {
-          value: `${data.serviceQuality.notificationPeriodDays}`,
+          value: `${serviceQuality.notificationPeriodDays}`,
         },
       },
     ],
@@ -199,9 +198,7 @@ const ServiceQuality = (props: Extract<Props, { status: "found" }>) => {
 export const prepComplianceCardProps = (
   props: Extract<Props, { status: "found" }>
 ) => {
-  const { latestYear } = props.operationalStandards;
-  const data = props.operationalStandards;
-  console.log("compliance", data.compliance);
+  const { latestYear, compliance } = props.operationalStandards;
   return {
     title: (
       <Trans id="sunshine.operational-standards.compliance.comparison-card-title">
@@ -222,7 +219,7 @@ export const prepComplianceCardProps = (
         ),
         value: {
           // TODO Translate
-          value: `${data.compliance.francsRule}`,
+          value: `${compliance.francsRule}`,
         },
       },
       {
@@ -232,7 +229,7 @@ export const prepComplianceCardProps = (
           </Trans>
         ),
         value: {
-          value: data.compliance.timelyPaperSubmission ? (
+          value: compliance.timelyPaperSubmission ? (
             <Trans id="sunshine.compliance.timely-paper-submission.yes">
               Yes
             </Trans>

--- a/src/pages/sunshine/[entity]/[id]/overview.tsx
+++ b/src/pages/sunshine/[entity]/[id]/overview.tsx
@@ -539,6 +539,7 @@ const OverviewPage = (props: Props) => {
             <YearlyNavigation
               activeTab={year}
               handleTabChange={(_, value) => updateYear(value)}
+              sx={{ mb: 4 }}
             />
           }
           linkContent={
@@ -562,6 +563,7 @@ const OverviewPage = (props: Props) => {
             <YearlyNavigation
               activeTab={year}
               handleTabChange={(_, value) => updateYear(value)}
+              sx={{ mb: 4 }}
             />
           }
           linkContent={

--- a/src/pages/sunshine/[entity]/[id]/overview.tsx
+++ b/src/pages/sunshine/[entity]/[id]/overview.tsx
@@ -28,7 +28,10 @@ import {
   Props as SharedPageProps,
 } from "src/data/shared-page-props";
 import { categories, ElectricityCategory } from "src/domain/data";
-import { sunshineDetailsLink, useQueryStateSunshineOverviewFilters } from "src/domain/query-states";
+import {
+  sunshineDetailsLink,
+  useQueryStateSunshineOverviewFilters,
+} from "src/domain/query-states";
 import {
   NetworkLevel,
   SunshineCostsAndTariffsData,
@@ -150,20 +153,12 @@ const OverviewPage = (props: Props) => {
     />
   );
   const saidiYearlyObservations = useMemo(() => {
-    return (
-      props.powerStability.saidi.yearlyData.filter(
-        (x) => x.year === latestYear
-      ) ?? []
-    );
-  }, [props.powerStability.saidi.yearlyData, latestYear]);
+    return props.powerStability.saidi.yearlyData;
+  }, [props.powerStability.saidi.yearlyData]);
 
   const saifiYearlyObservations = useMemo(() => {
-    return (
-      props.powerStability.saifi.yearlyData.filter(
-        (x) => x.year === latestYear
-      ) ?? []
-    );
-  }, [props.powerStability.saifi.yearlyData, latestYear]);
+    return props.powerStability.saifi.yearlyData;
+  }, [props.powerStability.saifi.yearlyData]);
 
   const getItemLabel = (id: string) => getLocalizedLabel({ id });
   const groupedCategories = useMemo(() => {
@@ -179,7 +174,8 @@ const OverviewPage = (props: Props) => {
     ] as ComponentProps<typeof Combobox>["items"];
   }, []);
 
-  const [overviewFilters, setOverviewFilters] = useQueryStateSunshineOverviewFilters();
+  const [overviewFilters, setOverviewFilters] =
+    useQueryStateSunshineOverviewFilters();
   const { year, category, networkLevel } = overviewFilters;
 
   const updateYear = (newYear: string) => {
@@ -322,7 +318,9 @@ const OverviewPage = (props: Props) => {
             items={groupedCategories}
             getItemLabel={getItemLabel}
             selectedItem={category}
-            setSelectedItem={(item) => updateCategory(item as ElectricityCategory)}
+            setSelectedItem={(item) =>
+              updateCategory(item as ElectricityCategory)
+            }
             //FIXME: Might need change
             infoDialogSlug="help-categories"
             sx={{

--- a/src/pages/sunshine/[entity]/[id]/overview.tsx
+++ b/src/pages/sunshine/[entity]/[id]/overview.tsx
@@ -19,6 +19,7 @@ import { DetailsPageSidebar } from "src/components/detail-page/sidebar";
 import { NetworkCostsTrendCardMinified } from "src/components/network-costs-trend-card";
 import { PowerStabilityCardMinified } from "src/components/power-stability-card";
 import { SunshineDataServiceDebug } from "src/components/sunshine-data-service-debug";
+import { YearlyNavigation } from "src/components/sunshine-tabs";
 import TableComparisonCard from "src/components/table-comparison-card";
 import { TariffsTrendCardMinified } from "src/components/tariffs-trend-card";
 import {
@@ -516,8 +517,13 @@ const OverviewPage = (props: Props) => {
         </Typography>
         <TableComparisonCard
           {...prepServiceQualityCardProps(props)}
-          activeTab={year}
-          handleTabChange={(_, value) => updateYear(value)}
+          subtitle={null}
+          description={
+            <YearlyNavigation
+              activeTab={year}
+              handleTabChange={(_, value) => updateYear(value)}
+            />
+          }
           linkContent={
             <Link
               href={sunshineDetailsLink(
@@ -534,8 +540,13 @@ const OverviewPage = (props: Props) => {
         />
         <TableComparisonCard
           {...prepComplianceCardProps(props)}
-          activeTab={year}
-          handleTabChange={(_, value) => updateYear(value)}
+          subtitle={null}
+          description={
+            <YearlyNavigation
+              activeTab={year}
+              handleTabChange={(_, value) => updateYear(value)}
+            />
+          }
           linkContent={
             <Link
               href={sunshineDetailsLink(

--- a/src/pages/sunshine/[entity]/[id]/overview.tsx
+++ b/src/pages/sunshine/[entity]/[id]/overview.tsx
@@ -235,6 +235,23 @@ const OverviewPage = (props: Props) => {
     | EnergyTariffsQuery["energyTariffs"]
     | undefined;
 
+  const { yearComplianceProps, yearServiceQualityProps } = useMemo(() => {
+    const yearComplianceProps = prepComplianceCardProps(
+      props.operationalStandards.compliance,
+      Number(props.operationalStandards.latestYear),
+      true
+    );
+    const yearServiceQualityProps = prepServiceQualityCardProps(
+      props.operationalStandards.serviceQuality,
+      Number(props.operationalStandards.latestYear),
+      true
+    );
+    return {
+      yearComplianceProps,
+      yearServiceQualityProps,
+    };
+  }, [props]);
+
   const mainContent = (
     <>
       <DetailsPageHeader>
@@ -516,7 +533,7 @@ const OverviewPage = (props: Props) => {
           </Trans>
         </Typography>
         <TableComparisonCard
-          {...prepServiceQualityCardProps(props)}
+          {...yearServiceQualityProps}
           subtitle={null}
           description={
             <YearlyNavigation
@@ -539,7 +556,7 @@ const OverviewPage = (props: Props) => {
           sx={{ gridArea: "service-quality" }}
         />
         <TableComparisonCard
-          {...prepComplianceCardProps(props)}
+          {...yearComplianceProps}
           subtitle={null}
           description={
             <YearlyNavigation

--- a/src/pages/sunshine/[entity]/[id]/overview.tsx
+++ b/src/pages/sunshine/[entity]/[id]/overview.tsx
@@ -47,6 +47,7 @@ import {
   useEnergyTariffsQuery,
   useNetTariffsQuery,
   useNetworkCostsQuery,
+  useOperationalStandardsQuery,
 } from "src/graphql/queries";
 import { Icon } from "src/icons";
 import {
@@ -229,6 +230,17 @@ const OverviewPage = (props: Props) => {
     },
   });
 
+  // Client-side operational standards query for different years
+  const [operationalStandardsQuery] = useOperationalStandardsQuery({
+    variables: {
+      filter: {
+        operatorId,
+        period: parseInt(overviewFilters.year),
+      },
+    },
+    pause: overviewFilters.year === props.operationalStandards.latestYear,
+  });
+
   const networkCosts = networkCostsResult.data?.networkCosts as
     | NetworkCostsQuery["networkCosts"]
     | undefined;
@@ -240,21 +252,28 @@ const OverviewPage = (props: Props) => {
     | undefined;
 
   const { yearComplianceProps, yearServiceQualityProps } = useMemo(() => {
+    // Use client-side data if available and different year is selected
+    const operationalStandardsData =
+      overviewFilters.year === props.operationalStandards.latestYear
+        ? props.operationalStandards
+        : operationalStandardsQuery.data?.operationalStandards ||
+          props.operationalStandards;
+
     const yearComplianceProps = prepComplianceCardProps(
-      props.operationalStandards.compliance,
-      Number(props.operationalStandards.latestYear),
+      operationalStandardsData.compliance,
+      Number(overviewFilters.year),
       true
     );
     const yearServiceQualityProps = prepServiceQualityCardProps(
-      props.operationalStandards.serviceQuality,
-      Number(props.operationalStandards.latestYear),
+      operationalStandardsData.serviceQuality,
+      Number(overviewFilters.year),
       true
     );
     return {
       yearComplianceProps,
       yearServiceQualityProps,
     };
-  }, [props]);
+  }, [props, operationalStandardsQuery.data, overviewFilters.year]);
 
   const mainContent = (
     <>

--- a/src/pages/sunshine/[entity]/[id]/overview.tsx
+++ b/src/pages/sunshine/[entity]/[id]/overview.tsx
@@ -111,11 +111,15 @@ export const getServerSideProps: GetServerSideProps<Props, PageParams> = async (
       fetchOperationalStandards(sunshineDataService, {
         operatorId: id,
       }),
-      fetchPowerStability(sunshineDataService, { operatorId: id }),
+      fetchPowerStability(sunshineDataService, {
+        operatorId: id,
+        operatorOnly: true,
+      }),
       fetchOperatorCostsAndTariffsData(sunshineDataService, {
         operatorId: id,
         networkLevel: "NE5",
         category: "C2",
+        operatorOnly: true,
       }),
     ]);
 


### PR DESCRIPTION
Operator documents
- **refactor: Extract OperatorDocumentsPopoverContent to have it inside Storybook**
- **feat: Allow scrolling for OperatorDocuments**
- **feat: Remove id of operator in operator documents popover content**
- **refactor: Extract OperatorDocumentsPopoverContent to have it inside Storybook**


Informing customers about outages

- **fix: Do not convert boolean value as string otherwise it is always true**

Chart improvements

- **refactor: Remove showInteractionsWhenComparing & showOtherOperatorsLegend**

Peer median calculation fixes

- **refactor: Rename getIndicatorMedian into getYearlyIndicatorMedians**
- **fix: Correctly filter by peer group for median calculation**
- **feat: Make the TableComparisonCard less knowing about the year**
- **refactor: Destructure props early**

Operational standards change when clicking tabs in Overview Page

- **refactor: Prepare for dynamic year**
- **feat: Margin bottom for YearlyNavigation**
- **feat: Add operatorOnly to queries for overview data to fetch only what's necessary**
- **feat: Allow to have dynamic operational standards based on selected year**


