### PR TITLE
Fix/search field

### DIFF
--- a/e2e/sunshine.spec.ts
+++ b/e2e/sunshine.spec.ts
@@ -126,4 +126,33 @@ test.describe("Sunshine map details panel", () => {
       locator: page.getByTestId("map-details-content"),
     });
   });
+
+  test("it should be possible to use the search while on detail panel", async ({
+    page,
+    snapshot,
+  }) => {
+    test.setTimeout(120_000);
+    await page.goto("/en/map?flag__sunshine=true");
+
+    const tracker = new InflightRequests(page);
+    await page.getByTitle("Indicators").click();
+    await sleep(1000);
+    await page.getByRole("combobox", { name: "Year" }).click();
+    await page.getByRole("option", { name: "2025" }).click();
+    await snapshot({
+      note: "Sunshine Map - Initial",
+      locator: page.getByTestId("map-sidebar"),
+    });
+    await page
+      .locator("a")
+      .filter({ hasText: "Gemeinde Eichberg, Elektra" })
+      .first()
+      .click();
+
+    await waitForRequests(tracker);
+    await page.getByPlaceholder("Municipality, canton, grid").click();
+    await page.keyboard.type("Bern");
+    await waitForRequests(tracker);
+    await page.locator("#search-global-option-0").getByText("Bern");
+  });
 });

--- a/e2e/sunshine.spec.ts
+++ b/e2e/sunshine.spec.ts
@@ -75,17 +75,17 @@ test.describe("Sunshine map details panel", () => {
     await page.goto("/en/map?flag__sunshine=true");
 
     const tracker = new InflightRequests(page);
-    await page.getByRole("tab", { name: "Indicators" }).click();
+    await page.getByTitle("Indicators").click();
     await sleep(1000);
     await page.getByRole("combobox", { name: "Year" }).click();
-    await page.getByRole("option", { name: "2024" }).click();
+    await page.getByRole("option", { name: "2025" }).click();
     await snapshot({
       note: "Sunshine Map - Initial",
       locator: page.getByTestId("map-sidebar"),
     });
     await page
       .locator("a")
-      .filter({ hasText: "Werke am Zürichsee AG (" })
+      .filter({ hasText: "Gemeinde Eichberg, Elektra" })
       .first()
       .click();
 
@@ -101,7 +101,7 @@ test.describe("Sunshine map details panel", () => {
     await page.getByRole("option", { name: "Energy tariffs" }).click();
     await page
       .locator("a")
-      .filter({ hasText: "Elektrizitätswerk Göschenen1," })
+      .filter({ hasText: "Elektra Andwil Stromversorgung" })
       .first()
       .click();
     await waitForRequests(tracker);

--- a/src/components/drawer.tsx
+++ b/src/components/drawer.tsx
@@ -25,6 +25,7 @@ export const InlineDrawer = ({
       anchor="left"
       ModalProps={{
         disablePortal: true,
+        disableAutoFocus: true,
         keepMounted: true,
         disableScrollLock: true,
         sx: {


### PR DESCRIPTION
## Description

Search field can be used while detail panel is opened (https://www.notion.so/interactivethings/Testing-Document-22930da54302804b86b3c7d1dc2ebd04?source=copy_link#23330da5430281c38e14cd62c8f6d277)

+ Fixing existing E2E tests.

## How to test

- Use the sunshine flag
- On the "indicators" tab, click an operator to open the details panel
- Click the search field and search for something. It should be possible.