### PR TITLE
Hover entity + link state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fix
+  - Hover on canton list correctly shows the canton median
 
 # 2.12.2 (2025-09-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ You can also check the
 
 # Unreleased
 
+- Feat
+
+  - Energy prices details links from details panel passes along the current filter state
+
 - Fix
   - Hover on canton list correctly shows the canton median
+  - Hover on canton list draws a canton overlay on the map
 
 # 2.12.2 (2025-09-02)
 

--- a/src/components/energy-prices-map.tsx
+++ b/src/components/energy-prices-map.tsx
@@ -53,7 +53,7 @@ export const EnergyPricesMap = ({
   priceComponent: PriceComponent;
 }) => {
   const [hovered, setHovered] = useState<HoverState>();
-  const { activeId, onEntitySelect } = useMap();
+  const { activeId, onEntitySelect, setEntity } = useMap();
   const legendId = useId();
   const formatNumber = useFormatCurrency();
 
@@ -150,6 +150,7 @@ export const EnergyPricesMap = ({
         return;
       }
 
+      setEntity("municipality");
       onEntitySelect(ev, "municipality", id.toString());
     };
 
@@ -214,6 +215,7 @@ export const EnergyPricesMap = ({
     hovered,
     activeId,
     featureIndexes,
+    setEntity,
     onEntitySelect,
   ]);
 

--- a/src/components/energy-prices-map.tsx
+++ b/src/components/energy-prices-map.tsx
@@ -81,6 +81,7 @@ export const EnergyPricesMap = ({
     enrichedData: enrichedData,
     colorScale: colorScale!,
     formatValue: formatNumber,
+    priceComponent: priceComponent,
   });
 
   const { value: highlightContext } = useContext(HighlightContext);

--- a/src/components/energy-prices-map.tsx
+++ b/src/components/energy-prices-map.tsx
@@ -69,6 +69,7 @@ export const EnergyPricesMap = ({
           ? hovered.id.toString()
           : null,
       selectedId: null,
+      entityType: hovered?.type === "municipality" ? "municipality" : "canton",
     }),
     [hovered]
   );

--- a/src/components/energy-prices-map.tsx
+++ b/src/components/energy-prices-map.tsx
@@ -18,7 +18,7 @@ import {
 import { HoverState } from "src/components/map-helpers";
 import {
   makeCantonsLayer,
-  makeEnergyPricesMunicipalitiesOverlayLayer,
+  makeEnergyPricesOverlayLayer,
   makeLakesLayer,
   makeMunicipalityLayer,
 } from "src/components/map-layers";
@@ -192,10 +192,17 @@ export const EnergyPricesMap = ({
       makeCantonsLayer({
         data: geoData.data.cantonMesh,
       }),
-      makeEnergyPricesMunicipalitiesOverlayLayer({
+      makeEnergyPricesOverlayLayer({
+        data: geoData.data.cantons,
+        hovered,
+        activeId: activeId ?? undefined,
+        type: "canton",
+      }),
+      makeEnergyPricesOverlayLayer({
         data: geoData.data.municipalities,
         hovered,
         activeId: activeId ?? undefined,
+        type: "municipality",
       }),
     ];
   }, [

--- a/src/components/map-details-content.tsx
+++ b/src/components/map-details-content.tsx
@@ -10,6 +10,7 @@ import { indicatorToChart } from "src/components/map-details-chart-adapters";
 import { Entity } from "src/domain/data";
 import { useFormatCurrency } from "src/domain/helpers";
 import {
+  energyPricesDetailsLink,
   getSunshineDetailsPageFromIndicator,
   QueryStateEnergyPricesMap,
   sunshineDetailsLink,
@@ -204,6 +205,14 @@ export const MapDetailsContent: React.FC<{
   onBack: () => void;
 }> = ({ colorScale, entity, selectedItem, onBack }) => {
   const [{ tab }] = useQueryStateMapCommon();
+  const [
+    {
+      period: energyPricesPeriod,
+      priceComponent: energyPricesPriceComponent,
+      category: energyPricesCategory,
+      product: energyPricesProduct,
+    },
+  ] = useQueryStateEnergyPricesMap();
   const [{ indicator, period }] = useQueryStateSunshineMap();
   return (
     <MapDetailsContentWrapper onBack={onBack}>
@@ -239,7 +248,12 @@ export const MapDetailsContent: React.FC<{
         endIcon={<Icon name="arrowright" />}
         href={
           tab === "electricity"
-            ? `/${entity}/${selectedItem.id}`
+            ? energyPricesDetailsLink(`/${entity}/${selectedItem.id}`, {
+                period: [energyPricesPeriod],
+                priceComponent: [energyPricesPriceComponent],
+                category: [energyPricesCategory],
+                product: [energyPricesProduct],
+              })
             : sunshineDetailsLink(
                 `/sunshine/operator/${
                   selectedItem.id

--- a/src/components/map-helpers.tsx
+++ b/src/components/map-helpers.tsx
@@ -181,22 +181,22 @@ export const styles = {
         withoutData: [221, 225, 227, 255] as Color,
       },
     },
-    overlay: {
-      default: {
-        fillColor: [0, 0, 0, 0] as Color,
-        lineColor: [0, 0, 0, 0] as Color,
-        lineWidth: 0,
-      },
-      active: {
-        fillColor: [0, 0, 0, 50] as Color, // Dark overlay similar to sunshine layers
-        lineColor: [31, 41, 55, 255] as Color,
-        lineWidth: 3,
-      },
-      inactive: {
-        fillColor: [255, 255, 255, 102] as Color,
-        lineColor: [0, 0, 0, 0],
-        lineWidth: 0,
-      },
+  },
+  overlay: {
+    default: {
+      fillColor: [0, 0, 0, 0] as Color,
+      lineColor: [0, 0, 0, 0] as Color,
+      lineWidth: 0,
+    },
+    active: {
+      fillColor: [0, 0, 0, 50] as Color, // Dark overlay similar to sunshine layers
+      lineColor: [31, 41, 55, 255] as Color,
+      lineWidth: 3,
+    },
+    inactive: {
+      fillColor: [255, 255, 255, 102] as Color,
+      lineColor: [0, 0, 0, 0],
+      lineWidth: 0,
     },
   },
   municipalityMesh: {

--- a/src/components/map-layers.tsx
+++ b/src/components/map-layers.tsx
@@ -175,19 +175,20 @@ export function makeCantonsLayer(options: CantonsLayerOptions) {
   });
 }
 
-interface EnergyPricesMunicipalitiesOverlayLayerOptions {
+interface EnergyPricesOverlayLayerOptions {
   data: GeoJSON.FeatureCollection;
   hovered?: HoverState;
   activeId?: string | null;
+  type: "municipality" | "canton";
 }
 
-export function makeEnergyPricesMunicipalitiesOverlayLayer(
-  options: EnergyPricesMunicipalitiesOverlayLayerOptions
+export function makeEnergyPricesOverlayLayer(
+  options: EnergyPricesOverlayLayerOptions
 ) {
-  const { data, hovered, activeId } = options;
+  const { data, hovered, activeId, type } = options;
 
   return new GeoJsonLayer({
-    id: "municipalities-overlay",
+    id: `${type}-overlay`,
     /** @ts-expect-error bad types */
     data,
     pickable: false,
@@ -196,37 +197,37 @@ export function makeEnergyPricesMunicipalitiesOverlayLayer(
     extruded: false,
     getFillColor: (d) => {
       const id = d?.id?.toString();
-      if (!id) return styles.municipalities.overlay.default.fillColor;
+      if (!id) return styles.overlay.default.fillColor;
 
       const isActive = activeId === id;
-      const isHovered = hovered?.type === "municipality" && hovered.id === id;
+      const isHovered = hovered?.type === type && hovered.id === id;
 
       // Only show overlay for the hovered/active municipality
       if (isActive || isHovered) {
-        return styles.municipalities.overlay.active.fillColor;
+        return styles.overlay.active.fillColor;
       }
       // All other municipalities remain transparent (no reduced opacity overlay)
-      return styles.municipalities.overlay.default.fillColor;
+      return styles.overlay.default.fillColor;
     },
     getLineColor: (d) => {
       const id = d?.id?.toString();
       const isActive = activeId === id;
-      const isHovered = hovered?.type === "municipality" && hovered.id === id;
+      const isHovered = hovered?.type === type && hovered.id === id;
 
       if (isActive || isHovered) {
-        return styles.municipalities.overlay.active.lineColor;
+        return styles.overlay.active.lineColor;
       }
-      return styles.municipalities.overlay.default.lineColor;
+      return styles.overlay.default.lineColor;
     },
     getLineWidth: (d) => {
       const id = d?.id?.toString();
       const isActive = activeId === id;
-      const isHovered = hovered?.type === "municipality" && hovered.id === id;
+      const isHovered = hovered?.type === type && hovered.id === id;
 
       if (isActive || isHovered) {
-        return styles.municipalities.overlay.active.lineWidth;
+        return styles.overlay.active.lineWidth;
       }
-      return styles.municipalities.overlay.default.lineWidth;
+      return styles.overlay.default.lineWidth;
     },
     lineWidthUnits: "pixels",
     updateTriggers: {

--- a/src/components/sunshine-map.tsx
+++ b/src/components/sunshine-map.tsx
@@ -131,6 +131,7 @@ const SunshineMap = ({
   const [entitySelection, setEntitySelection] = useState<EntitySelection>({
     hoveredId: null,
     selectedId: null,
+    entityType: "municipality",
   });
 
   // Use the unified entity selection hook
@@ -140,6 +141,7 @@ const SunshineMap = ({
     dataType: "sunshine" as const,
     colorScale,
     formatValue: valueFormatter,
+    priceComponent: "",
   });
 
   // Handle hover on operator layer

--- a/src/domain/query-states.ts
+++ b/src/domain/query-states.ts
@@ -125,15 +125,14 @@ const sunshineDetailsSchema = z.object({
   tab: detailTabsSchema,
 });
 
-export const sunshineDetailsLink = (
-  route: string,
-  state: Parameters<
-    ReturnType<typeof makeLinkGenerator<typeof sunshineDetailsSchema.shape>>
-  >[1]
-) => {
-  const baseLink = makeLinkGenerator(sunshineDetailsSchema)(route, state);
-  return `${baseLink}#main-content`;
-};
+export const energyPricesDetailsLink = makeLinkGenerator(
+  energyPricesDetailsSchema,
+  "main-content"
+);
+export const sunshineDetailsLink = makeLinkGenerator(
+  sunshineDetailsSchema,
+  "main-content"
+);
 
 const sunshineOverviewFiltersSchema = z.object({
   year: z.string().default("2025"),

--- a/src/hooks/use-selected-entity-data.ts
+++ b/src/hooks/use-selected-entity-data.ts
@@ -18,6 +18,7 @@ import {
 export interface EntitySelection {
   hoveredId: string | null;
   selectedId: string | null;
+  entityType: "municipality" | "canton";
 }
 
 interface UseSelectedEntityDataOptions {
@@ -88,6 +89,7 @@ export function useSelectedEntityData(
     // Handle energy prices data
     if (dataType === "energy-prices") {
       const energyData = enrichedData as EnrichedEnergyPricesData;
+      const entityType = selection.entityType;
 
       // Use the pre-built indexes for efficient lookup
       const municipalityObservations =
@@ -95,8 +97,9 @@ export function useSelectedEntityData(
       const cantonObservations = energyData.observationsByCanton.get(entityId);
 
       const entityObservations =
-        municipalityObservations || cantonObservations || [];
-      const entityType = municipalityObservations ? "municipality" : "canton";
+        (entityType === "municipality"
+          ? municipalityObservations
+          : cantonObservations) ?? [];
 
       if (entityObservations.length === 0) {
         return {
@@ -170,6 +173,7 @@ export function useSelectedEntityData(
     entityId,
     selection.hoveredId,
     selection.selectedId,
+    selection.entityType,
     enrichedData,
     colorScale,
     formatValue,

--- a/src/lib/use-query-state.ts
+++ b/src/lib/use-query-state.ts
@@ -83,9 +83,15 @@ export function makeUseQueryState<T extends z.ZodRawShape>(
 }
 
 export const makeLinkGenerator = <T extends z.ZodRawShape>(
-  _schema: z.ZodObject<T>
+  _schema: z.ZodObject<T>,
+  defaultFragment?: string
 ) => {
-  return (route: string, state: Partial<UseQueryStateSingle<T>>) => {
+  return (
+    route: string,
+    state: Partial<UseQueryStateSingle<T>>,
+    optionsFragment?: string
+  ) => {
+    const fragment = optionsFragment ?? defaultFragment;
     const query: { [key: string]: string } = {};
     for (const key in state) {
       const value = state[key];
@@ -94,6 +100,6 @@ export const makeLinkGenerator = <T extends z.ZodRawShape>(
       }
     }
     const queryString = new URLSearchParams(query).toString();
-    return `${route}?${queryString}`;
+    return `${route}?${queryString}${fragment ? `#${fragment}` : ""}`;
   };
 };

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -120,6 +120,10 @@ const MapPageContent = ({
   const isElectricityTab = tab === "electricity";
   const isSunshineTab = tab === "sunshine";
 
+  // Entity should be part of the state
+  const { entity: mapEntity, setEntity } = useMap();
+  const entity = isElectricityTab ? mapEntity : "operator";
+
   const colorAccessor = useCallback((d: { value: number }) => d.value, []);
 
   // Simple accessor for sunshine data - just get the value field
@@ -228,9 +232,6 @@ const MapPageContent = ({
       indicator={indicator}
     />
   );
-
-  const { entity: mapEntity, setEntity } = useMap();
-  const entity = isElectricityTab ? mapEntity : "operator";
 
   const listGroups = useMemo(() => {
     if (isElectricityTab) {
@@ -343,13 +344,7 @@ const MapPageContent = ({
     selection: {
       selectedId: selectedItem?.id ?? null,
       hoveredId: null,
-      entityType: isElectricityTab
-        ? energyPricesView === "municipality"
-          ? "municipality"
-          : energyPricesView === "canton"
-          ? "canton"
-          : "operator"
-        : "operator",
+      entityType: entity,
     },
     colorScale,
     formatValue: valueFormatter,

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -102,6 +102,7 @@ const MapPageContent = ({
       product,
       download,
       tab = "electricity",
+      view: energyPricesView,
     },
   ] = useQueryStateEnergyPricesMap();
 
@@ -342,9 +343,17 @@ const MapPageContent = ({
     selection: {
       selectedId: selectedItem?.id ?? null,
       hoveredId: null,
+      entityType: isElectricityTab
+        ? energyPricesView === "municipality"
+          ? "municipality"
+          : energyPricesView === "canton"
+          ? "canton"
+          : "operator"
+        : "operator",
     },
     colorScale,
     formatValue: valueFormatter,
+    priceComponent: priceComponent,
   });
 
   return (

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -102,7 +102,6 @@ const MapPageContent = ({
       product,
       download,
       tab = "electricity",
-      view: energyPricesView,
     },
   ] = useQueryStateEnergyPricesMap();
 

--- a/src/utils/entity-formatting.tsx
+++ b/src/utils/entity-formatting.tsx
@@ -29,6 +29,7 @@ export const formatEnergyPricesEntity = (
   entityType: Entity,
   colorScale: ScaleThreshold<number, string, never>,
   formatValue: (value: number) => string,
+  priceComponent: string,
   coverageRatioFlag = false
 ): EntityDisplayData => {
   if (!observations || observations.length === 0) {
@@ -62,7 +63,7 @@ export const formatEnergyPricesEntity = (
 
   // Create values array from observations
   const values: EntityValue[] = observations.map((obs) => ({
-    label: obs.operatorLabel || "",
+    label: obs.operatorLabel ?? priceComponent ?? "",
     formattedValue: `${
       obs.value !== undefined && obs.value !== null
         ? formatValue(obs.value)

--- a/src/utils/entity-formatting.tsx
+++ b/src/utils/entity-formatting.tsx
@@ -49,10 +49,6 @@ export const formatEnergyPricesEntity = (
       firstObs.municipalityData?.name ||
       firstObs.municipalityLabel ||
       "Unknown Municipality"
-    }${
-      firstObs.cantonData?.name || firstObs.cantonLabel
-        ? ` - ${firstObs.cantonData?.name || firstObs.cantonLabel}`
-        : ""
     }`;
   } else if (entityType === "canton") {
     title =


### PR DESCRIPTION

## Description

- **fix: Use selected entity data remembers correctly the state**
- **fix: Hover canton list correctly shows the canton median**
- **fix: Remove canton name from municipality tooltip formatting**
- **fix: Show canton overlay when hovering on list**
- **fix: Show correctly the municipality in mobile control when clicking on it**
- **feat: Make energy prices details links remember the state**
- **fix: Types**

