### PR TITLE
Fix/trivy

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,5 @@
+# This affects form-data only used in development
+CVE-2025-7783
+# This affects esbuild go version, this is only used in development
+CVE-2025-47907 
+

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,5 @@
 # This affects form-data only used in development
-CVE-2025-7783
+CVE-2025-7783 exp:2026-02-01
 # This affects esbuild go version, this is only used in development
-CVE-2025-47907 
+CVE-2025-47907 exp:2026-02-01
 

--- a/README.md
+++ b/README.md
@@ -197,14 +197,18 @@ This way it is easy to quickly generate a test.
 Both the frontend and the screenshot service can be built as docker images
 and spin up through docker-compose.
 
-```
-yarn docker:build
-yarn docker:build-screenshot
+```bash
+yarn docker:build # Build the image and tag it as interactivethings/electricity-prices-switzerland
 docker compose up
 ```
 
-To mimick a cloud infrastructure where the /api/screenshot route is routed
-to "screenshots" instances, the traefik reverse proxy is used.
+Trivy is used for vulnerability scanning and must pass for the image to be
+accepted on the Federal Administration infrastructure. A check is done before
+publishing the docker image on GHCR. It can also be run against a local image.
+
+```bash
+yarn docker:trivy # Runs trivy against interactivethings/electricity-prices-switzerland:latest
+```
 
 ## SPARQL notebook
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -34,6 +34,8 @@ const config: KnipConfig = {
     "open",
     // Used for managing mock data, available via nix
     "duckdb",
+    // Used to run security vulnerability scan, available via nix
+    "trivy",
   ],
   ignoreUnresolved: [
     // Used in package.json:scripts:start to configure HTTP_PROXY.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "e2e:k6:har": "npx playwright test e2e/generate-k6-har.spec.ts --headed",
     "e2e:k6:update": "bun e2e/update-k6-test-from-har.ts browsing-test-ref.har 802626",
     "docker:build": "docker buildx build --platform linux/amd64 -t interactivethings/electricity-prices-switzerland .",
+    "docker:trivy": "trivy image interactivethings/electricity-prices-switzerland:latest --offline-scan --image-src docker --scanners vuln --severity HIGH,CRITICAL  --show-suppressed --ignore-unfixed",
     "knip": "knip",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build -o public/storybook",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "typescript-lru-cache": "^2.0.0",
     "undici": "^5.25.2",
     "urql": "^4.2.2",
-    "vitest": "^3.2.4",
     "wonka": "^6.3.5",
     "xml-c14n": "^0.0.6",
     "zod": "^3.24.2"
@@ -197,7 +196,8 @@
     "tpo-deepl": "^1.2.4",
     "tsx": "^4.20.3",
     "typescript": "^5.8.2",
-    "vite": "6.2.4"
+    "vite": "6.2.4",
+    "vitest": "^3.2.4"
   },
   "resolutions": {
     "js-base64": "2.5.2",

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,7 @@ let
   pkgs = import <nixpkgs> { };
   nodejs = pkgs.nodejs_22;
   yarn = pkgs.yarn.override { inherit nodejs; };
+  trivy = pkgs.trivy;
 
 in pkgs.mkShell {
   buildInputs = [

--- a/src/components/color-legend.stories.tsx
+++ b/src/components/color-legend.stories.tsx
@@ -1,0 +1,79 @@
+import { StoryGrid } from "src/components/storybook/story-grid";
+import withQueryClient from "src/components/storybook/with-query-client";
+
+import { MapColorLegend } from "./color-legend";
+
+import type { Decorator, Meta, StoryObj } from "@storybook/react";
+
+const withContainer: Decorator = (Story) => (
+  <div
+    style={{
+      minHeight: 130,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+    }}
+  >
+    <Story />
+  </div>
+);
+const meta: Meta<typeof MapColorLegend> = {
+  title: "Components/MapColorLegend",
+  component: MapColorLegend,
+  parameters: {
+    docs: {
+      page: () => <StoryGrid title={""} />,
+    },
+  },
+  argTypes: {
+    id: { control: "text" },
+    title: { control: "text" },
+    ticks: { control: "object" },
+    infoDialogButtonProps: { control: "object" },
+  },
+  decorators: [withQueryClient, withContainer],
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof MapColorLegend>;
+
+export const Default: Story = {
+  args: {
+    id: "map-legend",
+    title: "Price Distribution",
+    ticks: [
+      { value: 100, label: "$100" },
+      { value: 250, label: "$250" },
+      { value: 500, label: "$500" },
+      { value: 750, label: "$750" },
+      { value: 1000, label: "$1000" },
+    ],
+  },
+};
+
+export const EmptyTicks: Story = {
+  args: {
+    id: "map-legend-empty",
+    title: "No Data Available",
+    ticks: [
+      { value: undefined, label: "" },
+      { value: undefined, label: "" },
+      { value: undefined, label: "" },
+    ],
+  },
+};
+
+export const LongTitle: Story = {
+  args: {
+    id: "map-legend-long-title",
+    title: "Very Long Legend Title That Might Need Truncation",
+    ticks: [
+      { value: 1000, label: "$1,000" },
+      { value: 5000, label: "$5,000" },
+      { value: 10000, label: "$10,000" },
+      { value: 50000, label: "$50,000" },
+      { value: 100000, label: "$100,000" },
+    ],
+  },
+};

--- a/src/components/storybook/with-query-client.tsx
+++ b/src/components/storybook/with-query-client.tsx
@@ -1,0 +1,14 @@
+import { Decorator } from "@storybook/react";
+import { useMemo } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const withQueryClient: Decorator = (Story) => {
+  const queryClient = useMemo(() => new QueryClient(), []);
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Story />
+    </QueryClientProvider>
+  );
+};
+
+export default withQueryClient;

--- a/src/components/sunshine-charts.stories.tsx
+++ b/src/components/sunshine-charts.stories.tsx
@@ -14,7 +14,7 @@ import {
   TableRow,
   TextField,
 } from "@mui/material";
-import { Decorator, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { Axis } from "@visx/axis";
 import { localPoint } from "@visx/event";
 import { Group } from "@visx/group";
@@ -25,8 +25,10 @@ import { LinePath } from "@visx/shape";
 import { defaultStyles, TooltipWithBounds, useTooltip } from "@visx/tooltip";
 import { sortBy } from "lodash";
 import React, { useMemo, useState } from "react";
-import { QueryClient, QueryClientProvider, useQuery } from "react-query";
+import { useQuery } from "react-query";
 import { z } from "zod";
+
+import withQueryClient from "src/components/storybook/with-query-client";
 
 const ErrorComponent = ({ message }: { message: string }) => (
   <div style={{ color: "red", fontWeight: 700 }}>
@@ -679,15 +681,6 @@ export const Template = () => {
         )}
       </div>
     </div>
-  );
-};
-
-const withQueryClient: Decorator = (Story) => {
-  const queryClient = useMemo(() => new QueryClient(), []);
-  return (
-    <QueryClientProvider client={queryClient}>
-      <Story />
-    </QueryClientProvider>
   );
 };
 

--- a/src/env/schema.ts
+++ b/src/env/schema.ts
@@ -4,7 +4,7 @@ export const buildSchema = z.object({
   // Used to display a mention of the current deployment in development mode
   DEPLOYMENT: z.string().optional(),
   CURRENT_PERIOD: z.string().default("2025"),
-  FIRST_PERIOD: z.string().default("2009"),
+  FIRST_PERIOD: z.string().default("2011"),
   VERSION: z.string().optional(),
   ALLOW_ENGLISH: z.boolean().default(false),
 });


### PR DESCRIPTION
## Description

The Trivy vulnerability scanner was detecting two vulnerabilities that are actually only used by dependencies of our dev tools. I am silencing those with trivyignore file. This allows to be able to update the docker image.

I used the `exp` tag in the trivyignore file so that we can revisit those in 6 months. Then perhaps the dependencies will have updated and we do not need to add the ignores.