### PR TITLE
Display municipality name on map

### DIFF
--- a/src/utils/entity-formatting.tsx
+++ b/src/utils/entity-formatting.tsx
@@ -45,7 +45,7 @@ export const formatEnergyPricesEntity = (
   let title: null | string = null;
 
   if (entityType === "municipality") {
-    title = null;
+    title = firstObs.municipalityData?.name || firstObs.municipalityLabel || null;
   } else if (entityType === "canton") {
     title = firstObs.cantonData?.name || firstObs.cantonLabel || null;
   } else if (entityType === "operator") {


### PR DESCRIPTION
## Description
This PR adds back the name of the municipality in the map tooltip, as requested by the client. 

## Related Issues
fixes #540 

## Testing Performed

- [x] Tested with the following Browsers: Brave
- [x] Tested on the following devices: MacBook
- [x] Verified functionality: Name shows up
- [ ] Storybook updated
- [ ] Automated tests added

## Screenshots
<img width="832" height="392" alt="image" src="https://github.com/user-attachments/assets/b67f3948-7fcb-45ce-9547-9018f5e4856a" />

<img width="364" height="568" alt="image" src="https://github.com/user-attachments/assets/afe3c3d0-eed3-4303-a70c-c628524741d1" />


## Checklist

<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [ ] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [ ] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog
- [ ] I have run locales:extract if I changed any locale string
