### PR TITLE
fix: Map image can be downloaded

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,7 @@ jobs:
           BASIC_AUTH_CREDENTIALS: ${{ secrets.BASIC_AUTH_CREDENTIALS }}
           PLAYWRIGHT_BASE_URL: ${{ steps.deployment-url.outputs.deployment-url }}
           PLAYWRIGHT_NO_WEBSERVER: true
-        run: yarn playwright test --grep-invert "@storybook|@har"
+        run: yarn run test:playwright:app
 
       - uses: actions/upload-artifact@v4
         if: always()
@@ -64,7 +64,7 @@ jobs:
           PLAYWRIGHT_BASE_URL: ${{ steps.deployment-url.outputs.deployment-url }}/storybook
         run: |
           curl -u "$BASIC_AUTH_CREDENTIALS" "$PLAYWRIGHT_BASE_URL/index.json" -o storybook-index.json
-          yarn playwright test --grep @storybook
+          yarn run test:playwright:storybook
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fix
+  - Map image can be downloaded
 
 # 2.11.4 (2025-08-27)
 

--- a/e2e/common.ts
+++ b/e2e/common.ts
@@ -8,6 +8,7 @@ import {
   Locator,
   Page,
   PageScreenshotOptions,
+  TestInfo,
 } from "@playwright/test";
 import {
   locatorFixtures as fixtures,
@@ -17,6 +18,15 @@ import {
 import slugify from "./slugify";
 
 type SnapshotOptions = { note?: string; page?: Page; locator?: Locator };
+
+export const snapshotDir = path.join(__dirname, "snapshots");
+
+export const getSnapshotName = (testInfo: TestInfo, note: string) => {
+  return `${testInfo.project.name} > ${testInfo.titlePath
+    .map((x) => x.replace(/\.spec\.ts$/, ""))
+    .map(slugify)
+    .join(" > ")} ${note}`;
+};
 
 const test = base.extend<TestingLibraryFixtures>(fixtures).extend<{
   snapshot: (options?: SnapshotOptions & PageScreenshotOptions) => void;
@@ -33,12 +43,11 @@ const test = base.extend<TestingLibraryFixtures>(fixtures).extend<{
     ) => {
       const { note, page: pageOption, locator, ...screenshotOptions } = options;
       const toScreenshot = pageOption ?? locator ?? page;
-      const name = `${testInfo.project.name} > ${testInfo.titlePath
-        .map((x) => x.replace(/\.spec\.ts$/, ""))
-        .map(slugify)
-        .join(" > ")} ${index++}${note ? ` ${note}` : ""}`;
+      const name = getSnapshotName(
+        testInfo,
+        `${index++}${note ? ` ${note}` : ""}`
+      );
 
-      const snapshotDir = path.join(__dirname, "snapshots");
       await toScreenshot.screenshot({
         animations: "disabled",
         path: path.join(snapshotDir, `${name}.png`),

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -1,0 +1,36 @@
+import fs from "fs/promises";
+import path from "path";
+
+import { expect } from "@playwright/test";
+import { getSnapshotName, snapshotDir, test } from "e2e/common";
+
+test.describe("The Map Page", () => {
+  test("should be possible to download the map", async ({ page }, testInfo) => {
+    const resp = await page.goto("/map");
+    await expect(resp?.status()).toEqual(200);
+    // click the download button, it has text "Download image"
+    const downloadButton = await page.locator(
+      "button:has-text('Download image')"
+    );
+    await expect(downloadButton).toBeVisible();
+    const downloadPromise = page.waitForEvent("download");
+    await downloadButton.click();
+    // wait for a download to be triggered
+    const download = await downloadPromise;
+    // read the download, and assert the mime type
+    const mimeType = download.suggestedFilename().split(".").pop();
+    expect(mimeType).toBe("png");
+    // read via createReadStream and create a file
+    const downloadFileName = getSnapshotName(testInfo, "downloaded-map");
+    const filePath = path.join(snapshotDir, `${downloadFileName}.png`);
+    const fileStream = await download.createReadStream();
+    const writeStream = await fs
+      .open(filePath, "w")
+      .then((f) => f.createWriteStream());
+    await new Promise<void>((resolve, reject) => {
+      fileStream.pipe(writeStream);
+      writeStream.on("finish", () => resolve());
+      writeStream.on("error", reject);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "lint": "eslint .",
     "oxlint": "oxlint .",
     "test": "vitest --project unit",
+    "test:argos": "argos upload ./e2e/snapshots",
     "test:integration": "vitest --project integration",
+    "test:playwright:app": "playwright test --grep-invert \"@storybook|@har\"",
+    "test:playwright:storybook": "playwright test --grep \"@storybook\"",
     "setup": "yarn && yarn locales:compile && yarn graphql:codegen",
     "locales:extract": "NODE_ENV=development lingui extract --clean && ./scripts/strip-locale-line-numbers.sh && tsx scripts/populate-aa.ts",
     "locales:compile": "lingui compile --verbose --typescript",
@@ -41,7 +44,6 @@
     "knip": "knip",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build -o public/storybook",
-    "test:argos": "argos upload ./e2e/snapshots",
     "data:peer-groups": "duckdb -f ./scripts/peer-groups.sql",
     "mocks": "dotenv -e .env.local -- tsx scripts/mocks.ts",
     "mocks:debug-views": "tsx scripts/show-sunshine-views.ts"

--- a/src/components/detail-page/download-image.tsx
+++ b/src/components/detail-page/download-image.tsx
@@ -1,5 +1,5 @@
 import { Trans } from "@lingui/macro";
-import { Box, IconButton, Link as MUILink } from "@mui/material";
+import { Box, Button, IconButton } from "@mui/material";
 import html2canvas from "html2canvas";
 import * as React from "react";
 
@@ -101,22 +101,16 @@ export const DownloadImage = ({
   return (
     <Box>
       {!downloading && !iconOnly && (
-        <MUILink
-          variant="body2"
+        <Button
+          variant="text"
           onClick={onDownload}
-          target="_blank"
-          color={"text.primary"}
-          rel="noopener noreferrer"
-          href="#"
+          startIcon={<Icon name="download" size={iconSize} />}
           sx={{
-            display: "flex",
-            alignItems: "center",
-            gap: 1,
+            color: "text.primary",
           }}
         >
-          <Icon name="download" size={iconSize} />
           <Trans id="image.download">Download image</Trans>
-        </MUILink>
+        </Button>
       )}
       {iconOnly && (
         <IconButton

--- a/src/components/generic-map.tsx
+++ b/src/components/generic-map.tsx
@@ -24,6 +24,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -171,6 +172,7 @@ export const GenericMap = ({
   const [screenshotting, setScreenshotting] = useState(false);
 
   const highlightContext = useContext(HighlightContext).value;
+  const legendId = useId();
 
   // Syncs highlight context (coming from the right list hover) with hovered
   useEffect(() => {
@@ -276,13 +278,10 @@ export const GenericMap = ({
             const deck = ref.deck;
             if (!deck) return;
 
-            // Get the legend element if a download ID is provided
-            const legendElement = downloadId
-              ? document.getElementById(downloadId)
+            // Get the legend element if a legend ID is provided
+            const legendElement = legendId
+              ? document.getElementById(legendId)
               : null;
-            if (!legendElement) {
-              return;
-            }
 
             return getImageData(deck, legendElement || undefined);
           } finally {
@@ -349,6 +348,7 @@ export const GenericMap = ({
     featureMatchesId,
     initialBBox,
     layers,
+    legendId,
     mapZoomPadding,
     viewState,
   ]);
@@ -448,6 +448,7 @@ export const GenericMap = ({
                 borderRadius: "2px",
                 p: 4,
               }}
+              id={legendId}
             >
               {legend}
             </Box>

--- a/src/components/share-button.tsx
+++ b/src/components/share-button.tsx
@@ -1,5 +1,5 @@
 import { t } from "@lingui/macro";
-import { Box, Button, Input, Link, Typography } from "@mui/material";
+import { Box, Button, Input, Typography } from "@mui/material";
 import { useRef } from "react";
 
 import { TooltipBox } from "src/components/charts-generic/interaction/tooltip-box";
@@ -16,7 +16,7 @@ const ShareButton = () => {
     close: setFocusOff,
   } = useDisclosure();
   const tooltipBoxRef = useRef<HTMLDivElement>(null);
-  const linkRef = useRef<HTMLAnchorElement>(null);
+  const linkRef = useRef<HTMLButtonElement>(null);
   const mouse = useRef({ x: 0, y: 0 });
 
   const handleClick = () => {
@@ -46,21 +46,17 @@ const ShareButton = () => {
 
   return (
     <>
-      <Link
-        variant="body2"
-        color="text.primary"
+      <Button
+        variant="text"
         ref={linkRef}
         onClick={handleClick}
+        startIcon={<Icon name="share" size={20} />}
         sx={{
-          cursor: "pointer",
-          display: "flex",
-          alignItems: "center",
-          gap: 1,
+          color: "text.primary",
         }}
       >
-        <Icon name="share" size={20} />
         {t({ id: "map.share", message: "Share" })}
-      </Link>
+      </Button>
       {isOpen && (
         <TooltipBox
           ref={tooltipBoxRef}

--- a/src/domain/screenshot.ts
+++ b/src/domain/screenshot.ts
@@ -20,7 +20,10 @@ export const SCREENSHOT_CANVAS_SIZE = {
  * Get the map as an image, using the Deck.gl canvas and html2canvas to get
  * the legend as an image.
  */
-export const getImageData = async (deck: Deck, legend: HTMLElement) => {
+export const getImageData = async (
+  deck: Deck,
+  legend: HTMLElement | undefined
+) => {
   if (!deck || "canvas" in deck === false) {
     return;
   }
@@ -71,20 +74,21 @@ export const getImageData = async (deck: Deck, legend: HTMLElement) => {
     canvas.height
   );
 
-  const legendCanvas = await html2canvas(legend);
+  if (legend) {
+    const legendCanvas = await html2canvas(legend);
+    // We need to draw the legend using the device pixel ratio otherwise we get
+    // difference between different browsers (Safari legend would be bigger somehow)
+    const { width, height } = legend.getBoundingClientRect();
 
-  // We need to draw the legend using the device pixel ratio otherwise we get
-  // difference between different browsers (Safari legend would be bigger somehow)
-  const { width, height } = legend.getBoundingClientRect();
-
-  const legendPadding = 24;
-  context.drawImage(
-    legendCanvas,
-    legendPadding,
-    legendPadding,
-    width * ratio,
-    height * ratio
-  );
+    const legendPadding = 24;
+    context.drawImage(
+      legendCanvas,
+      legendPadding,
+      legendPadding,
+      width * ratio,
+      height * ratio
+    );
+  }
 
   // Returns the canvas as a png
   const res = await toBlob(newCanvas, "image/png").then((blob) =>

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -459,11 +459,10 @@ const IndexPageContent = ({
                       right: 0,
                       mb: 0,
                       mr: 3,
-                      px: 4,
-                      py: 3,
+                      p: 1,
                       backgroundColor: "background.paper",
                       display: "flex",
-                      gap: "2rem",
+                      gap: 1,
                       borderRadius: "3px 3px 0 0",
                     }}
                   >


### PR DESCRIPTION
## Description

Due to a refactoring in 338d5883bf04216d5d4e172e1c69e498dc77a5f1, the legend
id was not correctly passed to the legend item, and it would break the
screenshotting functionality of the map.

## Related Issues

closes #325

## Testing Performed

- [x] Tested with the following Browsers: Firefox
- [x] Tested on the following devices: MacBook Prop
- [x] Verified functionality: Opened electricity tariffs, clicked on download map, worked, also tested on two sunshine indicators
- [ ] Automated tests added

### Testing/Reproduction Steps

1. Navigate to the map
2. Click the download button, an image should be downloaded
3. Switch to sunshine indicators and verify that it also works

## Checklist

- [x] I have tested my changes thoroughly
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [x] I have added an entry in the changelog

