### PR TITLE
Share tooltip zindex

### DIFF
--- a/src/components/share-button.tsx
+++ b/src/components/share-button.tsx
@@ -86,7 +86,7 @@ const ShareButton = () => {
                 <Button
                   color="secondary"
                   onClick={handleClickCopyButton}
-                  sx={{ minWidth: "auto" }}
+                  sx={{ minWidth: "auto", pointerEvents: "auto" }}
                 >
                   <Icon name="duplicate" />
                 </Button>


### PR DESCRIPTION
## Description

This PR adds the theme tooltip zindex to the share tooltip to make sure it is visible on mobile. 

## Related Issues
fixes #553 

## Testing Performed

<!-- Describe the testing you've done -->

- [x] Tested with the following Browsers: Safari, Brave
- [x] Tested on the following devices: iPhone, Macbook
- [ ] Verified functionality: share "works" 
- [ ] Storybook updated
- [ ] Automated tests added

## Screenshots
<img width="360" height="629" alt="image" src="https://github.com/user-attachments/assets/b1d52b6d-5a19-4be4-bc69-20de34f7725b" />

## Checklist

<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [ ] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [ ] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog
- [ ] I have run locales:extract if I changed any locale string

## Notes for Reviewers
@Muchete the tooltip now "works" (you can use it, it's not broken) but the width is fixed at 300px, and it is not super pretty. Im fine to leave it for now but let's think about a better design for this (e.g. full width as the details card) 

@ptbrowne I didn't find a simple (1-2 lines of codes) way to achieve the same tooltip style on mobile as the details card so I didn't touch anything beyond the zindex for now. Feel free to improve the layout if you have time and take it from here. Note that at the moment, on very small screens (iPhone 13 mini) the tooltip causes a slight layout shift, which is not ideal. This is something that affects all tooltips and documented here: #555 
