### PR TITLE
feat/compliance

### DIFF
--- a/src/components/sunshine-selectors/base.tsx
+++ b/src/components/sunshine-selectors/base.tsx
@@ -89,7 +89,9 @@ export const SunshineSelectorsBase = ({
       <Combobox
         id="indicator"
         label={t({ id: "selector.indicator", message: "Indicator" })}
-        items={indicatorOptions}
+        items={indicatorOptions.filter((x) => {
+          return x !== "outageInfo" && x !== "daysInAdvanceOutageNotification";
+        })}
         getItemLabel={(id) => {
           // The client has decided for franc-rule to be directly in the indicator selector
           // instead of compliance, so we map it here. It should be changed if in the future,

--- a/src/e2e/map.spec.ts
+++ b/src/e2e/map.spec.ts
@@ -209,20 +209,8 @@ test.describe("Map Details Table Information", () => {
         notExpectedFields: ["Network level", "Category"],
       },
       {
-        indicatorName: "Compliance",
-        indicatorPattern: /Compliance/i,
-        expectedFields: ["Year", "Typology"],
-        notExpectedFields: ["Network level", "Category"],
-      },
-      {
-        indicatorName: "Outage information",
-        indicatorPattern: /Outage information/i,
-        expectedFields: ["Year"],
-        notExpectedFields: ["Network level", "Category", "Typology"],
-      },
-      {
-        indicatorName: "Days in advance",
-        indicatorPattern: /Days in advance outage notification/i,
+        indicatorName: "Franc Rule",
+        indicatorPattern: /Franc Rule/i,
         expectedFields: ["Year"],
         notExpectedFields: ["Network level", "Category"],
       },


### PR DESCRIPTION
## Description

Two change on the map page.

- Hide charts "Informationen zu Ausfällen" and "Benachrichtigung über Ausfälle Tage im Voraus"  (#481)
- Remove "Compliance" and make "Frankenregel" a top level indicator (#480)
