### PR TITLE
Translate default label all_grid_operators

### DIFF
--- a/src/components/map/mobile-controls.tsx
+++ b/src/components/map/mobile-controls.tsx
@@ -187,7 +187,9 @@ const MobileControls = ({
   const indicatorLabel =
     tab === "electricity" ? priceComponentLabel : sunshineIndicatorLabel;
   const sunshinePeerGroupLabel =
-    peerGroupsById[sunshinePeerGroup]?.name ?? sunshinePeerGroup;
+    sunshinePeerGroup === "all_grid_operators"
+      ? getLocalizedLabel({ id: "peer-group.all-grid-operators" })
+      : peerGroupsById[sunshinePeerGroup]?.name ?? sunshinePeerGroup;
   const sunshineNetworkLevelLabel = getLocalizedLabel({
     id: `network-level.${sunshineNetworkLevel}.short`,
   });


### PR DESCRIPTION
## Description
This PR adds an exception to catch the all_grid_operators label that is apparently not translated on LINDAS (?) 

## Testing Performed
- [x] Tested with the following Browsers: Safari
- [x] Tested on the following devices: iPhone mini
- [x] Verified functionality: label is now translated
- [ ] Storybook updated
- [ ] Automated tests added

### Testing/Reproduction Steps
1. Navigate to /de/map
2. Click on Indicators
3. Observe no missing translations

## Screenshots
<img width="368" height="653" alt="image" src="https://github.com/user-attachments/assets/13a30696-99da-4d19-ab32-550da1579f34" />
<img width="366" height="655" alt="image" src="https://github.com/user-attachments/assets/22f58560-6960-440b-9be6-cee38ac69430" />


## Checklist

<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [ ] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [ ] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog
- [ ] I have run locales:extract if I changed any locale string

## Notes for Reviewers
@ptbrowne if something else is causing this, feel free to close this PR and implement a better fix. 
