### PR TITLE
chore: Update docker GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
         # Build app
       - name: Extract metadata (tags, labels) for Docker
         id: meta-app
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.IMAGE_NAME_APP}}
           # Added type=sha to the default
@@ -60,18 +60,18 @@ jobs:
             type=sha
 
       - name: Log in to Github Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build and export to Docker
         id: build-app
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: ./Dockerfile
@@ -93,7 +93,7 @@ jobs:
           severity: "CRITICAL,HIGH"
 
       - name: Build and Push Docker image to registry
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
## Summary

- `docker/login-action` v3.7.0 → v4.0.0
- `docker/metadata-action` v5.10.0 → v6.0.0
- `docker/build-push-action` v6.19.2 → v7.0.0
- `docker/setup-buildx-action` v3.12.0 → v4.0.0

Supersedes and closes the Dependabot PRs:
- Closes #596
- Closes #597
- Closes #598
- Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)