### PR TITLE
Validate query params

### DIFF
--- a/src/domain/data.ts
+++ b/src/domain/data.ts
@@ -58,7 +58,7 @@ export const periods = range(
   -1
 ).map((d) => d.toString());
 
-const allPriceComponents = [
+export const allPriceComponents = [
   "total",
   "gridusage",
   "energy",
@@ -84,7 +84,7 @@ export const detailsPriceComponents = allPriceComponents.filter(
   (x) => x !== "annualmeteringcost"
 );
 
-export const products = ["cheapest", "standard"];
+export const products = ["cheapest", "standard"] as const;
 export const categories = [
   "H1",
   "H2",

--- a/src/domain/query-states.spec.ts
+++ b/src/domain/query-states.spec.ts
@@ -291,4 +291,127 @@ describe("Query States", () => {
       });
     });
   });
+
+  describe("Parameter Validation", () => {
+    describe("Map Schema Validation - Invalid Value Fallbacks", () => {
+      it("should fallback to default when invalid category is provided", () => {
+        const mockRouter = createMockRouter({
+          category: "INVALID",
+        });
+
+        const { result } = renderHook(() =>
+          queryStates.useQueryStateEnergyPricesMap({ router: mockRouter })
+        );
+
+        expect(result.current[0].category).toBe("H4");
+      });
+
+      it("should fallback to default when invalid product is provided", () => {
+        const mockRouter = createMockRouter({
+          product: "invalidProduct",
+        });
+
+        const { result } = renderHook(() =>
+          queryStates.useQueryStateEnergyPricesMap({ router: mockRouter })
+        );
+
+        expect(result.current[0].product).toBe("standard");
+      });
+
+      it("should fallback to default when invalid priceComponent is provided", () => {
+        const mockRouter = createMockRouter({
+          priceComponent: "invalidComponent",
+        });
+
+        const { result } = renderHook(() =>
+          queryStates.useQueryStateEnergyPricesMap({ router: mockRouter })
+        );
+
+        expect(result.current[0].priceComponent).toBe("total");
+      });
+
+      it("should fallback to default when invalid period is provided", () => {
+        const mockRouter = createMockRouter({
+          period: "9999",
+        });
+
+        const { result } = renderHook(() =>
+          queryStates.useQueryStateEnergyPricesMap({ router: mockRouter })
+        );
+
+        expect(result.current[0].period).toBe(buildEnv.CURRENT_PERIOD);
+      });
+    });
+
+    describe("Details Schema Array Validation", () => {
+      it("should filter invalid categories and keep valid ones", () => {
+        const mockRouter = createMockRouter({
+          category: "H4,INVALID,H7,ALSOINVALID,C6",
+        });
+
+        const { result } = renderHook(() =>
+          queryStates.useQueryStateEnergyPricesDetails({ router: mockRouter })
+        );
+
+        expect(result.current[0].category).toEqual(["H4", "H7", "C6"]);
+      });
+
+      it("should filter invalid products and keep valid ones", () => {
+        const mockRouter = createMockRouter({
+          product: "standard,premium,cheapest,luxury,INVALID",
+        });
+
+        const { result } = renderHook(() =>
+          queryStates.useQueryStateEnergyPricesDetails({ router: mockRouter })
+        );
+
+        expect(result.current[0].product).toEqual(["standard", "cheapest"]);
+      });
+
+      it("should filter invalid periods and keep valid ones", () => {
+        const mockRouter = createMockRouter({
+          period: "2024,9999,2023,1800",
+        });
+
+        const { result } = renderHook(() =>
+          queryStates.useQueryStateEnergyPricesDetails({ router: mockRouter })
+        );
+
+        expect(result.current[0].period).toEqual(
+          expect.arrayContaining(["2024", "2023"])
+        );
+        expect(result.current[0].period).not.toEqual(
+          expect.arrayContaining(["9999", "1800"])
+        );
+      });
+
+      it("should fallback to default when all values are invalid", () => {
+        const mockRouter = createMockRouter({
+          category: "INVALID1,INVALID2,INVALID3",
+        });
+
+        const { result } = renderHook(() =>
+          queryStates.useQueryStateEnergyPricesDetails({ router: mockRouter })
+        );
+
+        expect(result.current[0].category).toEqual(["H4"]);
+      });
+
+      it("should handle priceComponent validation with array filtering", () => {
+        const mockRouter = createMockRouter({
+          priceComponent: "total,invalid1,energy,invalid2,gridusage",
+        });
+
+        const { result } = renderHook(() =>
+          queryStates.useQueryStateEnergyPricesDetails({ router: mockRouter })
+        );
+
+        expect(result.current[0].priceComponent).toEqual([
+          "total",
+          "energy",
+          "gridusage",
+        ]);
+      });
+    });
+  });
 });

--- a/src/domain/query-states.spec.ts
+++ b/src/domain/query-states.spec.ts
@@ -98,7 +98,7 @@ describe("Query States", () => {
         period: "2024",
         category: "H7",
         priceComponent: "energy",
-        product: "premium",
+        product: "standard",
       });
 
       const { result } = renderHook(() =>
@@ -110,7 +110,7 @@ describe("Query States", () => {
         period: "2024",
         category: "H7",
         priceComponent: "energy",
-        product: "premium",
+        product: "standard",
         cantonsOrder: "median-asc",
         view: "collapsed",
       });

--- a/src/domain/query-states.ts
+++ b/src/domain/query-states.ts
@@ -7,6 +7,13 @@ import {
   UseQueryStateSingle,
 } from "src/lib/use-query-state";
 
+import {
+  allPriceComponents,
+  categories,
+  mapPriceComponents,
+  periods,
+  products,
+} from "./data";
 import { SunshineIndicator, sunshineIndicatorSchema } from "./sunshine";
 
 /**
@@ -22,6 +29,27 @@ const stringToArray = (defaultValue: string[] = []) => {
     .default(defaultValue.join(","));
 };
 
+/**
+ * Helper function to validate and convert query parameter strings to arrays
+ * @returns Zod schema that transforms comma-separated strings to validated arrays
+ */
+const stringToValidatedArray = <T extends readonly string[]>(
+  validOptions: T,
+  defaultValue: T[number][] = []
+) => {
+  return z
+    .string()
+    .transform((x) => {
+      const values = x ? x.split(",").filter(Boolean) : defaultValue;
+      // Filter to only valid options, fallback to default if none are valid
+      const validValues = values.filter((v) =>
+        validOptions.includes(v as T[number])
+      );
+      return validValues.length > 0 ? validValues : defaultValue;
+    })
+    .default(defaultValue.join(","));
+};
+
 const mapTabsSchema = z.enum(["electricity", "sunshine"] as const);
 
 const mapCommonSchema = z.object({
@@ -29,7 +57,9 @@ const mapCommonSchema = z.object({
   activeId: z.string().nullable().default(null),
 });
 
-const periodSchema = z.string().default(buildEnv.CURRENT_PERIOD);
+const periodSchema = z
+  .enum(periods as [string, ...string[]])
+  .default(buildEnv.CURRENT_PERIOD);
 
 const energyPricesMapSchema = z.object({
   tab: mapTabsSchema.default("electricity"),
@@ -37,26 +67,27 @@ const energyPricesMapSchema = z.object({
   period: periodSchema,
   municipality: z.string().optional(),
   canton: z.string().optional(),
-  category: z.string().default("H4"),
-  priceComponent: z.string().default("total"),
-  product: z.string().default("standard"),
+  category: z.enum(categories).default("H4"),
+  priceComponent: z.enum(allPriceComponents).default("total"),
+  product: z.enum(products).default("standard"),
   download: z.string().optional(),
   cantonsOrder: z.string().default("median-asc"),
   view: z.string().default("collapsed"),
 });
 const energyPricesDetailsSchema = z.object({
   operator: stringToArray().optional(),
-  period: stringToArray([buildEnv.CURRENT_PERIOD]),
+  period: stringToValidatedArray(periods, [buildEnv.CURRENT_PERIOD]),
   municipality: stringToArray([]),
   canton: stringToArray([]),
-  category: stringToArray(["H4"]),
-  priceComponent: stringToArray(["total"]),
-  product: stringToArray(["standard"]),
+  category: stringToValidatedArray(categories, ["H4"]),
+  priceComponent: stringToValidatedArray(mapPriceComponents, ["total"]),
+  product: stringToValidatedArray(products, ["standard"]),
   cantonsOrder: stringToArray(["median-asc"]),
   download: z.string().optional(),
   view: stringToArray(["collapsed"]),
 });
 
+// TODO: Sunshine params are currently not validated
 const sunshineMapSchema = z.object({
   tab: mapTabsSchema.default("sunshine"),
   period: periodSchema,


### PR DESCRIPTION
## Description
This PR validates query params for `period`, `category`, `priceComponent` and `product`
- map: enforces a single value (fixes bug detected in #349)
- details panel: enforces array of known values


## Related Issues
fixes #349 

## Testing Performed

<!-- Describe the testing you've done -->

- [x] Tested with the following Browsers: Brave
- [x] Tested on the following devices:Macbook
- [x] Verified functionality: details->map navigation bug resolved, invalid param injections handled gracefully
- [ ] Storybook updated
- [x] Automated tests added

### Testing or Reproduction Steps

### Testing Steps navigation bug
1. Navigate to `/municipality/3746?period=2025%2C2023%2C2018%2C2022%2C2024`
2. Click on 'Back to map view'
3. Observe it defaults to the most recent year (map doesn't take arrays)

### Testing Steps navigation bug
1. Navigate to `/map?period=2023&priceComponent=gridusage&category=H6&product=cheapest`
2. Manually modify the params with invalid values, e.g. `/map?period=1023%2C2023&priceComponent=hello&category=world&product=premium`
3. Observe it reverts to default values (url params are not reset however)


## Checklist

<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [ ] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [x] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog
- [ ] I have run locales:extract if I changed any locale string

## Notes for Reviewers

@ptbrowne I figured that would make most sense to validate in `query-states.ts` but there might be better ways to do it. feel free to propose a different approach.

Also note that:
- IDs for cantons, municipalities and operators are currently not validated
- Sunshine params are also not validated
- Invalid query params are not reset in the URL and persist, until they are naturally reset
- currently defaults to latest year when going back to the map (since the map only takes a valid single year, not an array); custom logic could be introduced for selecting the largest valid year from an array when returning from the detail view to the map but this seems overkill at this point


<!--
### Configuration Required
- Environment variables:
- Feature flags:
- Database changes:

### Known Limitations
-

### Performance Considerations
-

### Alternative Approaches Considered
-

### Future Improvements
-
-->
