### PR TITLE
Highlight map view on detail pages too

### DIFF
--- a/src/components/app-layout.tsx
+++ b/src/components/app-layout.tsx
@@ -82,7 +82,8 @@ const AppNavigation = () => {
           active={
             asPath === "/map" ||
             asPath.includes("municipality") ||
-            asPath.includes("canton")
+            asPath.includes("canton") ||
+            asPath.includes("operator")
           }
           href={"/map"}
           //FIXME: alter MenuButton for searchbar spacing


### PR DESCRIPTION
## Description
With this PR we highlight the "Map view" navigation when the user is on the details page, as per the [design](https://www.figma.com/design/opxTrkS7ygOwWw6iGbHL1O/ElCom---Sunshine-Visual-Design?node-id=6749-95829&t=YYXLMNtiEP3SKag7-4). 

## Related Issues
closes #521 

## Testing Performed

- [x] Tested with the following Browsers: Brave
- [x] Tested on the following devices: MacBook
- [x] Verified functionality: map view is highlighted now
- [ ] Storybook updated
- [ ] Automated tests added

### Testing/Reproduction Steps
1. Navigate to [/municipality/3712](https://elcom-electricity-price-website-git-chore-highlight-map-ixt1.vercel.app/municipality/3712)
2. Observe "Map View" is highlighted

## Screenshots
<img width="1546" height="761" alt="image" src="https://github.com/user-attachments/assets/0766ba12-9500-421c-88e5-f44c94807024" />


## Checklist

<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [ ] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [ ] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog
- [ ] I have run locales:extract if I changed any locale string

## Notes for Reviewers
@ptbrowne @Muchete let's discuss next week if this is the right thing to do. to me the detail views and map views are quite different and if we do change something, I'd probably rather introduce the `Detail View` as a third nav element. But for this we'd have to first update mobile too (#551) 

