### PR TITLE
Map zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ You can also check the
   - Sunshine Details: Overview filter state is backed by URL, reloading the page keeps the filters
   - Overview: SAIDI & SAIFI charts correctly display
 
+- Fix
+
+  - Map Page: Zoom in/out animation works again
+
 - Chore
 
   - Ability to set flags at runtime without rebuilding

--- a/src/components/generic-map.tsx
+++ b/src/components/generic-map.tsx
@@ -246,6 +246,8 @@ export const GenericMap = ({
               zoom: newViewState.zoom,
               longitude: newViewState.longitude,
               latitude: newViewState.latitude,
+              transitionDuration: newViewState.transitionDuration,
+              transitionInterpolator: newViewState.transitionInterpolator,
             });
           }
         },
@@ -265,6 +267,8 @@ export const GenericMap = ({
               zoom: newViewState.zoom,
               longitude: newViewState.longitude,
               latitude: newViewState.latitude,
+              transitionDuration: newViewState.transitionDuration,
+              transitionInterpolator: newViewState.transitionInterpolator,
             });
           }
         },

--- a/src/components/map-helpers.tsx
+++ b/src/components/map-helpers.tsx
@@ -75,6 +75,13 @@ export const constrainZoom = (
   };
 };
 
+const getFlyToInterpolator = () => {
+  return new FlyToInterpolator({
+    speed: 4,
+    curve: 1.5,
+  });
+};
+
 export const getZoomedViewState = (
   currentViewState: MapViewState & { width: number; height: number },
   bbox: GeoJsonBBox,
@@ -99,7 +106,7 @@ export const getZoomedViewState = (
         ...currentViewState,
         ...fitted,
         transitionDuration,
-        transitionInterpolator: new FlyToInterpolator(),
+        transitionInterpolator: getFlyToInterpolator(),
       };
     } catch {
       // If it fails, reduce padding and try again
@@ -148,6 +155,8 @@ export const INITIAL_VIEW_STATE = {
   bearing: 0,
   width: 200,
   height: 200,
+  transitionDuration: 0,
+  transitionInterpolator: getFlyToInterpolator(),
 };
 
 export type BBox = [[number, number], [number, number]];

--- a/src/domain/query-states.spec.ts
+++ b/src/domain/query-states.spec.ts
@@ -184,6 +184,31 @@ describe("Query States", () => {
         activeId: "abc123",
       });
     });
+
+    it('should delete "activeId" when set to null', () => {
+      const mockRouter = createMockRouter({
+        tab: "sunshine",
+        activeId: "abc123",
+      });
+
+      const router = mockRouter();
+      const { result } = renderHook(() =>
+        queryStates.useQueryStateSunshineMap({ router: () => router })
+      );
+
+      act(() => {
+        result.current[1]({ activeId: null });
+      });
+
+      expect(router.replace).toHaveBeenCalledWith(
+        {
+          pathname: "/test",
+          query: { tab: "sunshine" },
+        },
+        undefined,
+        { shallow: true }
+      );
+    });
   });
 
   describe("Sunshine Details Schema", () => {

--- a/src/domain/query-states.ts
+++ b/src/domain/query-states.ts
@@ -65,7 +65,7 @@ const sunshineMapSchema = z.object({
   indicator: sunshineIndicatorSchema.default("networkCosts"),
   category: z.string().default("C2"),
   networkLevel: z.string().default("NE5"),
-  activeId: z.string().optional(),
+  activeId: z.string().optional().nullable(),
 });
 
 export const sunshineMapLink = makeLinkGenerator(sunshineMapSchema);

--- a/src/lib/use-query-state.ts
+++ b/src/lib/use-query-state.ts
@@ -38,9 +38,16 @@ export function makeUseQueryState<T extends z.ZodRawShape>(
             newQuery[k as string] = Array.isArray(v) ? v.join(",") : String(v);
           }
         }
+        const updatedQuery = { ...query, ...newQuery };
+        // Remove keys that are set to null
+        for (const k of schemaKeys) {
+          if (newQueryState[k as keyof typeof newQueryState] === null) {
+            delete updatedQuery[k as string];
+          }
+        }
         const href = {
           pathname,
-          query: { ...query, ...newQuery },
+          query: updatedQuery,
         };
         replace(href, undefined, { shallow: true });
       },

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -208,7 +208,7 @@ const IndexPageContent = ({
     sunshineObservations,
   ]);
 
-  const isSunshine = useFlag("sunshine");
+  const hasSunshineFlag = useFlag("sunshine");
 
   // Determine the data field to use for the map based on the active tab and indicator
   const mapYear = period;
@@ -222,7 +222,7 @@ const IndexPageContent = ({
     useRef(null);
 
   useEffect(() => {
-    if (isSunshine) {
+    if (hasSunshineFlag) {
       try {
         if (activeId) {
           controlsRef.current?.zoomOn(activeId);
@@ -233,7 +233,7 @@ const IndexPageContent = ({
         console.error("Error zooming on map:", e);
       }
     }
-  }, [activeId, isSunshine]);
+  }, [activeId, hasSunshineFlag]);
 
   const valueFormatter = useIndicatorValueFormatter(indicator);
 


### PR DESCRIPTION
## Description

Map zoom in/out works again.
Map zooming out could not work since activeId was always "true" since "null" (as a string) was stored in the URL when
clicking the Back button.
The transitionDuration and interpolator were also lost during state update.

