### PR TITLE
Preserve language when clicking main CTA button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ You can also check the
 # Unreleased
 
 - Feat
+
   - Validate and sanitize energy prices query parameters
+
+- Fix
+  - Language is persisted when navigating from overview to map page
 
 # 2.12.0 (2025-09-02)
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,6 +12,7 @@ import dynamic from "next/dynamic";
 import Head from "next/head";
 import Image from "next/image";
 
+import { MapLink } from "src/components/links";
 import { SunshineTopics } from "src/components/sunshine/sunshine-topics";
 import { Icon } from "src/icons";
 import { defaultLocale } from "src/locales/config";
@@ -103,7 +104,7 @@ const IndexPage = () => {
                   }}
                   color="primary"
                   endIcon={<Icon name="arrowright" />}
-                  href="/map"
+                  component={MapLink}
                 >
                   <Typography variant="h3">
                     <Trans id="home.hero-section.primary-cta">


### PR DESCRIPTION
## Description
This PR resolves a bug where the language would revert back to DE (default) when clicking the main CTA button on the overview page. 

## Related Issues
Fixes #345 

## Testing Performed

<!-- Describe the testing you've done -->

- [x] Tested with the following Browsers: Brave
- [x] Tested on the following devices: Macbook
- [x] Verified functionality: Language param is preserved
- [ ] Storybook updated
- [ ] Automated tests added


### Testing/Reproduction Steps
1. Navigate to `/`
2. Change the language to italian
3. Click on the primary CTA: "Tariffe elettriche in Svizzera"
4. Observe you go to `/it/map` instead of `/map` and the language is still italian


## Checklist

<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [ ] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [x] I have marked this PR with the appropriate label
- [x] I have added an entry in the changelog
- [ ] I have run locales:extract if I changed any locale string

## Notes for Reviewers

<!-- Add any notes that might help reviewers understand your changes. -->

<!--
### Configuration Required
- Environment variables:
- Feature flags:
- Database changes:

### Known Limitations
-

### Performance Considerations
-

### Alternative Approaches Considered
-

### Future Improvements
-
-->
