### PR TITLE
Align tariff combobox

### DIFF
--- a/src/components/combobox.tsx
+++ b/src/components/combobox.tsx
@@ -143,18 +143,8 @@ export const MultiCombobox = ({
       }}
       popupIcon={<Icon name="chevrondown" color="black" />}
       renderInput={(params) => (
-        <Box
-          position="relative"
-          flexDirection="column"
-          width="100%"
-          display="flex"
-          gap="8px"
-        >
-          <ComboboxLabel
-            label={label}
-            htmlFor={htmlFor}
-            sx={{ minHeight: "auto" }}
-          />
+        <Box position="relative" flexDirection="column" width="100%" display="flex">
+          <ComboboxLabel label={label} htmlFor={htmlFor} />
           <TextField
             {...params}
             variant="outlined"


### PR DESCRIPTION
## Description
This PR fixes the vertical alignment of the selects on the tariffs page

## Related Issues
Fixes #524 

## Testing Performed
- [x] Tested with the following Browsers: Brave, Safari
- [x] Tested on the following devices: Macbook
- [x] Verified functionality: still works
- [ ] Storybook updated
- [ ] Automated tests added


### Testing/Reproduction Steps
1. Navigate to /de/operator/72
2. Observe the selects are aligned

## Screenshots
<img width="3266" height="650" alt="image" src="https://github.com/user-attachments/assets/c6a83afa-2d12-405b-af63-7f386725f28f" />


## Checklist
- [x] I have tested my changes thoroughly
- [ ] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [ ] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog
- [ ] I have run locales:extract if I changed any locale string