### PR TITLE
Fix asc/desc label localization

### DIFF
--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -234,27 +234,6 @@ const indicatorLabelTypes: Record<"prices" | SunshineIndicator, LabelType> = {
   compliance: "timely",
 } as const;
 
-const labels: Record<
-  LabelType,
-  {
-    ASC: string;
-    DESC: string;
-  }
-> = {
-  prices: {
-    ASC: t({ id: "list.order.prices.asc", message: "Ascending" }),
-    DESC: t({ id: "list.order.prices.desc", message: "Descending" }),
-  },
-  quality: {
-    ASC: t({ id: "list.order.quality.asc", message: "Ascending" }),
-    DESC: t({ id: "list.order.quality.desc", message: "Descending" }),
-  },
-  timely: {
-    ASC: t({ id: "list.order.timely.asc", message: "Ascending" }),
-    DESC: t({ id: "list.order.timely.desc", message: "Descending" }),
-  },
-};
-
 export const List = ({
   grouped,
   colorScale,
@@ -272,6 +251,27 @@ export const List = ({
 }) => {
   const [sortState, setSortState] = useState<SortState>("ASC");
   const [searchQuery, setSearchQuery] = useState<string>("");
+
+  const labels: Record<
+    LabelType,
+    {
+      ASC: string;
+      DESC: string;
+    }
+  > = {
+    prices: {
+      ASC: t({ id: "list.order.prices.asc", message: "Ascending" }),
+      DESC: t({ id: "list.order.prices.desc", message: "Descending" }),
+    },
+    quality: {
+      ASC: t({ id: "list.order.quality.asc", message: "Ascending" }),
+      DESC: t({ id: "list.order.quality.desc", message: "Descending" }),
+    },
+    timely: {
+      ASC: t({ id: "list.order.timely.asc", message: "Ascending" }),
+      DESC: t({ id: "list.order.timely.desc", message: "Descending" }),
+    },
+  };
 
   const sortOptions = [
     {

--- a/src/components/sunshine/sunshine-topics.tsx
+++ b/src/components/sunshine/sunshine-topics.tsx
@@ -188,6 +188,7 @@ export const SunshineTopics = () => {
                     indicator: "saifi",
                   })}
                   icon={<Icon name="arrowright" />}
+                  hideBorder
                 />
               </SunshineCardContent>
             </SunshineCard>


### PR DESCRIPTION
## Description
This PR fixes two small things that came up during testing. 

### Move acs/desc labels inside List component to fix localization
- Ensure t() calls execute at render time when locale context is available in order to display the labels in the correct language.
 
### Remove border on power-stability card
- Only a single divider is required since the card now only has two links.

## Testing Performed

<!-- Describe the testing you've done -->

- [x] Tested with the following Browsers: Brave, Safari
- [x] Tested on the following devices: MacBook
- [x] Verified functionality: asc/desc labels are displayed in the correct language
- [ ] Storybook updated
- [ ] Automated tests added

<!--
### Testing or Reproduction Steps

### Testing/Reproduction Steps
1. Navigate to [specific page]
2. Click on [specific element]
3. Observe [expected behavior]
-->

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Checklist

<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [x] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [ ] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog
- [ ] I have run locales:extract if I changed any locale string

<!--
## Notes for Reviewers




### Configuration Required
- Environment variables:
- Feature flags:
- Database changes:

### Known Limitations
-

### Performance Considerations
-

### Alternative Approaches Considered
-

### Future Improvements
-
-->
