### PR TITLE
refactor: move comparison selector out of power stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ You can also check the
 
 - Style
   - Improved the styling of the info banner fixed alignment
-  
+  - Moved comparison selector out of power stability and cost and tariffs cards to the page level.
+
 - Feat
   - Added OG tags to the app
-  - Added custom tooltip to all button groups 
+  - Added custom tooltip to all button groups
 
 # 2.9.0
 

--- a/src/components/power-stability-card.tsx
+++ b/src/components/power-stability-card.tsx
@@ -1,4 +1,4 @@
-import { t, Trans } from "@lingui/macro";
+import { Trans } from "@lingui/macro";
 import {
   Card,
   CardContent,
@@ -11,7 +11,6 @@ import React, { ReactNode } from "react";
 
 import { ButtonGroup } from "src/components/button-group";
 import CardSource from "src/components/card-source";
-import { filterBySeparator } from "src/domain/helpers";
 import { useQueryStatePowerStabilityCardFilters } from "src/domain/query-states";
 import { PeerGroup, SunshinePowerStabilityData } from "src/domain/sunshine";
 import { getLocalizedLabel, getPeerGroupLabels } from "src/domain/translation";
@@ -20,7 +19,6 @@ import { CardHeader } from "./detail-page/card";
 import { Download, DownloadImage } from "./detail-page/download-image";
 import { InfoDialogButton, InfoDialogButtonProps } from "./info-dialog";
 import { PowerStabilityChart } from "./power-stability-chart";
-import { AllOrMultiCombobox } from "./query-combobox";
 
 const DOWNLOAD_ID: Download = "power-stability";
 
@@ -52,7 +50,7 @@ type PowerStabilityCardProps = {
   setQueryState: ReturnType<typeof useQueryStatePowerStabilityCardFilters>[1];
 } & CardProps;
 
-const getPowerStabilityCardState = (
+export const getPowerStabilityCardState = (
   props: Omit<
     PowerStabilityCardProps,
     "cardTitle" | "infoDialogProps" | "state" | "setQueryState"
@@ -105,19 +103,6 @@ const getPowerStabilityCardState = (
   };
 };
 
-export const PowerStabilityCardState = (
-  props: Omit<PowerStabilityCardProps, "state" | "setQueryState">
-) => {
-  const [state, setQueryState] = useQueryStatePowerStabilityCardFilters();
-  return (
-    <PowerStabilityCard
-      {...props}
-      state={state}
-      setQueryState={setQueryState}
-    />
-  );
-};
-
 export const PowerStabilityCard: React.FC<PowerStabilityCardProps> = (
   props
 ) => {
@@ -127,7 +112,6 @@ export const PowerStabilityCard: React.FC<PowerStabilityCardProps> = (
   const {
     peerGroupLabel,
     observations,
-    multiComboboxOptions,
     updateDate,
     operatorId,
     operatorLabel,
@@ -280,34 +264,6 @@ export const PowerStabilityCard: React.FC<PowerStabilityCardProps> = (
                 }
               />
             )}
-          </Grid>
-          <Grid item xs={12} sm={4} sx={{ display: "flex" }}>
-            <AllOrMultiCombobox
-              label={t({
-                id: "sunshine.costs-and-tariffs.compare-with",
-                message: "Compare With",
-              })}
-              items={[
-                { id: "sunshine.select-all" },
-                ...multiComboboxOptions.map((item) => {
-                  return {
-                    id: String(item.operator),
-                    name: item.operator_name,
-                  };
-                }),
-              ]}
-              selectedItems={compareWith}
-              setSelectedItems={(items) =>
-                setQueryState({
-                  ...state,
-                  compareWith: filterBySeparator(
-                    items,
-                    compareWith ?? [],
-                    "sunshine.select-all"
-                  ),
-                })
-              }
-            />
           </Grid>
         </Grid>
         <PowerStabilityChart

--- a/src/locales/aa/messages.po
+++ b/src/locales/aa/messages.po
@@ -1046,6 +1046,34 @@ msgid "selector.priceComponents"
 msgstr "selector.priceComponents"
 
 #: src/domain/translation.tsx
+msgid "selector.priceComponents.aidfee-content"
+msgstr "selector.priceComponents.aidfee-content"
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.charge-content"
+msgstr "selector.priceComponents.charge-content"
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.collapsed-content"
+msgstr "selector.priceComponents.collapsed-content"
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.energy-content"
+msgstr "selector.priceComponents.energy-content"
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.expanded-content"
+msgstr "selector.priceComponents.expanded-content"
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.gridusage-content"
+msgstr "selector.priceComponents.gridusage-content"
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.total-content"
+msgstr "selector.priceComponents.total-content"
+
+#: src/domain/translation.tsx
 msgid "selector.pricecomponent.aidfee"
 msgstr "selector.pricecomponent.aidfee"
 
@@ -1086,13 +1114,21 @@ msgstr "selector.product.cheapest"
 msgid "selector.product.standard"
 msgstr "selector.product.standard"
 
-#: src/components/combined-selectors/index.tsx
+#: src/domain/translation.tsx
 msgid "selector.tab.electricity"
 msgstr "selector.tab.electricity"
 
-#: src/components/combined-selectors/index.tsx
+#: src/domain/translation.tsx
+msgid "selector.tab.electricity-content"
+msgstr "selector.tab.electricity-content"
+
+#: src/domain/translation.tsx
 msgid "selector.tab.indicators"
 msgstr "selector.tab.indicators"
+
+#: src/domain/translation.tsx
+msgid "selector.tab.indicators-content"
+msgstr "selector.tab.indicators-content"
 
 #: src/components/sunshine-selectors/base.tsx
 msgid "selector.typology"
@@ -1144,9 +1180,11 @@ msgstr "sunshine.compliance.timely-paper-submission.yes"
 msgid "sunshine.costs-and-tariffs.benchmarking-peer-group"
 msgstr "sunshine.costs-and-tariffs.benchmarking-peer-group"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/power-stability-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/power-stability.tsx
+#: src/pages/sunshine/[entity]/[id]/power-stability.tsx
 msgid "sunshine.costs-and-tariffs.compare-with"
 msgstr "sunshine.costs-and-tariffs.compare-with"
 
@@ -1183,10 +1221,13 @@ msgstr "sunshine.costs-and-tariffs.energy-tariffs.overview"
 msgid "sunshine.costs-and-tariffs.latest-year"
 msgstr "sunshine.costs-and-tariffs.latest-year"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.latest-year-option"
 msgstr "sunshine.costs-and-tariffs.latest-year-option"
+
+#: src/domain/translation.tsx
+msgid "sunshine.costs-and-tariffs.latest-year-option-content"
+msgstr "sunshine.costs-and-tariffs.latest-year-option-content"
 
 #: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
 #: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -1252,10 +1293,13 @@ msgstr "sunshine.costs-and-tariffs.operator"
 msgid "sunshine.costs-and-tariffs.peer-group"
 msgstr "sunshine.costs-and-tariffs.peer-group"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.progress-over-time"
 msgstr "sunshine.costs-and-tariffs.progress-over-time"
+
+#: src/domain/translation.tsx
+msgid "sunshine.costs-and-tariffs.progress-over-time-content"
+msgstr "sunshine.costs-and-tariffs.progress-over-time-content"
 
 #: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.selected-operators"
@@ -1270,8 +1314,7 @@ msgstr "sunshine.costs-and-tariffs.source"
 msgid "sunshine.costs-and-tariffs.title"
 msgstr "sunshine.costs-and-tariffs.title"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.view-by"
 msgstr "sunshine.costs-and-tariffs.view-by"
 
@@ -1400,7 +1443,7 @@ msgstr "sunshine.overview-sunshine.title"
 msgid "sunshine.power-stability.description"
 msgstr "sunshine.power-stability.description"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.duration"
 msgstr "sunshine.power-stability.duration"
 
@@ -1409,9 +1452,13 @@ msgstr "sunshine.power-stability.duration"
 msgid "sunshine.power-stability.latest-year"
 msgstr "sunshine.power-stability.latest-year"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.latest-year-option"
 msgstr "sunshine.power-stability.latest-year-option"
+
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.latest-year-option-content"
+msgstr "sunshine.power-stability.latest-year-option-content"
 
 #: src/pages/sunshine/[entity]/[id]/power-stability.tsx
 #: src/pages/sunshine/[entity]/[id]/power-stability.tsx
@@ -1431,27 +1478,35 @@ msgstr "sunshine.power-stability.no-saifi-data"
 msgid "sunshine.power-stability.operator"
 msgstr "sunshine.power-stability.operator"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.overall-option"
 msgstr "sunshine.power-stability.overall-option"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.overall-tooltip"
 msgstr "sunshine.power-stability.overall-tooltip"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.planned-option"
 msgstr "sunshine.power-stability.planned-option"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.planned-tooltip"
+msgstr "sunshine.power-stability.planned-tooltip"
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.progress-over-time"
 msgstr "sunshine.power-stability.progress-over-time"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.progress-over-time-content"
+msgstr "sunshine.power-stability.progress-over-time-content"
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.ratio-option"
 msgstr "sunshine.power-stability.ratio-option"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.ratio-tooltip"
 msgstr "sunshine.power-stability.ratio-tooltip"
 
@@ -1511,16 +1566,23 @@ msgstr "sunshine.power-stability.saifi.info-dialog-label"
 msgid "sunshine.power-stability.title"
 msgstr "sunshine.power-stability.title"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.total-option"
 msgstr "sunshine.power-stability.total-option"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.total-tooltip"
+msgstr "sunshine.power-stability.total-tooltip"
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.unplanned-option"
 msgstr "sunshine.power-stability.unplanned-option"
 
-#: src/components/power-stability-card.tsx
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.unplanned-tooltip"
+msgstr "sunshine.power-stability.unplanned-tooltip"
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.view-by"
 msgstr "sunshine.power-stability.view-by"
 

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -1046,6 +1046,34 @@ msgid "selector.priceComponents"
 msgstr "Preiskomponenten"
 
 #: src/domain/translation.tsx
+msgid "selector.priceComponents.aidfee-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.charge-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.collapsed-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.energy-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.expanded-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.gridusage-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.total-content"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "selector.pricecomponent.aidfee"
 msgstr "Netzzuschlag gem. Art. 35 EnG"
 
@@ -1086,13 +1114,21 @@ msgstr "Günstigstes"
 msgid "selector.product.standard"
 msgstr "Standard"
 
-#: src/components/combined-selectors/index.tsx
+#: src/domain/translation.tsx
 msgid "selector.tab.electricity"
 msgstr "Stromtarife"
 
-#: src/components/combined-selectors/index.tsx
+#: src/domain/translation.tsx
+msgid "selector.tab.electricity-content"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "selector.tab.indicators"
 msgstr "Indikatoren"
+
+#: src/domain/translation.tsx
+msgid "selector.tab.indicators-content"
+msgstr ""
 
 #: src/components/sunshine-selectors/base.tsx
 msgid "selector.typology"
@@ -1144,9 +1180,11 @@ msgstr "Ja"
 msgid "sunshine.costs-and-tariffs.benchmarking-peer-group"
 msgstr "Benchmark innerhalb der Vergleichsgruppe: {peerGroupLabel}"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/power-stability-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/power-stability.tsx
+#: src/pages/sunshine/[entity]/[id]/power-stability.tsx
 msgid "sunshine.costs-and-tariffs.compare-with"
 msgstr "Vergleichen mit"
 
@@ -1183,10 +1221,13 @@ msgstr "Energietarife"
 msgid "sunshine.costs-and-tariffs.latest-year"
 msgstr "Aktuelles Jahr ({latestYear})"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.latest-year-option"
 msgstr "Aktuelles Jahr"
+
+#: src/domain/translation.tsx
+msgid "sunshine.costs-and-tariffs.latest-year-option-content"
+msgstr ""
 
 #: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
 #: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -1252,10 +1293,13 @@ msgstr "{operatorLabel}"
 msgid "sunshine.costs-and-tariffs.peer-group"
 msgstr "Vergleichsgruppe"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.progress-over-time"
 msgstr "Entwicklung über die Zeit"
+
+#: src/domain/translation.tsx
+msgid "sunshine.costs-and-tariffs.progress-over-time-content"
+msgstr ""
 
 #: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.selected-operators"
@@ -1270,8 +1314,7 @@ msgstr "Quelle: {dataSource}"
 msgid "sunshine.costs-and-tariffs.title"
 msgstr "Netzkosten und Stromtarife"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.view-by"
 msgstr "Ansicht von"
 
@@ -1400,7 +1443,7 @@ msgstr "Effizienz-Indikatoren Übersicht"
 msgid "sunshine.power-stability.description"
 msgstr "Diese Seite bietet anhand von zwei wichtigen Kennzahlen Einblicke in die Zuverlässigkeit der Stromversorgung: SAIFI (System Average Interruption Frequency Index) und SAIDI (System Average Interruption Duration Index). Mithilfe dieser Kennzahlen wird die Häufigkeit und die Dauer von Stromunterbrechungen gemessen. Da die Daten innerhalb derselben Netzbetreibergruppe vergleichbar sind, ist eine klare Bewertung der Stromversorgungssicherheit und -zuverlässigkeit im gesamten Netz möglich."
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.duration"
 msgstr "Unterbrechungsdauer"
 
@@ -1409,9 +1452,13 @@ msgstr "Unterbrechungsdauer"
 msgid "sunshine.power-stability.latest-year"
 msgstr "Aktuelles Jahr ({latestYear})"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.latest-year-option"
 msgstr "Aktuelles Jahr"
+
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.latest-year-option-content"
+msgstr ""
 
 #: src/pages/sunshine/[entity]/[id]/power-stability.tsx
 #: src/pages/sunshine/[entity]/[id]/power-stability.tsx
@@ -1431,27 +1478,35 @@ msgstr "Für diesen Netzbetreiber sind für das ausgewählte Jahr keine SAIFI-Da
 msgid "sunshine.power-stability.operator"
 msgstr "{operatorLabel}"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.overall-option"
 msgstr "Gesamtschau"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.overall-tooltip"
 msgstr "Zeigt die Gesamtdauer der Stromunterbrechung pro Netzbetreiber an, wobei geplante und ungeplante Unterbrechungen für einen direkten Vergleich zusammengezählt werden."
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.planned-option"
 msgstr "Geplant"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.planned-tooltip"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.progress-over-time"
 msgstr "Entwicklung über die Zeit"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.progress-over-time-content"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.ratio-option"
 msgstr "Verhältnis"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.ratio-tooltip"
 msgstr "Zeigt das Verhältnis von ungeplanten zu den gesamten Stromunterbrechungen an und gibt so Aufschluss über die Stabilität der Energieversorgung."
 
@@ -1511,16 +1566,23 @@ msgstr "Durchschnittliche Häufigkeit von Stromunterbrechungen (SAIFI)"
 msgid "sunshine.power-stability.title"
 msgstr "Versorgungsqualität"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.total-option"
 msgstr "Insgesamt"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.total-tooltip"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.unplanned-option"
 msgstr "Ungeplant"
 
-#: src/components/power-stability-card.tsx
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.unplanned-tooltip"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.view-by"
 msgstr "Ansicht von"
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1046,6 +1046,34 @@ msgid "selector.priceComponents"
 msgstr "Price components"
 
 #: src/domain/translation.tsx
+msgid "selector.priceComponents.aidfee-content"
+msgstr "Lorem ipsum"
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.charge-content"
+msgstr "Lorem ipsum"
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.collapsed-content"
+msgstr "Lorem ipsum"
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.energy-content"
+msgstr "Lorem ipsum"
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.expanded-content"
+msgstr "Lorem ipsum"
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.gridusage-content"
+msgstr "Lorem ipsum"
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.total-content"
+msgstr "Lorem ipsum"
+
+#: src/domain/translation.tsx
 msgid "selector.pricecomponent.aidfee"
 msgstr "Grid surcharge pursuant to Art. 35 EnG"
 
@@ -1086,13 +1114,21 @@ msgstr "Cheapest"
 msgid "selector.product.standard"
 msgstr "Standard"
 
-#: src/components/combined-selectors/index.tsx
+#: src/domain/translation.tsx
 msgid "selector.tab.electricity"
 msgstr "Electricity Tariffs"
 
-#: src/components/combined-selectors/index.tsx
+#: src/domain/translation.tsx
+msgid "selector.tab.electricity-content"
+msgstr "Lorem ipsum"
+
+#: src/domain/translation.tsx
 msgid "selector.tab.indicators"
 msgstr "Indicators"
+
+#: src/domain/translation.tsx
+msgid "selector.tab.indicators-content"
+msgstr "Lorem ipsum"
 
 #: src/components/sunshine-selectors/base.tsx
 msgid "selector.typology"
@@ -1144,9 +1180,11 @@ msgstr "Yes"
 msgid "sunshine.costs-and-tariffs.benchmarking-peer-group"
 msgstr "Benchmarking within the Peer Group: {peerGroupLabel}"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/power-stability-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/power-stability.tsx
+#: src/pages/sunshine/[entity]/[id]/power-stability.tsx
 msgid "sunshine.costs-and-tariffs.compare-with"
 msgstr "Compare With"
 
@@ -1183,10 +1221,13 @@ msgstr "Energy Tariffs"
 msgid "sunshine.costs-and-tariffs.latest-year"
 msgstr "Latest year ({latestYear})"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.latest-year-option"
 msgstr "Latest year"
+
+#: src/domain/translation.tsx
+msgid "sunshine.costs-and-tariffs.latest-year-option-content"
+msgstr "Lorem ipsum"
 
 #: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
 #: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -1252,10 +1293,13 @@ msgstr "{operatorLabel}"
 msgid "sunshine.costs-and-tariffs.peer-group"
 msgstr "Peer Group"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.progress-over-time"
 msgstr "Progress over time"
+
+#: src/domain/translation.tsx
+msgid "sunshine.costs-and-tariffs.progress-over-time-content"
+msgstr "Lorem ipsum"
 
 #: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.selected-operators"
@@ -1270,8 +1314,7 @@ msgstr "Source: {dataSource}"
 msgid "sunshine.costs-and-tariffs.title"
 msgstr "Costs and Tariffs"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.view-by"
 msgstr "View By"
 
@@ -1400,7 +1443,7 @@ msgstr "Sunshine Indicators Overview"
 msgid "sunshine.power-stability.description"
 msgstr "The Power Stability page provides insights into the reliability of the electricity supply through two key indicators: SAIFI (System Average Interruption Frequency Index) and SAIDI (System Average Interruption Duration Index). These indicators measure the frequency and duration of power interruptions. The data is comparable within the same grid operator group, allowing for a clear assessment of power stability and reliability across the network."
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.duration"
 msgstr "Duration"
 
@@ -1409,9 +1452,13 @@ msgstr "Duration"
 msgid "sunshine.power-stability.latest-year"
 msgstr "Latest year ({latestYear})"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.latest-year-option"
 msgstr "Latest year"
+
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.latest-year-option-content"
+msgstr "Lorem ipsum"
 
 #: src/pages/sunshine/[entity]/[id]/power-stability.tsx
 #: src/pages/sunshine/[entity]/[id]/power-stability.tsx
@@ -1431,27 +1478,35 @@ msgstr "No SAIFI data available for this operator in the selected year."
 msgid "sunshine.power-stability.operator"
 msgstr "{operatorLabel}"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.overall-option"
 msgstr "Overall"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.overall-tooltip"
 msgstr "Shows the total outage duration per operator, combining planned and unplanned outages for direct comparison."
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.planned-option"
 msgstr "Planned"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.planned-tooltip"
+msgstr "Shows only planned outages, which are scheduled maintenance or upgrades."
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.progress-over-time"
 msgstr "Progress over time"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.progress-over-time-content"
+msgstr "Lorem ipsum"
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.ratio-option"
 msgstr "Ratio"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.ratio-tooltip"
 msgstr "Shows the ratio of unplanned outages to total outages, providing insight into the stability of the power supply."
 
@@ -1511,16 +1566,23 @@ msgstr "Total Outage Frequency"
 msgid "sunshine.power-stability.title"
 msgstr "Power Stability"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.total-option"
 msgstr "Total"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.total-tooltip"
+msgstr "Shows the total outage duration per operator, combining planned and unplanned outages for direct comparison."
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.unplanned-option"
 msgstr "Unplanned"
 
-#: src/components/power-stability-card.tsx
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.unplanned-tooltip"
+msgstr "Shows only unplanned outages, which are unexpected interruptions."
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.view-by"
 msgstr "View By"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1046,6 +1046,34 @@ msgid "selector.priceComponents"
 msgstr "Composantes du prix"
 
 #: src/domain/translation.tsx
+msgid "selector.priceComponents.aidfee-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.charge-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.collapsed-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.energy-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.expanded-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.gridusage-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.total-content"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "selector.pricecomponent.aidfee"
 msgstr "Supplément de réseau selon l'art. 35 LEne"
 
@@ -1086,13 +1114,21 @@ msgstr "Meilleur marché"
 msgid "selector.product.standard"
 msgstr "Standard"
 
-#: src/components/combined-selectors/index.tsx
+#: src/domain/translation.tsx
 msgid "selector.tab.electricity"
 msgstr "Tarifs de l'électricité"
 
-#: src/components/combined-selectors/index.tsx
+#: src/domain/translation.tsx
+msgid "selector.tab.electricity-content"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "selector.tab.indicators"
 msgstr "Indicateurs"
+
+#: src/domain/translation.tsx
+msgid "selector.tab.indicators-content"
+msgstr ""
 
 #: src/components/sunshine-selectors/base.tsx
 msgid "selector.typology"
@@ -1144,9 +1180,11 @@ msgstr "Oui"
 msgid "sunshine.costs-and-tariffs.benchmarking-peer-group"
 msgstr "Analyse comparative au sein du groupe de référence : {peerGroupLabel}"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/power-stability-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/power-stability.tsx
+#: src/pages/sunshine/[entity]/[id]/power-stability.tsx
 msgid "sunshine.costs-and-tariffs.compare-with"
 msgstr "Comparer avec"
 
@@ -1183,10 +1221,13 @@ msgstr "Tarifs de l'énergie"
 msgid "sunshine.costs-and-tariffs.latest-year"
 msgstr "Dernière année ({latestYear})"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.latest-year-option"
 msgstr "Dernière année"
+
+#: src/domain/translation.tsx
+msgid "sunshine.costs-and-tariffs.latest-year-option-content"
+msgstr ""
 
 #: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
 #: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -1252,10 +1293,13 @@ msgstr "{operatorLabel}"
 msgid "sunshine.costs-and-tariffs.peer-group"
 msgstr "Groupe de pairs"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.progress-over-time"
 msgstr "Progrès dans le temps"
+
+#: src/domain/translation.tsx
+msgid "sunshine.costs-and-tariffs.progress-over-time-content"
+msgstr ""
 
 #: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.selected-operators"
@@ -1270,8 +1314,7 @@ msgstr "sunshine.costs-and-tariffs.source"
 msgid "sunshine.costs-and-tariffs.title"
 msgstr "Coûts et tarifs"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.view-by"
 msgstr "Voir par"
 
@@ -1400,7 +1443,7 @@ msgstr "Aperçu des indicateurs d'ensoleillement"
 msgid "sunshine.power-stability.description"
 msgstr "La page Stabilité de l'énergie donne un aperçu de la fiabilité de l'approvisionnement en électricité grâce à deux indicateurs clés : SAIFI (System Average Interruption Frequency Index) et SAIDI (System Average Interruption Duration Index). Ces indicateurs mesurent la fréquence et la durée des interruptions de courant. Les données sont comparables au sein d'un même groupe de gestionnaires de réseau, ce qui permet une évaluation claire de la stabilité et de la fiabilité de l'électricité sur l'ensemble du réseau."
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.duration"
 msgstr "Durée de l’accord"
 
@@ -1409,9 +1452,13 @@ msgstr "Durée de l’accord"
 msgid "sunshine.power-stability.latest-year"
 msgstr "Dernière année ({latestYear})"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.latest-year-option"
 msgstr "Dernière année"
+
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.latest-year-option-content"
+msgstr ""
 
 #: src/pages/sunshine/[entity]/[id]/power-stability.tsx
 #: src/pages/sunshine/[entity]/[id]/power-stability.tsx
@@ -1431,27 +1478,35 @@ msgstr "Aucune donnée SAIFI n'est disponible pour cet opérateur pour l'année 
 msgid "sunshine.power-stability.operator"
 msgstr "{operatorLabel}"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.overall-option"
 msgstr "Dans l'ensemble"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.overall-tooltip"
 msgstr "Indique la durée totale des arrêts par opérateur, en combinant les arrêts planifiés et non planifiés pour une comparaison directe."
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.planned-option"
 msgstr "Prévu"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.planned-tooltip"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.progress-over-time"
 msgstr "Progrès dans le temps"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.progress-over-time-content"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.ratio-option"
 msgstr "Ratio"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.ratio-tooltip"
 msgstr "Indique le rapport entre les pannes non planifiées et les pannes totales, ce qui donne une idée de la stabilité de l'alimentation électrique."
 
@@ -1511,16 +1566,23 @@ msgstr "Fréquence totale des interruptions"
 msgid "sunshine.power-stability.title"
 msgstr "Stabilité de la puissance"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.total-option"
 msgstr "Total"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.total-tooltip"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.unplanned-option"
 msgstr "Non planifié"
 
-#: src/components/power-stability-card.tsx
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.unplanned-tooltip"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.view-by"
 msgstr "Voir par"
 

--- a/src/locales/it/messages.po
+++ b/src/locales/it/messages.po
@@ -1046,6 +1046,34 @@ msgid "selector.priceComponents"
 msgstr "Componenti di prezzo"
 
 #: src/domain/translation.tsx
+msgid "selector.priceComponents.aidfee-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.charge-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.collapsed-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.energy-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.expanded-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.gridusage-content"
+msgstr ""
+
+#: src/domain/translation.tsx
+msgid "selector.priceComponents.total-content"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "selector.pricecomponent.aidfee"
 msgstr "Supplemento rete ai sensi dell'art. 35 LEne"
 
@@ -1086,13 +1114,21 @@ msgstr "Più economico"
 msgid "selector.product.standard"
 msgstr "Standard"
 
-#: src/components/combined-selectors/index.tsx
+#: src/domain/translation.tsx
 msgid "selector.tab.electricity"
 msgstr "Tariffe elettriche"
 
-#: src/components/combined-selectors/index.tsx
+#: src/domain/translation.tsx
+msgid "selector.tab.electricity-content"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "selector.tab.indicators"
 msgstr "Indicatori"
+
+#: src/domain/translation.tsx
+msgid "selector.tab.indicators-content"
+msgstr ""
 
 #: src/components/sunshine-selectors/base.tsx
 msgid "selector.typology"
@@ -1144,9 +1180,11 @@ msgstr "Sì"
 msgid "sunshine.costs-and-tariffs.benchmarking-peer-group"
 msgstr "Benchmarking all'interno del gruppo di riferimento: {peerGroupLabel}"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/power-stability-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+#: src/pages/sunshine/[entity]/[id]/power-stability.tsx
+#: src/pages/sunshine/[entity]/[id]/power-stability.tsx
 msgid "sunshine.costs-and-tariffs.compare-with"
 msgstr "Confronta con"
 
@@ -1183,10 +1221,13 @@ msgstr "Tariffe energetiche"
 msgid "sunshine.costs-and-tariffs.latest-year"
 msgstr "Ultimo anno ({latestYear})"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.latest-year-option"
 msgstr "Ultimo anno"
+
+#: src/domain/translation.tsx
+msgid "sunshine.costs-and-tariffs.latest-year-option-content"
+msgstr ""
 
 #: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
 #: src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -1252,10 +1293,13 @@ msgstr "{operatorLabel}"
 msgid "sunshine.costs-and-tariffs.peer-group"
 msgstr "Gruppo di pari"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.progress-over-time"
 msgstr "Progressi nel tempo"
+
+#: src/domain/translation.tsx
+msgid "sunshine.costs-and-tariffs.progress-over-time-content"
+msgstr ""
 
 #: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.selected-operators"
@@ -1270,8 +1314,7 @@ msgstr "sunshine.costi-e-tariffe.fonte"
 msgid "sunshine.costs-and-tariffs.title"
 msgstr "Costi e tariffe"
 
-#: src/components/network-costs-trend-card.tsx
-#: src/components/tariffs-trend-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.costs-and-tariffs.view-by"
 msgstr "Vedi da"
 
@@ -1400,7 +1443,7 @@ msgstr "Panoramica degli indicatori di sole"
 msgid "sunshine.power-stability.description"
 msgstr "La pagina sulla stabilità dell'energia fornisce informazioni sull'affidabilità della fornitura di energia elettrica attraverso due indicatori chiave: SAIFI (System Average Interruption Frequency Index) e SAIDI (System Average Interruption Duration Index). Questi indicatori misurano la frequenza e la durata delle interruzioni di corrente. I dati sono comparabili all'interno dello stesso gruppo di gestori di rete, consentendo una chiara valutazione della stabilità e dell'affidabilità dell'energia in tutta la rete."
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.duration"
 msgstr "Durata"
 
@@ -1409,9 +1452,13 @@ msgstr "Durata"
 msgid "sunshine.power-stability.latest-year"
 msgstr "Ultimo anno ({latestYear})"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.latest-year-option"
 msgstr "Ultimo anno"
+
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.latest-year-option-content"
+msgstr ""
 
 #: src/pages/sunshine/[entity]/[id]/power-stability.tsx
 #: src/pages/sunshine/[entity]/[id]/power-stability.tsx
@@ -1431,27 +1478,35 @@ msgstr "Non sono disponibili dati SAIFI per questo operatore nell'anno seleziona
 msgid "sunshine.power-stability.operator"
 msgstr "{operatorLabel}"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.overall-option"
 msgstr "In generale"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.overall-tooltip"
 msgstr "Mostra la durata totale delle interruzioni per operatore, combinando le interruzioni pianificate e non pianificate per un confronto diretto."
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.planned-option"
 msgstr "Pianificato"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.planned-tooltip"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.progress-over-time"
 msgstr "Progressi nel tempo"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.progress-over-time-content"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.ratio-option"
 msgstr "Rapporto"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.ratio-tooltip"
 msgstr "Mostra il rapporto tra le interruzioni non pianificate e le interruzioni totali, fornendo indicazioni sulla stabilità dell'alimentazione."
 
@@ -1511,16 +1566,23 @@ msgstr "Frequenza totale delle interruzioni"
 msgid "sunshine.power-stability.title"
 msgstr "Stabilità di potenza"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.total-option"
 msgstr "Totale"
 
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.total-tooltip"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.unplanned-option"
 msgstr "Non pianificato"
 
-#: src/components/power-stability-card.tsx
-#: src/components/power-stability-card.tsx
+#: src/domain/translation.tsx
+msgid "sunshine.power-stability.unplanned-tooltip"
+msgstr ""
+
+#: src/domain/translation.tsx
 msgid "sunshine.power-stability.view-by"
 msgstr "Vedi da"
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

This PR moves the comparison selectors to the top of the details pages for both the power stability page and the costs and tariffs page. 

## Related Issues

This is related to [P1: Move Comparison out of Visualization](https://www.notion.so/interactivethings/Testing-Document-22930da54302804b86b3c7d1dc2ebd04?source=copy_link#23330da543028146a0e6f4aea9e0be74)

<!-- Link any related issues using #issue_number format -->

## Testing Performed

<!-- Describe the testing you've done -->

- [x] Tested with the following Browsers: Chrome, Safari <!-- [Chrome, Firefox, Safari, etc] -->
- [x] Tested on the following devices: MacBook Pro, Large Monitor <!-- [MacBook Pro, iPhone 13, iPad, etc] -->
- [x] Verified functionality: Manually <!-- [Tested this functionality manually, automated, etc] -->
- [ ] Storybook updated
- [ ] Automated tests added

<!--
### Testing or Reproduction Steps

### Testing/Reproduction Steps
1. Navigate to [specific page]
2. Click on [specific element]
3. Observe [expected behavior]
-->

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Checklist

<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [x] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [x] I have marked this PR with the appropriate label
- [x] I have added an entry in the changelog
- [x] I have run locales:extract if I changed any locale string

## Notes for Reviewers

<!-- Add any notes that might help reviewers understand your changes. -->

<!--
### Configuration Required
- Environment variables:
- Feature flags:
- Database changes:

### Known Limitations
-

### Performance Considerations
-

### Alternative Approaches Considered
-

### Future Improvements
-
-->
