### PR TITLE
Re-order price components

### DIFF
--- a/src/components/detail-page/cantons-comparison-range.tsx
+++ b/src/components/detail-page/cantons-comparison-range.tsx
@@ -178,6 +178,13 @@ export const CantonsComparisonRangePlots = ({ id, entity }: SectionProps) => {
                   }),
                 },
                 {
+                  value: "meteringrate",
+                  label: getLocalizedLabel({ id: "meteringrate" }),
+                  content: getLocalizedLabel({
+                    id: "price-components.meteringrate-content",
+                  }),
+                },
+                {
                   value: "energy",
                   label: getLocalizedLabel({ id: "energy" }),
                   content: getLocalizedLabel({
@@ -189,13 +196,6 @@ export const CantonsComparisonRangePlots = ({ id, entity }: SectionProps) => {
                   label: getLocalizedLabel({ id: "charge" }),
                   content: getLocalizedLabel({
                     id: "price-components.charge-content",
-                  }),
-                },
-                {
-                  value: "meteringrate",
-                  label: getLocalizedLabel({ id: "meteringrate" }),
-                  content: getLocalizedLabel({
-                    id: "price-components.meteringrate-content",
                   }),
                 },
               ]}

--- a/src/components/detail-page/price-distribution-histogram.tsx
+++ b/src/components/detail-page/price-distribution-histogram.tsx
@@ -145,6 +145,13 @@ export const PriceDistributionHistograms = ({ id, entity }: SectionProps) => {
                   }),
                 },
                 {
+                  value: "meteringrate",
+                  label: getLocalizedLabel({ id: "meteringrate" }),
+                  content: getLocalizedLabel({
+                    id: "price-components.meteringrate-content",
+                  }),
+                },
+                {
                   value: "energy",
                   label: getLocalizedLabel({ id: "energy" }),
                   content: getLocalizedLabel({
@@ -156,13 +163,6 @@ export const PriceDistributionHistograms = ({ id, entity }: SectionProps) => {
                   label: getLocalizedLabel({ id: "charge" }),
                   content: getLocalizedLabel({
                     id: "price-components.charge-content",
-                  }),
-                },
-                {
-                  value: "meteringrate",
-                  label: getLocalizedLabel({ id: "meteringrate" }),
-                  content: getLocalizedLabel({
-                    id: "price-components.meteringrate-content",
                   }),
                 },
               ]}

--- a/src/domain/data.ts
+++ b/src/domain/data.ts
@@ -61,8 +61,6 @@ export const periods = range(
 export const allPriceComponents = [
   "total",
   "gridusage",
-  "energy",
-  "charge",
   /**
    * Metering costs are measured in CHF per year. For comparing between operators (on the map),
    * this is the value that is used.
@@ -72,6 +70,8 @@ export const allPriceComponents = [
    * For the details display, they are converted by Elcom to Rp/kWh to align with other price components.
    */
   "meteringrate",
+  "energy",
+  "charge",
 
   /** We need to keep aidfee even if not shown on the map for the total to be OK */
   "aidfee",

--- a/src/domain/query-states.ts
+++ b/src/domain/query-states.ts
@@ -10,7 +10,7 @@ import {
 import {
   allPriceComponents,
   categories,
-  mapPriceComponents,
+  detailsPriceComponents,
   periods,
   products,
 } from "./data";
@@ -80,7 +80,7 @@ const energyPricesDetailsSchema = z.object({
   municipality: stringToArray([]),
   canton: stringToArray([]),
   category: stringToValidatedArray(categories, ["H4"]),
-  priceComponent: stringToValidatedArray(mapPriceComponents, ["total"]),
+  priceComponent: stringToValidatedArray(detailsPriceComponents, ["total"]),
   product: stringToValidatedArray(products, ["standard"]),
   cantonsOrder: stringToArray(["median-asc"]),
   download: z.string().optional(),


### PR DESCRIPTION
## Description
This PR changes the order of the price components in the map drop down and on the detail page, as per ElCom's request. The order should be: 
- total
- grid usage
- metering cost / rate
- energy cost
- charge
- aidfee

It also fixes a bug where the details page was validating against the wrong priceComponent schema. 

## Testing Performed

<!-- Describe the testing you've done -->

- [x] Tested with the following Browsers: Brave
- [x] Tested on the following devices: MacBook
- [x] Verified functionality: Order is correct, Messtarif button works
- [ ] Storybook updated
- [ ] Automated tests added

### Testing/Reproduction Steps
1. Navigate to https://elcom-electricity-price-website-git-fix-price-compo-70e367-ixt1.vercel.app/municipality/3871?period=2026&priceComponent=meteringrate&municipality=6621%2C1301
2. Observe the order is updated
3. Scroll to "Preisverteilung in der Schweiz"
4. Select "Messtarif"
5. Observe it works now


## Screenshots
Affects:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/a20ae951-e84b-4d66-b92c-73babaf8dee8" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/1df79359-f5c4-4b55-8dc8-b71d8b0b692b" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/63248a19-aa3d-4f95-b909-9da88bc87d6f" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/07c4d6ec-aa34-4d62-8660-addfee542b32" />

## Checklist

<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [ ] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [x] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog
- [ ] I have run locales:extract if I changed any locale string

## Notes for Reviewers
I forgot to open a ticket for this. Looks to me that we can only change the order in data.ts and the toggle group components but I'll need to test if this affects other places too. 

The messtarif-validation bug was introduced in [here](https://github.com/visualize-admin/electricity-prices-switzerland/commit/0f186e35f88235c6729fc31e57e9f82309e3e5cd#diff-457ac92f0e871d7b6cf3a13acc662dc2acdabbde83e2f6a2dd9ca23887bbb434R83) by validating against the mapComponents in the detailSchema
