### PR TITLE
fix: New opendata footer link

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -155,7 +155,7 @@ export const Footer = ({ sx }: { sx?: SxProps }) => {
         </Link>
 
         <Link
-          href={`https://opendata.swiss/${locale}/group/ener?organization=elcom`}
+          href={`https://opendata.swiss/${locale}/organization/elcom`}
           target="_blank"
           underline="none"
         >


### PR DESCRIPTION
## Description

Closes #591

This PR fixes the opendata footer link, so it correctly points to `https://opendata.swiss/de/organization/elcom`

### Testing/Reproduction Steps
1. Navigate to homepage
2. Click on the footer opendata link
3. Observe page loads


## Checklist

<!-- Mark items with 'x' as completed -->

- [x] I have tested my changes thoroughly
- [x] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [ ] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog
- [ ] I have run locales:extract if I changed any locale string

## Notes for Reviewers

Reported by ElCom on 260316


> Salut,
> 
> Pareil pour moi par contre, juste un petit quelque chose qui ne fonctionne pas : un lien ne fonctionne pas
> Quand on clic sur : « daten on opendata » -> le lien envoie au mauvais endroit : [Energie | opendata.swiss](https://opendata.swiss/de/group/ener?organization=elcom)
> 
> Le lien correcte est : [Eidgenössische Elektrizitätskommission ElCom | opendata.swiss](https://opendata.swiss/de/organization/elcom)
> 
> Est ce que c’est possible d’adapter le lien ?