### PR TITLE
Fix locale glitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fix
+  - Page change glitch on localized domains
 
 # 2.15.6
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -17,7 +17,7 @@ import { LocaleProvider } from "src/lib/use-locale";
 import { useNProgress } from "src/lib/use-nprogress";
 import { i18n as appI18n, parseLocaleString } from "src/locales/locales";
 import { preloadFonts, theme } from "src/themes/elcom";
-import { useRuntimeFlags } from "src/utils/flags";
+import { useFlag, useRuntimeFlags } from "src/utils/flags";
 
 import "src/styles/nprogress.css";
 
@@ -30,7 +30,11 @@ const useSetI18nLocale = (locale: string) => {
     appI18n.activate(locale);
   }
 
+  const noManualLocalActivate = useFlag("noManualLocaleActivate");
   useEffect(() => {
+    if (noManualLocalActivate) {
+      return;
+    }
     const handleRouteStart = (url: string) => {
       const locale = parseLocaleString(url.slice(1));
       if (appI18n.locale !== locale) {
@@ -42,7 +46,7 @@ const useSetI18nLocale = (locale: string) => {
     return () => {
       routerEvents.off("routeChangeStart", handleRouteStart);
     };
-  }, [routerEvents]);
+  }, [noManualLocalActivate, routerEvents]);
 };
 
 const useRouterEventAnalytics = () => {

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -34,7 +34,15 @@ const specs = {
   /** Show mock operational standards chart */
   mockOperationalStandardsChart: {},
 
+  /** Shows coverage ratio in map tooltips */
   coverageRatio: {},
+
+  /**
+   * Deactivate setting locale from URL, only rely on Next router locale.
+   * This should be set permanently at some point. The flag is there to
+   * be able to test safely in production.
+   */
+  noManualLocaleActivate: {},
 } as const;
 
 const keysAsValues = <R extends Record<string | number | symbol, unknown>>(


### PR DESCRIPTION
- **refactor: Detangle hooks**
- **feat: Ability to deactivate manual locale activation**

## Description

This PR introduces a flag that can bypass a locale activation logic based
on the URL. 

This activation logic seems buggy since it relies on an heuristic to detect
the locale (searches for <locale> in the URL), and fails to return the correct
locale in case of localised domains.

