### PR TITLE
fix: Correctly translate units

### DIFF
--- a/src/components/charts-generic/histogram/histogram.stories.tsx
+++ b/src/components/charts-generic/histogram/histogram.stories.tsx
@@ -1,3 +1,4 @@
+import { useLingui } from "@lingui/react";
 import { Box } from "@mui/material";
 import { median as d3Median } from "d3";
 
@@ -33,7 +34,7 @@ export default meta;
 export const Histogram = () => {
   const medianValue = 20;
   const annotations = [mockData[0], mockData[1], mockData[2]];
-
+  const { i18n } = useLingui()
   return (
     <Box width="100%" maxWidth="800px" m={5}>
       <HistogramComponent
@@ -42,7 +43,7 @@ export const Histogram = () => {
         aspectRatio={0.3}
         xAxisLabel="Price"
         yAxisLabel="Number of municipalities"
-        xAxisUnit={RP_PER_KWH}
+        xAxisUnit={i18n._(RP_PER_KWH)}
         fields={{
           x: {
             componentIri: "value",

--- a/src/components/comparison-table.stories.tsx
+++ b/src/components/comparison-table.stories.tsx
@@ -1,3 +1,4 @@
+import { useLingui } from "@lingui/react";
 import { TableBody, TableCell, TableRow, Typography } from "@mui/material";
 
 import ComparisonTable from "src/components/comparison-table";
@@ -9,6 +10,7 @@ export const Example = () => {
   const operatorLabel = "Operator XYZ";
   const operatorRate = 1500;
   const peerGroupMedianRate = 1200;
+  const { i18n } = useLingui()
   return (
     <ComparisonTable size="small">
       <TableBody>
@@ -21,7 +23,7 @@ export const Example = () => {
           <TableCell>
             <UnitValueWithTrend
               value={operatorRate}
-              unit={RP_PER_KM}
+              unit={i18n._(RP_PER_KM)}
               trend={Trend.Down}
             />
           </TableCell>
@@ -35,7 +37,7 @@ export const Example = () => {
           <TableCell>
             <UnitValueWithTrend
               value={peerGroupMedianRate}
-              unit={RP_PER_KM}
+              unit={i18n._(RP_PER_KM)}
               trend={Trend.Stable}
             />
           </TableCell>

--- a/src/components/detail-page/price-components-bars.tsx
+++ b/src/components/detail-page/price-components-bars.tsx
@@ -1,4 +1,5 @@
 import { t, Trans } from "@lingui/macro";
+import { useLingui } from "@lingui/react";
 import { Box } from "@mui/material";
 import { extent, groups } from "d3";
 import { uniq } from "lodash";
@@ -191,6 +192,8 @@ export const PriceComponentsBarChart = ({ id, entity }: SectionProps) => {
     product: product[0],
   };
 
+    const { i18n } = useLingui()
+
   return (
     <Card downloadId={DOWNLOAD_ID}>
       <CardHeader
@@ -297,7 +300,7 @@ export const PriceComponentsBarChart = ({ id, entity }: SectionProps) => {
                   fields={{
                     x: {
                       componentIri: "value",
-                      axisLabel: RP_PER_KWH,
+                      axisLabel: i18n._(RP_PER_KWH),
                     },
                     domain: xDomain,
                     y: {

--- a/src/components/detail-page/price-distribution-histogram.tsx
+++ b/src/components/detail-page/price-distribution-histogram.tsx
@@ -1,4 +1,5 @@
 import { t, Trans } from "@lingui/macro";
+import { useLingui } from "@lingui/react";
 import { Box } from "@mui/material";
 import { groups } from "d3";
 
@@ -241,6 +242,7 @@ const PriceDistributionHistogram = ({
   product: string[];
 }) => {
   const locale = useLocale();
+  const { i18n } = useLingui()
 
   const [observationsQuery] = useObservationsQuery({
     variables: {
@@ -332,7 +334,7 @@ const PriceDistributionHistogram = ({
             data={observations as GenericObservation[]}
             medianValue={medianValue}
             yAxisLabel={getEntityLabelId(entity)}
-            xAxisUnit={RP_PER_KWH}
+            xAxisUnit={i18n._(RP_PER_KWH)}
             fields={{
               x: {
                 componentIri: "value",

--- a/src/components/detail-page/price-evolution-line-chart.tsx
+++ b/src/components/detail-page/price-evolution-line-chart.tsx
@@ -1,4 +1,5 @@
 import { t, Trans } from "@lingui/macro";
+import { useLingui } from "@lingui/react";
 import { Box } from "@mui/material";
 import { memo } from "react";
 
@@ -229,6 +230,8 @@ const PriceEvolutionLineChart = (props: {
   const hasMultipleLines =
     new Set(withUniqueEntityId.map((obs) => obs.uniqueId)).size > 1;
 
+  const { i18n } = useLingui()
+
   return (
     <Box>
       <Box fontSize="1rem" fontWeight="bold">
@@ -242,7 +245,7 @@ const PriceEvolutionLineChart = (props: {
           },
           y: {
             componentIri: pc,
-            axisLabel: RP_PER_KWH,
+            axisLabel: i18n._(RP_PER_KWH),
           },
           segment: hasMultipleLines
             ? {

--- a/src/components/network-cost-trend-chart.tsx
+++ b/src/components/network-cost-trend-chart.tsx
@@ -1,4 +1,5 @@
 import { t } from "@lingui/macro";
+import { useLingui } from "@lingui/react";
 import { Box, BoxProps } from "@mui/material";
 import { useMemo } from "react";
 
@@ -83,6 +84,7 @@ const NetworkCostLatestYearChartView = (
   } = props;
 
   const entityField = "operator_id";
+  const { i18n } = useLingui()
 
   const mappedObservations = useMemo(() => {
     return observations
@@ -111,9 +113,9 @@ const NetworkCostLatestYearChartView = (
       compact={compact}
       xField={{
         componentIri: "rate",
-        axisLabel: getNetworkLevelMetrics(
+        axisLabel: i18n._(getNetworkLevelMetrics(
           observations[0]?.network_level as NetworkLevel["id"]
-        ),
+        )),
       }}
       yField={{ componentIri: "network_level" }}
       segmentField={{
@@ -166,6 +168,8 @@ const ProgressOvertimeChartView = (
     );
   }, [observations]);
 
+  const { i18n } = useLingui()
+
   if (observations.length === 0) {
     return <NoDataHint />;
   }
@@ -180,9 +184,9 @@ const ProgressOvertimeChartView = (
       mini={mini}
       xField="year"
       yField="rate"
-      yAxisLabel={getNetworkLevelMetrics(
+      yAxisLabel={i18n._(getNetworkLevelMetrics(
         observations[0].network_level as NetworkLevel["id"]
-      )}
+      ))}
       entityField="operator_id"
     />
   );

--- a/src/components/operational-standards-chart.tsx
+++ b/src/components/operational-standards-chart.tsx
@@ -1,4 +1,5 @@
 import { t } from "@lingui/macro";
+import { useLingui } from "@lingui/react";
 import { Box } from "@mui/material";
 import { median as d3Median } from "d3";
 import { useMemo } from "react";
@@ -36,6 +37,7 @@ export const ServiceQualityChart = ({
     return chartData;
   }, [data.operatorsNotificationPeriodDays]);
   const median = d3Median(chartData, (d) => d.days);
+  const { i18n } = useLingui()
 
   return (
     <Box position="relative">
@@ -44,12 +46,12 @@ export const ServiceQualityChart = ({
         medianValue={median}
         aspectRatio={0.3}
         groupedBy={5}
-        xAxisLabel={DAYS}
+        xAxisLabel={i18n._(DAYS)}
         yAxisLabel={t({
           id: "sunshine.operational-standards.service-quality.share-of-operators",
           message: "Share of operators",
         })}
-        xAxisUnit={DAYS}
+        xAxisUnit={i18n._(DAYS)}
         yAsPercentage
         fields={{
           x: { componentIri: "days" },
@@ -104,6 +106,7 @@ export const ComplianceChart = ({
   }, [data.operatorsFrancsPerInvoice]);
 
   const median = d3Median(chartData, (d) => d.francsPerInvoice);
+  const { i18n } = useLingui()
   return (
     <Box position="relative">
       <Histogram
@@ -111,12 +114,12 @@ export const ComplianceChart = ({
         medianValue={median}
         aspectRatio={0.3}
         groupedBy={25}
-        xAxisLabel={SWISS_FRANCS}
+        xAxisLabel={i18n._(SWISS_FRANCS)}
         yAxisLabel={t({
           id: "sunshine.operational-standards.compliance.share-of-operators",
           message: "Share of operators",
         })}
-        xAxisUnit={SWISS_FRANCS}
+        xAxisUnit={i18n._(SWISS_FRANCS)}
         yAsPercentage
         fields={{
           x: { componentIri: "francsPerInvoice" },

--- a/src/components/power-stability-horizontal-stacked-bars.tsx
+++ b/src/components/power-stability-horizontal-stacked-bars.tsx
@@ -1,4 +1,5 @@
 import { t } from "@lingui/macro";
+import { useLingui } from "@lingui/react";
 import { Box, Typography } from "@mui/material";
 import { max } from "d3";
 import { groupBy } from "lodash";
@@ -162,13 +163,15 @@ export const PowerStabilityHorizontalStackedBars = (
   }, [compact, sortedDataWithoutMedian]);
   const rowHeight = 46;
 
+  const { i18n } = useLingui()
+
   return (
     <StackedBarsChart
       data={sortedDataWithoutMedian}
       fields={{
         x: {
           componentIri: ["planned", "unplanned"],
-          axisLabel: overallOrRatio === "ratio" ? PERCENT : COUNT_PER_YEAR,
+          axisLabel: overallOrRatio === "ratio" ? i18n._(PERCENT) : i18n._(COUNT_PER_YEAR),
         },
         domain: xDomain,
         annotation: medianPeerGroupObservation

--- a/src/components/tariffs-trend-chart.tsx
+++ b/src/components/tariffs-trend-chart.tsx
@@ -1,4 +1,5 @@
 import { t } from "@lingui/macro";
+import { useLingui } from "@lingui/react";
 import { Box, BoxProps } from "@mui/material";
 import { useMemo } from "react";
 
@@ -68,6 +69,7 @@ const TariffsLatestYearChartView = (
   } = props;
 
   const entityField = "operator_id";
+  const { i18n } = useLingui()
 
   const mappedObservations = useMemo(() => {
     return observations
@@ -91,7 +93,7 @@ const TariffsLatestYearChartView = (
       compareWith={compareWith}
       colorMapping={colorMapping}
       entityField={entityField}
-      xField={{ componentIri: "rate", axisLabel: RP_PER_KWH }}
+      xField={{ componentIri: "rate", axisLabel: i18n._(RP_PER_KWH) }}
       yField={{ componentIri: "category" }}
       segmentField={{
         componentIri: "operator_name",
@@ -133,6 +135,7 @@ const ProgressOvertimeChartView = (
     colorMapping,
     mini,
   } = props;
+  const { i18n } = useLingui()
 
   const validObservations = useMemo(() => {
     return observations.filter(
@@ -150,7 +153,7 @@ const ProgressOvertimeChartView = (
       mini={mini}
       xField="period"
       yField="rate"
-      yAxisLabel={RP_PER_KWH}
+      yAxisLabel={i18n._(RP_PER_KWH)}
       entityField="operator_id"
     />
   );

--- a/src/domain/metrics.ts
+++ b/src/domain/metrics.ts
@@ -1,40 +1,40 @@
-import { t } from "@lingui/macro";
+import { defineMessage } from "@lingui/macro";
 
 import { NetworkLevel } from "./sunshine";
 
-export const RP_PER_KWH = t({
+export const RP_PER_KWH = defineMessage({
   id: "sunshine.metric-unit.rp-kwh",
   message: "Rp./kWh",
 });
-export const RP_PER_KM = t({
+export const RP_PER_KM = defineMessage({
   id: "sunshine.metric-unit.rp-km",
   message: "Rp./km",
 });
-const CHF_PER_KM = t({
+const CHF_PER_KM = defineMessage({
   id: "sunshine.metric-unit.chf-km",
   message: "CHF/km",
 });
-const CHF_PER_KVA = t({
+const CHF_PER_KVA = defineMessage({
   id: "sunshine.metric-unit.chf-kva",
   message: "CHF/kVA",
 });
-export const MIN_PER_YEAR = t({
+export const MIN_PER_YEAR = defineMessage({
   id: "sunshine.metric-unit.min-year",
   message: "Min./year",
 });
-export const COUNT_PER_YEAR = t({
+export const COUNT_PER_YEAR = defineMessage({
   id: "sunshine.metric-unit.anzahl-year",
   message: "Count/year",
 });
-export const PERCENT = t({
+export const PERCENT = defineMessage({
   id: "sunshine.metric-unit.percent",
   message: "%",
 });
-export const DAYS = t({
+export const DAYS = defineMessage({
   id: "sunshine.metric-unit.days",
   message: "days",
 });
-export const SWISS_FRANCS = t({
+export const SWISS_FRANCS = defineMessage({
   id: "sunshine.metric-unit.swiss-francs",
   message: "CHF",
 });

--- a/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+++ b/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -1,4 +1,5 @@
 import { t, Trans } from "@lingui/macro";
+import { useLingui } from "@lingui/react";
 import { Box, Typography, useTheme } from "@mui/material";
 import ErrorPage from "next/error";
 import Head from "next/head";
@@ -222,6 +223,7 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
     yearlyData: _yearlyData,
   } = networkCosts;
   const networkLabels = getNetworkLevelLabels({ id: networkLevel });
+  const { i18n } = useLingui()
 
   const operatorLabel = props.name;
 
@@ -244,7 +246,7 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
             ),
             value: {
               value: operatorRate,
-              unit: getNetworkLevelMetrics(networkLevel),
+              unit: i18n._(getNetworkLevelMetrics(networkLevel)),
               trend: operatorTrend,
               round: 0,
             },
@@ -259,7 +261,7 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
             ),
             value: {
               value: peerGroupMedianRate,
-              unit: getNetworkLevelMetrics(networkLevel),
+              unit: i18n._(getNetworkLevelMetrics(networkLevel)),
               trend: peerGroupMedianTrend,
               round: 0,
             },
@@ -410,6 +412,7 @@ const EnergyTariffs = (props: Extract<Props, { status: "found" }>) => {
   const categoryLabels = getCategoryLabels(category);
 
   const operatorLabel = props.name;
+  const { i18n } = useLingui()
 
   const comparisonCardProps = {
     title: (
@@ -430,7 +433,7 @@ const EnergyTariffs = (props: Extract<Props, { status: "found" }>) => {
             ),
             value: {
               value: operatorRate,
-              unit: RP_PER_KWH,
+              unit: i18n._(RP_PER_KWH),
               round: 2,
               trend: operatorTrend,
             },
@@ -445,7 +448,7 @@ const EnergyTariffs = (props: Extract<Props, { status: "found" }>) => {
             ),
             value: {
               value: peerGroupMedianRate,
-              unit: RP_PER_KWH,
+              unit: i18n._(RP_PER_KWH),
               round: 2,
               trend: peerGroupMedianTrend,
             },
@@ -602,6 +605,7 @@ const NetTariffs = (props: Extract<Props, { status: "found" }>) => {
   const categoryLabels = getCategoryLabels(category);
 
   const operatorLabel = props.name;
+  const { i18n } = useLingui()
 
   const comparisonCardProps = {
     title: (
@@ -622,7 +626,7 @@ const NetTariffs = (props: Extract<Props, { status: "found" }>) => {
             ),
             value: {
               value: operatorRate,
-              unit: RP_PER_KWH,
+              unit: i18n._(RP_PER_KWH),
               round: 2,
               trend: operatorTrend,
             },
@@ -637,7 +641,7 @@ const NetTariffs = (props: Extract<Props, { status: "found" }>) => {
             ),
             value: {
               value: peerGroupMedianRate,
-              unit: RP_PER_KWH,
+              unit: i18n._(RP_PER_KWH),
               round: 2,
               trend: peerGroupMedianTrend,
             },

--- a/src/pages/sunshine/[entity]/[id]/power-stability.tsx
+++ b/src/pages/sunshine/[entity]/[id]/power-stability.tsx
@@ -1,4 +1,5 @@
 import { t, Trans } from "@lingui/macro";
+import { useLingui } from "@lingui/react";
 import { useTheme } from "@mui/material";
 import ErrorPage from "next/error";
 import Head from "next/head";
@@ -123,6 +124,7 @@ const Saidi = (props: Extract<Props, { status: "found" }>) => {
   } = props.powerStability;
 
   const operatorLabel = props.name;
+  const { i18n } = useLingui()
 
   const comparisonCardProps = {
     title: (
@@ -138,7 +140,7 @@ const Saidi = (props: Extract<Props, { status: "found" }>) => {
         label: <Trans id="sunshine.power-stability.saidi.total">Total</Trans>,
         value: {
           value: saidi.operatorTotal,
-          unit: MIN_PER_YEAR,
+          unit: i18n._(MIN_PER_YEAR),
           trend: saidi.trendTotal,
           round: 2,
         },
@@ -149,7 +151,7 @@ const Saidi = (props: Extract<Props, { status: "found" }>) => {
         ),
         value: {
           value: saidi.operatorUnplanned,
-          unit: MIN_PER_YEAR,
+          unit: i18n._(MIN_PER_YEAR),
           trend: saidi.trendUnplanned,
           round: 2,
         },
@@ -162,7 +164,7 @@ const Saidi = (props: Extract<Props, { status: "found" }>) => {
         ),
         value: {
           value: saidi.peerGroupMedianTotal,
-          unit: MIN_PER_YEAR,
+          unit: i18n._(MIN_PER_YEAR),
           round: 2,
           trend: saidi.peerGroupMedianTrendTotal,
         },
@@ -175,7 +177,7 @@ const Saidi = (props: Extract<Props, { status: "found" }>) => {
         ),
         value: {
           value: saidi.peerGroupMedianUnplanned,
-          unit: MIN_PER_YEAR,
+          unit: i18n._(MIN_PER_YEAR),
           round: 2,
           trend: saidi.peerGroupMedianTrendUnplanned,
         },
@@ -240,6 +242,7 @@ const Saifi = (props: Extract<Props, { status: "found" }>) => {
   } = props.powerStability;
 
   const operatorLabel = props.name;
+  const { i18n } = useLingui()
 
   const comparisonCardProps = {
     title: (
@@ -255,7 +258,7 @@ const Saifi = (props: Extract<Props, { status: "found" }>) => {
         label: <Trans id="sunshine.power-stability.saifi.total">Total</Trans>,
         value: {
           value: saifi.operatorTotal,
-          unit: COUNT_PER_YEAR,
+          unit: i18n._(COUNT_PER_YEAR),
           round: 2,
           trend: saifi.trendTotal,
         },
@@ -266,7 +269,7 @@ const Saifi = (props: Extract<Props, { status: "found" }>) => {
         ),
         value: {
           value: saifi.operatorUnplanned,
-          unit: COUNT_PER_YEAR,
+          unit: i18n._(COUNT_PER_YEAR),
           round: 2,
           trend: saifi.trendUnplanned,
         },
@@ -279,7 +282,7 @@ const Saifi = (props: Extract<Props, { status: "found" }>) => {
         ),
         value: {
           value: saifi.peerGroupMedianTotal,
-          unit: COUNT_PER_YEAR,
+          unit: i18n._(COUNT_PER_YEAR),
           round: 2,
           trend: saifi.peerGroupMedianTrendTotal,
         },
@@ -292,7 +295,7 @@ const Saifi = (props: Extract<Props, { status: "found" }>) => {
         ),
         value: {
           value: saifi.peerGroupMedianUnplanned,
-          unit: COUNT_PER_YEAR,
+          unit: i18n._(COUNT_PER_YEAR),
           round: 2,
           trend: saifi.peerGroupMedianTrendUnplanned,
         },


### PR DESCRIPTION

## Description

Units are module level were not translated

Go to https://elcom-electricity-price-website-git-fix-units-ixt1.vercel.app/fr/sunshine/operator/486/power-stability

## Related Issues

fix #572

## Testing Performed


- [x] Tested with the following Browsers: Firefox
- [x] Tested on the following devices: MacbookPro
- [x] Verified functionality:  Manually

### Testing/Reproduction Steps

- When looking at a SAIDI page in a non-german language (ie. `/sunshine/operator/486/power-stability#main-content`), the Anzahl/Jahr legend should be translated 
- Same on the Compliance page (`/sunshine/operator/486/operational-standards`)



## Checklist


- [ ] I have tested my changes thoroughly
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [x] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog
