### PR TITLE
Remove unused link from homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ You can also check the
 - General
   - Make layout generally more compact
   - Several design fixes from design review #501
+- Home page
+  - Removed "Service Quality" link in sunshine section
 
 # 2.31.0 - 2026-01-06
 

--- a/src/components/sunshine/sunshine-topics.tsx
+++ b/src/components/sunshine/sunshine-topics.tsx
@@ -157,13 +157,6 @@ const sunshineTopics: () => SunshineTopic[] = () => [
     links: [
       {
         label: t({
-          id: "home.sunshine-topics.service-quality.link",
-          message: "Service Quality",
-        }),
-        indicator: "outageInfo",
-      },
-      {
-        label: t({
           id: "home.sunshine-topics.compliance.link",
           message: "Compliance",
         }),

--- a/src/e2e/home.spec.ts
+++ b/src/e2e/home.spec.ts
@@ -57,7 +57,6 @@ test.describe("The Home Page", () => {
       "Energy Tariffs",
       "Power Outage Duration (SAIDI)",
       "Power Outage Frequency (SAIFI)",
-      "Service Quality",
       "Compliance",
     ];
     for (const link of links) {


### PR DESCRIPTION
## Description
ElCom has asked us to remove the link "Servicequalität" link from the homepage. This PR would remove it but the layout is quite unbalanced. I'm asking for confirmation if this is what they want. 

## Related Issues
fixes #504 

## Testing Performed

<!-- Describe the testing you've done -->

- [ ] Tested with the following Browsers: <!-- [Chrome, Firefox, Safari, etc] -->
- [ ] Tested on the following devices: <!-- [MacBook Pro, iPhone 13, iPad, etc] -->
- [ ] Verified functionality: <!-- [Tested this functionality manually, automated, etc] -->
- [ ] Storybook updated
- [ ] Automated tests added

<!--
### Testing or Reproduction Steps

### Testing/Reproduction Steps
1. Navigate to [specific page]
2. Click on [specific element]
3. Observe [expected behavior]
-->

## Screenshots
<img width="1515" height="883" alt="image" src="https://github.com/user-attachments/assets/d376d5ae-4145-406a-a96e-ca20fa84ff3f" />

## Checklist

<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [ ] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [ ] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog
- [ ] I have run locales:extract if I changed any locale string

## Notes for Reviewers
Waiting for confirmation by Barbara. 
"Compliance" also needs to be updated (string already changed in accent but not updated in this PR) 
