### PR TITLE
Fix SAIDI / SAIFI chart download

### DIFF
--- a/src/components/power-stability-card.tsx
+++ b/src/components/power-stability-card.tsx
@@ -164,7 +164,7 @@ export const PowerStabilityCard: React.FC<PowerStabilityCardProps> = (
   const colorMapping = createColorMapping(compareWith, "elcom2");
 
   return (
-    <Card {...cardProps}>
+    <Card {...cardProps} id={DOWNLOAD_ID}>
       <CardContent>
         <CardHeader
           trailingContent={


### PR DESCRIPTION
## Description
Set `id={DOWNLOAD_ID}` to fix the chart download documented in #510

## Related Issues
fixes #510

## Testing Performed

<!-- Describe the testing you've done -->

- [x] Tested with the following Browsers: Brave
- [x] Tested on the following devices: Macbook
- [x] Verified functionality: SAIDI / SAIFI download works
- [ ] Storybook updated
- [ ] Automated tests added

### Testing or Reproduction Steps

### Testing/Reproduction Steps
1. Navigate to https://elcom-electricity-price-website-git-fix-chart-download-ixt1.vercel.app/sunshine/operator/727/power-stability?compareWith=113%2C2&viewBy=latest&saidiSaifiType=total&overallOrRatio=overall&tabDetails=saifi
2. Click on download chart icon
3. Observe download works

## Checklist

<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [ ] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [ ] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog
- [ ] I have run locales:extract if I changed any locale string

