### PR TITLE
feat: Map takes the whole width of the page

### DIFF
--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -397,14 +397,13 @@ const IndexPageContent = ({
           </Box>
 
           {isMobile ? null : (
-            <ContentWrapper
+            <Box
               sx={{
-                // Need to have && here to override the default flexbox
-                "&&": {
-                  display: "grid",
-                },
+                position: "relative",
+                display: "grid",
                 gridTemplateColumns: "22.5rem 1fr",
                 gap: 0,
+                width: "100%",
               }}
             >
               <Box
@@ -442,10 +441,9 @@ const IndexPageContent = ({
               <Box
                 id={DOWNLOAD_ID}
                 sx={{
-                  top: HEADER_HEIGHT_UP,
                   width: "100%",
                   height: `calc(100vh - ${HEADER_HEIGHT_UP})`,
-                  position: "sticky",
+                  position: "relative",
                   bgcolor: "secondary.50",
                 }}
               >
@@ -477,7 +475,7 @@ const IndexPageContent = ({
                   </Box>
                 )}
               </Box>
-            </ContentWrapper>
+            </Box>
           )}
 
           {!isMobile ? null : (


### PR DESCRIPTION
Fix https://github.com/visualize-admin/electricity-prices-switzerland/issues/179#issuecomment-3228795753

## How to test

- Go the map, see the layout is "full-bleed", it extends to the side of the browser viewport
- Go to the details page, see that the layout width is constrained to ~1420px
