### PR TITLE
Perf/docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,8 @@
 node_modules
 .git
 public/storybook
+
+# trivy automatically caches to .cache/trivy on the CI
+# It prevents subsequent build to be cached when using "COPY . ."
+# This is why we have to ignore .cache here.
+.cache

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .next
 node_modules
 .git
+public/storybook

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,6 +85,7 @@ jobs:
           format: "table"
           exit-code: "1"
           ignore-unfixed: true
+          scanners: "vuln"
           severity: "CRITICAL,HIGH"
 
       - name: Build and Push Docker image to registry

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,31 +67,32 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
+      - name: Build and export to Docker
         id: build-app
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
-          push: false
           load: true
-          tags: ${{ steps.meta-app.outputs.tags }}
+          tags: ${{ env.IMAGE_NAME_APP }}:test
           labels: ${{ steps.meta-app.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ fromJSON(steps.meta-app.outputs.json).tags[0] }}
+          image-ref: ${{ env.IMAGE_NAME_APP }}:test
           format: "table"
           exit-code: "1"
           ignore-unfixed: true
           severity: "CRITICAL,HIGH"
 
-      - name: Push Docker image
-        shell: bash
-        run: |
-          for tag in ${{ join(fromJSON(steps.meta-app.outputs.json).tags, ' ') }}; do
-            docker push $tag
-          done
+      - name: Build and Push Docker image to registry
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta-app.outputs.tags }}
+          labels: ${{ steps.meta-app.outputs.labels }}
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Description

The docker github action cache was not correctly used, leading to not using the cache for all steps of the docker build,
leading to longer build times.

Context: we need to build and push the docker image in two steps since we need to validate the image using Trivy. Previously, we would use the docker/build-push-action for the build and then manually push the tags. It seems like
it manually pushing the tags is not enough to push the cache to github actions. Now, we reuse the docker/build-push-actions for both steps.

We also had a caching problem due to Trivy outputting its cache in the workspace directory. It would bust the cache
of the "COPY . . " instruction. To solve the problem we now have .cache in the .dockerignore.
