### PR TITLE
feat: Improve search reliability and UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "make-plural": "^7.0.0",
     "micromark": "^2.11.2",
     "micromark-extension-gfm": "^0.3.3",
+    "minisearch": "^7.2.0",
     "mitt": "^3.0.1",
     "next": "^15.5.15",
     "nextkit": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@storybook/nextjs": "^8.6.12",
     "@testing-library/react": "^16.3.2",
     "@tpluscode/rdf-ns-builders": "^1.0.0",
-    "@tpluscode/rdf-string": "^1.3.3",
+
     "@tpluscode/sparql-builder": "^2.0.3",
     "@turf/bbox": "^7.3.4",
     "@turf/centroid": "^6.5.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,10 @@ import { loadEnvConfig } from "@next/env";
 import { defineConfig, devices } from "@playwright/test";
 
 import { createMetricsReporterOptions } from "./src/metrics/playwright-reporter";
+import {
+  getExtraHttpHeadersFromEnv,
+  getHttpCredentialsFromEnv,
+} from "./src/utils/test-utils";
 
 loadEnvConfig(process.cwd(), true);
 
@@ -23,20 +27,6 @@ const argosBuildName =
         get: (test: { tags: string[] }) =>
           test.tags.includes("@storybook") ? "storybook" : "app",
       };
-
-const getHttpCredentialsFromEnv = () => {
-  const usernamePassword = process.env.BASIC_AUTH_CREDENTIALS;
-  if (!usernamePassword) {
-    return undefined;
-  }
-  const [username, password] = usernamePassword.split(":");
-  if (!username || !password) {
-    throw new Error(
-      "BASIC_AUTH_CREDENTIALS environment variable must be in the format 'username:password'"
-    );
-  }
-  return { username, password };
-};
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -89,13 +79,7 @@ export default defineConfig({
       use: {
         ...devices["Desktop Chrome"],
         httpCredentials: getHttpCredentialsFromEnv(),
-        extraHTTPHeaders: {
-          "x-vercel-skip-toolbar": "1",
-          ...(process.env.VERCEL_AUTOMATION_BYPASS_SECRET && {
-            "x-vercel-protection-bypass":
-              process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
-          }),
-        },
+        extraHTTPHeaders: getExtraHttpHeadersFromEnv(),
       },
     },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       micromark-extension-gfm:
         specifier: ^0.3.3
         version: 0.3.3
+      minisearch:
+        specifier: ^7.2.0
+        version: 7.2.0
       mitt:
         specifier: ^3.0.1
         version: 3.0.1
@@ -9153,6 +9156,9 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
@@ -23198,6 +23204,8 @@ snapshots:
   minipass@4.2.8: {}
 
   minipass@7.1.2: {}
+
+  minisearch@7.2.0: {}
 
   minizlib@3.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,9 +104,6 @@ importers:
       '@tpluscode/rdf-ns-builders':
         specifier: ^1.0.0
         version: 1.1.0(@zazuko/rdf-vocabularies@2023.1.19)(clownface@2.0.3)(safe-identifier@0.4.2)(ts-morph@27.0.2)(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))
-      '@tpluscode/rdf-string':
-        specifier: ^1.3.3
-        version: 1.3.4
       '@tpluscode/sparql-builder':
         specifier: ^2.0.3
         version: 2.0.4(sparql-http-client@2.4.2(encoding@0.1.13))

--- a/src/components/info-dialog-props.ts
+++ b/src/components/info-dialog-props.ts
@@ -61,6 +61,13 @@ const infoDialogProps = () =>
         message: "Outage Information",
       }),
     },
+    "help-peer-group": {
+      slug: "help-peer-group",
+      label: t({
+        id: "sunshine.costs-and-tariffs.peer-group",
+        message: "Peer Group",
+      }),
+    },
   } satisfies Partial<Record<WikiPageSlug, InfoDialogButtonProps>>);
 
 export const getInfoDialogProps = <

--- a/src/components/peer-group-card.tsx
+++ b/src/components/peer-group-card.tsx
@@ -28,7 +28,6 @@ const PeerGroupCard: React.FC<
             right: (theme) => theme.spacing(3),
           }}
           iconOnly
-          iconSize={24}
           type="outline"
           slug={infoDialogProps.slug}
           label={infoDialogProps.label}

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -197,9 +197,10 @@ const SearchField = ({
   type SearchAutocompleteProps = AutocompleteProps<Item, false, false, false>;
   const handleInputChange: SearchAutocompleteProps["onInputChange"] = (
     event,
-    value
+    value,
+    reason
   ) => {
-    if (!event) {
+    if (!event || reason === "reset") {
       return;
     }
     setInputValue(value);
@@ -218,6 +219,9 @@ const SearchField = ({
       };
       push(href);
       onSelection();
+      setInputValue("");
+      setSearchString("");
+      inputRef.current?.blur();
     }
   };
 

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -40,7 +40,7 @@ export const Search = () => {
     pause: searchString === "",
   });
 
-  const items = gqlQuery.data?.search ?? EMPTY_ARRAY;
+  const items = searchString === "" ? EMPTY_ARRAY : (gqlQuery.data?.search ?? EMPTY_ARRAY);
 
   useEffect(() => {
     const currentVariables = gqlQuery.operation?.variables as

--- a/src/e2e/details.spec.ts
+++ b/src/e2e/details.spec.ts
@@ -1,13 +1,16 @@
-import { test, expect } from "src/e2e/common";
+import { expect, test } from "src/e2e/common";
 
 test.describe("Segmented control visibility", () => {
   test("should appear for operator with multiple municipalities", async ({
     page,
   }) => {
     await page.goto("/en/operator/565?period=2025");
-    await page.getByRole("heading", { name: "Price components" }).waitFor();
+    const priceComponents = page.getByRole("heading", {
+      name: "Price components",
+    });
+    await priceComponents.scrollIntoViewIfNeeded();
     await expect(
-      await page.getByRole("button", { name: "Group municipalities",  })
+      await page.getByRole("button", { name: "Group municipalities" }),
     ).toBeVisible({
       timeout: 10_000,
     });
@@ -20,7 +23,7 @@ test.describe("Segmented control visibility", () => {
     await page.getByRole("heading", { name: "Price components" }).waitFor();
 
     await expect(
-      page.getByRole("button", { name: "Group municipalites" })
+      page.getByRole("button", { name: "Group municipalites" }),
     ).not.toBeVisible({
       timeout: 10_000,
     });
@@ -33,7 +36,7 @@ test.describe("Segmented control visibility", () => {
     await page.getByRole("heading", { name: "Price components" }).waitFor();
 
     await expect(
-      page.getByRole("button", { name: "Grouping network operators" })
+      page.getByRole("button", { name: "Grouping network operators" }),
     ).not.toBeVisible();
   });
 
@@ -44,14 +47,14 @@ test.describe("Segmented control visibility", () => {
     await page.getByRole("heading", { name: "Price components" }).waitFor();
 
     await expect(
-      page.getByRole("button", { name: "Grouping network operators" })
+      page.getByRole("button", { name: "Grouping network operators" }),
     ).toBeVisible({ timeout: 25_000 });
   });
 
   test("should not appear for canton view", async ({ page }) => {
     await page.goto("/en/canton/1");
     await expect(
-      page.getByRole("button", { name: "Group municipalities" })
+      page.getByRole("button", { name: "Group municipalities" }),
     ).not.toBeVisible();
   });
 });

--- a/src/e2e/home.spec.ts
+++ b/src/e2e/home.spec.ts
@@ -1,5 +1,6 @@
 import { ensureLoadingIsComplete, expect, sleep, test } from "src/e2e/common";
 import InflightRequests from "src/e2e/inflight";
+import { getExtraHttpHeadersFromEnv } from "src/utils/test-utils";
 
 test.describe("The Home Page", () => {
   test.beforeEach(async ({ setFlags, page }) => {
@@ -8,6 +9,7 @@ test.describe("The Home Page", () => {
   test("default language (de) should render on /", async ({ browser }) => {
     const page = await browser.newPage({
       extraHTTPHeaders: {
+        ...(getExtraHttpHeadersFromEnv() ?? {}),
         "Accept-Language": "de",
       },
     });

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -86,9 +86,9 @@ const searchWithIndex = async ({
   }
 
   const hits = index.search(query);
-  const byId = new Map(data.map((d) => [d.id, d]));
+  const byKey = new Map(data.map((d) => [`${d.type}:${d.id}`, d]));
   return hits
-    .map((hit) => byId.get(hit.id))
+    .map((hit) => byKey.get(`${(hit as $IntentionalAny).type}:${hit.id}`))
     .filter((r): r is CachedSearchResult => r !== undefined);
 };
 

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -1,17 +1,18 @@
 import { difference } from "d3";
 import { GraphQLError, GraphQLResolveInfo } from "graphql";
 import { parseResolveInfo, ResolveTree } from "graphql-parse-resolve-info";
+import { last, sortBy } from "lodash";
 import micromark from "micromark";
-import type { IndicatorMedianParams } from "src/lib/sunshine-data";
-import type { PeerGroupRecord } from "src/lib/sunshine-data-service";
+import { asElectricityCategory } from "src/domain/data";
 
 import { searchGeverDocuments } from "src/domain/gever";
+import { asNetworkLevel, SunshineIndicator } from "src/domain/sunshine";
 import { getWikiPage } from "src/domain/wiki/gitlab-api";
 import {
+  ElectricityCategory,
   ResolvedCantonMedianObservation,
   ResolvedOperatorObservation,
   ResolvedSwissMedianObservation,
-  ElectricityCategory,
 } from "src/graphql/resolver-mapped-types";
 import {
   CantonMedianObservationResolvers,
@@ -25,6 +26,8 @@ import {
   SunshineDataFilter,
   SwissMedianObservationResolvers,
 } from "src/graphql/resolver-types";
+import { getSearchIndex, SearchType } from "src/lib/search-index-cache";
+import type { IndicatorMedianParams } from "src/lib/sunshine-data";
 import {
   fetchEnergyTariffsData,
   fetchNetTariffsData,
@@ -35,33 +38,30 @@ import {
   fetchSaidi,
   fetchSaifi,
 } from "src/lib/sunshine-data";
+import type { PeerGroupRecord } from "src/lib/sunshine-data-service";
+import { truthy } from "src/lib/truthy";
 import { defaultLocale } from "src/locales/config";
-import {
-  getElectricityPriceCantonCube,
-  getDimensionValuesAndLabels,
-  getElectricityPriceObservations,
-  getElectricityPriceCube,
-  getOperatorDocuments,
-  getElectricityPriceSwissCube,
-  getOperatorsMunicipalities,
-  getView,
-} from "src/rdf/queries";
-import { fetchOperatorInfo } from "src/rdf/search-queries";
-import { getSearchIndex, SearchType } from "src/lib/search-index-cache";
-import { asElectricityCategory } from "src/domain/data";
-import { asNetworkLevel, SunshineIndicator } from "src/domain/sunshine";
-import { last, sortBy } from "lodash";
 import {
   CoverageCacheManager,
   DEFAULT_COVERAGE_NETWORK_LEVEL,
 } from "src/rdf/coverage-ratio";
-import { truthy } from "src/lib/truthy";
+import {
+  getDimensionValuesAndLabels,
+  getElectricityPriceCantonCube,
+  getElectricityPriceCube,
+  getElectricityPriceObservations,
+  getElectricityPriceSwissCube,
+  getOperatorDocuments,
+  getOperatorsMunicipalities,
+  getView,
+} from "src/rdf/queries";
+import { fetchOperatorInfo } from "src/rdf/search-queries";
 
 const gfmSyntax = require("micromark-extension-gfm");
 const gfmHtml = require("micromark-extension-gfm/html");
 
-import type { SearchResult as CachedSearchResult } from "src/lib/search-index-cache";
 import ParsingClient from "sparql-http-client/ParsingClient";
+import type { SearchResult as CachedSearchResult } from "src/lib/search-index-cache";
 
 const searchWithIndex = async ({
   locale,
@@ -111,9 +111,8 @@ const expectedCubeDimensions = [
 const Query: QueryResolvers = {
   sunshineData: async (_parent, args, context) => {
     const { filter } = args;
-    const sunshineData = await context.sunshineDataService.getSunshineData(
-      filter
-    );
+    const sunshineData =
+      await context.sunshineDataService.getSunshineData(filter);
     return sunshineData;
   },
   sunshineDataByIndicator: async (_parent, args, context) => {
@@ -138,7 +137,7 @@ const Query: QueryResolvers = {
 
     // Calculate median value
     const typedIndicator = filter.indicator as SunshineIndicator | undefined;
-    let medianValue: number | undefined = undefined;
+    let medianValue: number | undefined;
 
     if (typedIndicator) {
       try {
@@ -153,9 +152,9 @@ const Query: QueryResolvers = {
         if (medianParams) {
           const medianRows = sortBy(
             await context.sunshineDataService.getYearlyIndicatorMedians(
-              medianParams
+              medianParams,
             ),
-            (x) => x.period
+            (x) => x.period,
           );
           const medianResult = filter.period
             ? medianRows.find((x) => `${x.period}` === filter.period!)
@@ -164,7 +163,7 @@ const Query: QueryResolvers = {
             getMedianValueFromResult(
               medianResult,
               typedIndicator,
-              filter.saidiSaifiType ?? undefined
+              filter.saidiSaifiType ?? undefined,
             ) ?? undefined;
         }
       } catch (_error) {
@@ -172,7 +171,7 @@ const Query: QueryResolvers = {
         console.error(
           `Failed to calculate median for indicator ${filter.indicator}: ${
             _error instanceof Error ? _error.message : _error
-          }`
+          }`,
         );
       }
     }
@@ -206,9 +205,9 @@ const Query: QueryResolvers = {
       if (medianParams) {
         const medianRows = sortBy(
           await context.sunshineDataService.getYearlyIndicatorMedians(
-            medianParams
+            medianParams,
           ),
-          (x) => x.period
+          (x) => x.period,
         );
         const medianResult = filter.period
           ? medianRows.find((x) => `${x.period}` === filter.period!)
@@ -217,14 +216,14 @@ const Query: QueryResolvers = {
           getMedianValueFromResult(
             medianResult,
             typedIndicator!,
-            filter.saidiSaifiType ?? undefined
+            filter.saidiSaifiType ?? undefined,
           ) ?? 0;
       } else {
         throw new GraphQLError(
           `Unsupported indicator for median calculation: ${typedIndicator}`,
           {
             extensions: { code: "UNSUPPORTED_INDICATOR" },
-          }
+          },
         );
       }
     } catch (_error) {
@@ -234,7 +233,7 @@ const Query: QueryResolvers = {
         }`,
         {
           extensions: { code: "MEDIAN_CALCULATION_ERROR" },
-        }
+        },
       );
     }
 
@@ -245,9 +244,8 @@ const Query: QueryResolvers = {
     if (!filter.operatorId && !filter.period) {
       throw new Error("Must either filter by year or by provider.");
     }
-    const sunshineData = await context.sunshineDataService.getSunshineData(
-      filter
-    );
+    const sunshineData =
+      await context.sunshineDataService.getSunshineData(filter);
     return sunshineData;
   },
   sunshineTariffsByIndicator: async (_parent, args, context) => {
@@ -310,7 +308,7 @@ const Query: QueryResolvers = {
             {
               filters,
               dimensions: observationDimensionKeys,
-            }
+            },
           )
         : [];
 
@@ -320,7 +318,7 @@ const Query: QueryResolvers = {
     })) as ResolvedOperatorObservation[];
 
     const years = Array.from(
-      new Set(operatorObservations.map((x) => x.period).filter(truthy))
+      new Set(operatorObservations.map((x) => x.period).filter(truthy)),
     );
     if (years) {
       const defaultNetworkLevel = "NE7";
@@ -329,7 +327,7 @@ const Query: QueryResolvers = {
       operatorObservations.forEach((x) => {
         const coverageRatio = coverageManager.getCoverage(
           x,
-          defaultNetworkLevel
+          defaultNetworkLevel,
         );
         x.coverageRatio = coverageRatio;
         return x;
@@ -338,14 +336,14 @@ const Query: QueryResolvers = {
 
     return CoverageCacheManager.filterByCoverageRatio(
       operatorObservations,
-      (o) => o.coverageRatio
+      (o) => o.coverageRatio,
     );
   },
   cantonMedianObservations: async (
     _,
     { locale, filters, observationKind },
     ctx,
-    info
+    info,
   ) => {
     if (observationKind && observationKind !== ObservationKind.Canton) {
       return null;
@@ -367,7 +365,7 @@ const Query: QueryResolvers = {
     // Look ahead to select proper dimensions for query
     const medianObservationFields = getResolverFields(
       info,
-      "CantonMedianObservation"
+      "CantonMedianObservation",
     );
 
     const medianDimensionKeys = medianObservationFields
@@ -392,7 +390,7 @@ const Query: QueryResolvers = {
             {
               filters,
               dimensions: medianDimensionKeys,
-            }
+            },
           )
         : [];
 
@@ -422,7 +420,7 @@ const Query: QueryResolvers = {
     // Look ahead to select proper dimensions for query
     const medianObservationFields = getResolverFields(
       info,
-      "SwissMedianObservation"
+      "SwissMedianObservation",
     );
 
     const medianDimensionKeys = medianObservationFields
@@ -447,7 +445,7 @@ const Query: QueryResolvers = {
             {
               filters,
               dimensions: medianDimensionKeys,
-            }
+            },
           )
         : [];
 
@@ -513,7 +511,7 @@ const Query: QueryResolvers = {
     const { data } = await getSearchIndex(
       locale,
       ["municipality"],
-      context.sparqlClient
+      context.sparqlClient,
     );
     return data;
   },
@@ -571,7 +569,7 @@ const Query: QueryResolvers = {
     // Exit early if home-banner is requested and it's disabled
     const extraInfo = await getExtraInfo(slug);
     const wikiPage = await getWikiPage(
-      `${slug}/${locale === "en" ? "de" : locale}`
+      `${slug}/${locale === "en" ? "de" : locale}`,
     );
 
     if (!wikiPage) {
@@ -653,7 +651,7 @@ const Query: QueryResolvers = {
   operatorMunicipalities: async (
     _,
     { period, electricityCategory, networkLevel },
-    context
+    context,
   ) => {
     const category = electricityCategory
       ? asElectricityCategory(electricityCategory)
@@ -674,7 +672,7 @@ const Query: QueryResolvers = {
           municipality: String(item.municipality),
           operator: item.operator,
         },
-        level
+        level,
       );
       return coverage;
     });
@@ -684,7 +682,7 @@ const Query: QueryResolvers = {
 const getExtraInfo = async (slug: string) => {
   if (slug === "home-banner") {
     const bannerEnabled = (await getWikiPage("home"))?.content.match(
-      /home_banner_enabled:\W*true/
+      /home_banner_enabled:\W*true/,
     );
     return { bannerEnabled };
   } else {
@@ -708,7 +706,7 @@ const Operator: OperatorResolvers = {
     const cube = await getElectricityPriceCube(ctx.sparqlClient);
 
     // Get locale from operation variables, default to 'de'
-    const locale = (info.variableValues as any)?.locale ?? 'de';
+    const locale = (info.variableValues as any)?.locale ?? "de";
 
     const municipalities = await getDimensionValuesAndLabels({
       cube,
@@ -740,7 +738,7 @@ const Operator: OperatorResolvers = {
     } catch (e) {
       console.warn(
         "Could not search documents",
-        e instanceof Error ? e.message : e
+        e instanceof Error ? e.message : e,
       );
       return [];
     }
@@ -748,11 +746,11 @@ const Operator: OperatorResolvers = {
 
   peerGroup: async ({ id }, _args, context) => {
     const latestYear = await context.sunshineDataService.getLatestYearSunshine(
-      parseInt(id, 10)
+      parseInt(id, 10),
     );
     const peerGroups = await context.sunshineDataService.getOperatorPeerGroup(
       id,
-      latestYear
+      latestYear,
     );
     return peerGroups;
   },
@@ -862,7 +860,7 @@ export const resolvers: Resolvers = {
 
 // Helper function to create indicator median params from structured filter
 const createIndicatorMedianParams = (
-  filter: SunshineDataFilter
+  filter: SunshineDataFilter,
 ): IndicatorMedianParams | null => {
   if (!filter.indicator) return null;
 
@@ -933,7 +931,7 @@ const createIndicatorMedianParams = (
 const getMedianValueFromResult = (
   result_: PeerGroupRecord<any> | undefined,
   indicator: SunshineIndicator,
-  saidiSaifiType?: string
+  saidiSaifiType?: string,
 ): number | undefined => {
   if (!result_) return undefined;
 

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -88,7 +88,7 @@ const searchWithIndex = async ({
   const hits = index.search(query);
   const byKey = new Map(data.map((d) => [`${d.type}:${d.id}`, d]));
   return hits
-    .map((hit) => byKey.get(`${(hit as $IntentionalAny).type}:${hit.id}`))
+    .map((hit) => byKey.get(`${hit.type}:${hit.id}`))
     .filter((r): r is CachedSearchResult => r !== undefined);
 };
 

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -46,7 +46,8 @@ import {
   getOperatorsMunicipalities,
   getView,
 } from "src/rdf/queries";
-import { fetchOperatorInfo, search } from "src/rdf/search-queries";
+import { fetchOperatorInfo } from "src/rdf/search-queries";
+import { getSearchIndex, SearchType } from "src/lib/search-index-cache";
 import { asElectricityCategory } from "src/domain/data";
 import { asNetworkLevel, SunshineIndicator } from "src/domain/sunshine";
 import { last, sortBy } from "lodash";
@@ -58,6 +59,38 @@ import { truthy } from "src/lib/truthy";
 
 const gfmSyntax = require("micromark-extension-gfm");
 const gfmHtml = require("micromark-extension-gfm/html");
+
+import type { SearchResult as CachedSearchResult } from "src/lib/search-index-cache";
+import ParsingClient from "sparql-http-client/ParsingClient";
+
+const searchWithIndex = async ({
+  locale,
+  types,
+  query,
+  ids,
+  client,
+}: {
+  locale: string;
+  types: SearchType[];
+  query: string;
+  ids: string[];
+  client: ParsingClient;
+}): Promise<CachedSearchResult[]> => {
+  if (query === "" && ids.length === 0) return [];
+
+  const { data, index } = await getSearchIndex(locale, types, client);
+
+  if (ids.length > 0) {
+    const idSet = new Set(ids);
+    return data.filter((d) => idSet.has(d.id));
+  }
+
+  const hits = index.search(query);
+  const byId = new Map(data.map((d) => [d.id, d]));
+  return hits
+    .map((hit) => byId.get(hit.id))
+    .filter((r): r is CachedSearchResult => r !== undefined);
+};
 
 const expectedCubeDimensions = [
   "https://energy.ld.admin.ch/elcom/electricityprice/dimension/category",
@@ -426,15 +459,13 @@ const Query: QueryResolvers = {
     return medianObservations;
   },
   operators: async (_, { query, ids, locale }, context) => {
-    const results = await search({
+    return searchWithIndex({
       locale,
       query: query ?? "",
       ids: ids ?? [],
       types: ["operator"],
       client: context.sparqlClient,
     });
-
-    return results;
   },
 
   peerGroups: async (_parent, { locale }, context) => {
@@ -443,82 +474,66 @@ const Query: QueryResolvers = {
   },
 
   municipalities: async (_, { query, ids, locale }, context) => {
-    const results = await search({
+    return searchWithIndex({
       locale,
       query: query ?? "",
       ids: ids ?? [],
       types: ["municipality"],
       client: context.sparqlClient,
     });
-
-    return results;
   },
   cantons: async (_, { query, ids, locale }, context) => {
-    const results = await search({
+    return searchWithIndex({
       locale,
       query: query ?? "",
       ids: ids ?? [],
       types: ["canton"],
       client: context.sparqlClient,
     });
-
-    return results;
   },
   search: async (_, { query, locale }, context) => {
-    const results = await search({
+    return searchWithIndex({
       locale,
       query: query ?? "",
       ids: [],
       types: ["municipality", "operator", "canton"],
       client: context.sparqlClient,
     });
-
-    return results;
   },
   searchMunicipalities: async (_, { query, locale, ids }, context) => {
-    const results = await search({
+    return searchWithIndex({
       locale,
       query: query ?? "",
       ids: ids ?? [],
       types: ["municipality"],
       client: context.sparqlClient,
     });
-
-    return results;
   },
   allMunicipalities: async (_, { locale }, context) => {
-    const results = await search({
+    const { data } = await getSearchIndex(
       locale,
-      query: ".*",
-      ids: [],
-      limit: 5000,
-      types: ["municipality"],
-      client: context.sparqlClient,
-    });
-
-    return results;
+      ["municipality"],
+      context.sparqlClient
+    );
+    return data;
   },
   searchOperators: async (_, { query, locale, ids }, context) => {
-    const results = await search({
+    return searchWithIndex({
       locale,
       query: query ?? "",
       ids: ids ?? [],
       types: ["operator"],
       client: context.sparqlClient,
     });
-
-    return results;
   },
   searchCantons: async (_, { query, locale, ids }, context) => {
-    const results = await search({
+    return searchWithIndex({
       locale,
       query: query ?? "",
       ids: ids ?? [],
       types: ["canton"],
       client: context.sparqlClient,
     });
-
-    return results;
   },
   municipality: async (_, { id }, ctx) => {
     const cube = await getElectricityPriceCube(ctx.sparqlClient);

--- a/src/lib/search-index-cache.ts
+++ b/src/lib/search-index-cache.ts
@@ -1,0 +1,108 @@
+import MiniSearch from "minisearch";
+import ParsingClient from "sparql-http-client/ParsingClient";
+
+import { search } from "src/rdf/search-queries";
+
+export type SearchType = "municipality" | "canton" | "operator";
+
+export type SearchResult = {
+  id: string;
+  name: string;
+  type: string;
+  isAbolished: boolean;
+};
+
+type CacheEntry = {
+  data: SearchResult[];
+  index: MiniSearch;
+  builtAt: number;
+};
+
+const STALE_AFTER_MS = 15 * 60 * 1000;
+
+// Keyed by `${endpointUrl}:${locale}:${type}`
+const cache = new Map<string, CacheEntry>();
+
+const normalizeText = (term: string) =>
+  term
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "");
+
+function buildIndex(data: SearchResult[]): MiniSearch {
+  const idx = new MiniSearch({
+    idField: "_key",
+    fields: ["name"],
+    storeFields: ["id", "name", "type", "isAbolished"],
+    tokenize: (term) => term.split(/[\s\-:(),]+/),
+    processTerm: normalizeText,
+    searchOptions: {
+      prefix: true,
+      fuzzy: 0.2,
+      processTerm: normalizeText,
+    },
+  });
+  idx.addAll(data.map((d) => ({ ...d, _key: `${d.type}:${d.id}` })));
+  return idx;
+}
+
+async function buildCacheEntry(
+  locale: string,
+  type: SearchType,
+  client: ParsingClient
+): Promise<CacheEntry> {
+  const data = await search({
+    query: ".*",
+    ids: [],
+    locale,
+    types: [type],
+    limit: 5000,
+    client,
+  });
+  const index = buildIndex(data);
+  return { data, index, builtAt: Date.now() };
+}
+
+function getEndpointUrl(client: ParsingClient): string {
+  return (client.query as $IntentionalAny).endpoint.endpointUrl as string;
+}
+
+async function getTypeEntry(
+  locale: string,
+  type: SearchType,
+  client: ParsingClient
+): Promise<CacheEntry> {
+  const key = `${getEndpointUrl(client)}:${locale}:${type}`;
+  const cached = cache.get(key);
+
+  if (!cached) {
+    const entry = await buildCacheEntry(locale, type, client);
+    cache.set(key, entry);
+    return entry;
+  }
+
+  if (Date.now() - cached.builtAt > STALE_AFTER_MS) {
+    buildCacheEntry(locale, type, client)
+      .then((entry) => cache.set(key, entry))
+      .catch(console.error);
+  }
+
+  return cached;
+}
+
+export async function getSearchIndex(
+  locale: string,
+  types: SearchType[],
+  client: ParsingClient
+): Promise<CacheEntry> {
+  if (types.length === 1) {
+    return getTypeEntry(locale, types[0], client);
+  }
+
+  const entries = await Promise.all(
+    types.map((t) => getTypeEntry(locale, t, client))
+  );
+  const data = entries.flatMap((e) => e.data);
+  const index = buildIndex(data);
+  return { data, index, builtAt: Date.now() };
+}

--- a/src/lib/search-index-cache.ts
+++ b/src/lib/search-index-cache.ts
@@ -1,16 +1,15 @@
 import MiniSearch from "minisearch";
 import ParsingClient from "sparql-http-client/ParsingClient";
 
-import { fetchLinkedMunicipalityIds, search } from "src/rdf/search-queries";
+import {
+  loadAllCantons,
+  loadAllMunicipalities,
+  loadAllOperators,
+  SearchResult,
+} from "src/rdf/search-queries";
 
+export type { SearchResult };
 export type SearchType = "municipality" | "canton" | "operator";
-
-export type SearchResult = {
-  id: string;
-  name: string;
-  type: string;
-  isAbolished: boolean;
-};
 
 type CacheEntry = {
   data: SearchResult[];
@@ -32,8 +31,8 @@ const normalizeText = (term: string) =>
 function buildIndex(data: SearchResult[]): MiniSearch {
   const idx = new MiniSearch({
     idField: "_key",
-    fields: ["name"],
-    storeFields: ["id", "name", "type", "isAbolished"],
+    fields: ["name", "postalCodes"],
+    storeFields: ["id", "name", "type", "isAbolished", "postalCodes"],
     tokenize: (term) => term.split(/[\s\-:(),]+/),
     processTerm: normalizeText,
     searchOptions: {
@@ -46,23 +45,27 @@ function buildIndex(data: SearchResult[]): MiniSearch {
   return idx;
 }
 
+async function loadAll(
+  locale: string,
+  type: SearchType,
+  client: ParsingClient
+): Promise<SearchResult[]> {
+  switch (type) {
+    case "municipality":
+      return loadAllMunicipalities({ client });
+    case "operator":
+      return loadAllOperators({ client });
+    case "canton":
+      return loadAllCantons({ client, locale });
+  }
+}
+
 async function buildCacheEntry(
   locale: string,
   type: SearchType,
   client: ParsingClient
 ): Promise<CacheEntry> {
-  const [allData, linkedIds] = await Promise.all([
-    search({ query: ".*", ids: [], locale, types: [type], limit: 5000, client }),
-    type === "municipality" ? fetchLinkedMunicipalityIds({ client }) : null,
-  ]);
-
-  const data =
-    linkedIds !== null
-      ? allData.filter((d) =>
-          linkedIds.has(`https://ld.admin.ch/municipality/${d.id}`)
-        )
-      : allData;
-
+  const data = await loadAll(locale, type, client);
   const index = buildIndex(data);
   return { data, index, builtAt: Date.now() };
 }

--- a/src/lib/search-index-cache.ts
+++ b/src/lib/search-index-cache.ts
@@ -1,7 +1,7 @@
 import MiniSearch from "minisearch";
 import ParsingClient from "sparql-http-client/ParsingClient";
 
-import { search } from "src/rdf/search-queries";
+import { fetchLinkedMunicipalityIds, search } from "src/rdf/search-queries";
 
 export type SearchType = "municipality" | "canton" | "operator";
 
@@ -51,14 +51,18 @@ async function buildCacheEntry(
   type: SearchType,
   client: ParsingClient
 ): Promise<CacheEntry> {
-  const data = await search({
-    query: ".*",
-    ids: [],
-    locale,
-    types: [type],
-    limit: 5000,
-    client,
-  });
+  const [allData, linkedIds] = await Promise.all([
+    search({ query: ".*", ids: [], locale, types: [type], limit: 5000, client }),
+    type === "municipality" ? fetchLinkedMunicipalityIds({ client }) : null,
+  ]);
+
+  const data =
+    linkedIds !== null
+      ? allData.filter((d) =>
+          linkedIds.has(`https://ld.admin.ch/municipality/${d.id}`)
+        )
+      : allData;
+
   const index = buildIndex(data);
   return { data, index, builtAt: Date.now() };
 }

--- a/src/pages/api/search.integration.spec.ts
+++ b/src/pages/api/search.integration.spec.ts
@@ -89,6 +89,22 @@ describe("Search - municipalities", () => {
     expect(results).toHaveLength(1);
     expect(results[0]).toMatchObject({ id: "351", name: "Bern" });
   });
+
+  it("finds municipality by exact zip code - 3011 returns Bern", async () => {
+    const results = await searchMunicipalities({ locale: "de", query: "3011" });
+    expect(results.some((r) => r.name === "Bern")).toBe(true);
+  });
+
+  it("finds municipality by exact zip code - 8001 returns Zürich", async () => {
+    const results = await searchMunicipalities({ locale: "de", query: "8001" });
+    expect(results.some((r) => r.name === "Zürich")).toBe(true);
+  });
+
+  it("finds municipalities by partial zip code prefix", async () => {
+    // Prefix "301" should match zip codes like 3011, 3012, 3013, … all in Bern
+    const results = await searchMunicipalities({ locale: "de", query: "301" });
+    expect(results.some((r) => r.name === "Bern")).toBe(true);
+  });
 });
 
 describe("Search - cantons", () => {

--- a/src/pages/api/search.integration.spec.ts
+++ b/src/pages/api/search.integration.spec.ts
@@ -78,6 +78,17 @@ describe("Search - municipalities", () => {
     expect(results[0]).toHaveProperty("id");
     expect(results[0]).toHaveProperty("name");
   });
+
+  it("hydrates labels by ids (empty query)", async () => {
+    // Used by MunicipalitiesCombobox to display names of already-selected items
+    const results = await searchMunicipalities({
+      locale: "de",
+      query: "",
+      ids: ["351"],
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ id: "351", name: "Bern" });
+  });
 });
 
 describe("Search - cantons", () => {
@@ -98,6 +109,16 @@ describe("Search - cantons", () => {
     expect(results.some((r) => r.name.toLowerCase().includes("zürich"))).toBe(
       true
     );
+  });
+
+  it("hydrates labels by ids (empty query)", async () => {
+    const results = await searchCantons({
+      locale: "de",
+      query: "",
+      ids: ["2"],
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ id: "2", name: "Bern" });
   });
 });
 
@@ -131,6 +152,16 @@ describe("Search - operators", () => {
       query: "axpo gid",
     });
     expect(results.some((r) => r.name === "Axpo Grid AG")).toBe(true);
+  });
+
+  it("hydrates labels by ids (empty query)", async () => {
+    const results = await searchOperators({
+      locale: "de",
+      query: "",
+      ids: ["36"],
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ id: "36", name: "BKW Energie AG" });
   });
 });
 

--- a/src/pages/api/search.integration.spec.ts
+++ b/src/pages/api/search.integration.spec.ts
@@ -41,7 +41,7 @@ describe("Search - municipalities", () => {
     const result = await makeClient()
       .query<MunicipalitiesQuery, MunicipalitiesQueryVariables>(
         MunicipalitiesDocument,
-        vars
+        vars,
       )
       .toPromise();
     return result.data?.municipalities ?? [];
@@ -123,7 +123,7 @@ describe("Search - cantons", () => {
   it("handles diacritics - zurich should match Zürich", async () => {
     const results = await searchCantons({ locale: "de", query: "zurich" });
     expect(results.some((r) => r.name.toLowerCase().includes("zürich"))).toBe(
-      true
+      true,
     );
   });
 
@@ -162,12 +162,12 @@ describe("Search - operators", () => {
     expect(results.some((r) => r.name === "AEW Energie AG")).toBe(true);
   });
 
-  it("handles typos - axpo gid should match Axpo Grid AG", async () => {
+  it("handles typos - axpo hidro should match Axpo Hydro", async () => {
     const results = await searchOperators({
       locale: "de",
-      query: "axpo gid",
+      query: "axpo hidro",
     });
-    expect(results.some((r) => r.name === "Axpo Grid AG")).toBe(true);
+    expect(results.some((r) => r.name === "Axpo Hydro Surselva AG")).toBe(true);
   });
 
   it("hydrates labels by ids (empty query)", async () => {
@@ -209,7 +209,9 @@ describe("Search - multi-type", () => {
     // which previously caused the municipality to be silently dropped from results.
     const results = await rawSearch("zurich");
     expect(
-      results.some((r) => r.__typename === "MunicipalityResult" && r.name === "Zürich")
+      results.some(
+        (r) => r.__typename === "MunicipalityResult" && r.name === "Zürich",
+      ),
     ).toBe(true);
   });
 });

--- a/src/pages/api/search.integration.spec.ts
+++ b/src/pages/api/search.integration.spec.ts
@@ -182,7 +182,7 @@ describe("Search - operators", () => {
 });
 
 describe("Search - multi-type", () => {
-  it("returns mixed types when searching across all types", async () => {
+  async function rawSearch(query: string) {
     const res = await fetch(GRAPHQL_URL, {
       method: "POST",
       headers: {
@@ -190,14 +190,26 @@ describe("Search - multi-type", () => {
         ...makeDeploymentAuthHeaders(),
       },
       body: JSON.stringify({
-        query: `query { search(locale: "de", query: "bern") { __typename id name } }`,
+        query: `query { search(locale: "de", query: "${query}") { __typename id name } }`,
       }),
     });
     const { data } = await res.json();
-    const typeNames = new Set(
-      (data.search as { __typename: string }[]).map((r) => r.__typename)
-    );
+    return data.search as { __typename: string; id: string; name: string }[];
+  }
+
+  it("returns mixed types when searching across all types", async () => {
+    const results = await rawSearch("bern");
+    const typeNames = new Set(results.map((r) => r.__typename));
     expect(typeNames.has("MunicipalityResult")).toBe(true);
     expect(typeNames.has("CantonResult")).toBe(true);
+  });
+
+  it("returns municipality Zürich when searching zurich (id collision regression)", async () => {
+    // Municipality Zürich (id=261) shares the same numeric ID as an operator,
+    // which previously caused the municipality to be silently dropped from results.
+    const results = await rawSearch("zurich");
+    expect(
+      results.some((r) => r.__typename === "MunicipalityResult" && r.name === "Zürich")
+    ).toBe(true);
   });
 });

--- a/src/pages/api/search.integration.spec.ts
+++ b/src/pages/api/search.integration.spec.ts
@@ -1,0 +1,156 @@
+import { Client, fetchExchange } from "urql";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  CantonsDocument,
+  type CantonsQuery,
+  type CantonsQueryVariables,
+  MunicipalitiesDocument,
+  type MunicipalitiesQuery,
+  type MunicipalitiesQueryVariables,
+  OperatorsDocument,
+  type OperatorsQuery,
+  type OperatorsQueryVariables,
+} from "src/graphql/queries";
+import { BASE_URL } from "src/utils/base-url";
+import { makeDeploymentAuthHeaders } from "src/utils/integration-headers";
+
+const GRAPHQL_URL = `${BASE_URL}/api/graphql`;
+
+const makeClient = () =>
+  new Client({
+    url: GRAPHQL_URL,
+    exchanges: [fetchExchange],
+    fetchOptions: { headers: makeDeploymentAuthHeaders() },
+  });
+
+beforeAll(async () => {
+  const res = await fetch(GRAPHQL_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...makeDeploymentAuthHeaders(),
+    },
+    body: JSON.stringify({ query: "{ __typename }" }),
+  });
+  if (!res.ok) throw new Error(`GraphQL not reachable: ${await res.text()}`);
+});
+
+describe("Search - municipalities", () => {
+  async function searchMunicipalities(vars: MunicipalitiesQueryVariables) {
+    const result = await makeClient()
+      .query<MunicipalitiesQuery, MunicipalitiesQueryVariables>(
+        MunicipalitiesDocument,
+        vars
+      )
+      .toPromise();
+    return result.data?.municipalities ?? [];
+  }
+
+  it("returns results for an exact match", async () => {
+    const results = await searchMunicipalities({
+      locale: "de",
+      query: "Zürich",
+    });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((r) => r.name === "Zürich")).toBe(true);
+  });
+
+  it("handles diacritics - zurich should match Zürich", async () => {
+    const results = await searchMunicipalities({
+      locale: "de",
+      query: "zurich",
+    });
+    expect(results.some((r) => r.name === "Zürich")).toBe(true);
+  });
+
+  it("handles typos - zurih should match Zürich", async () => {
+    const results = await searchMunicipalities({
+      locale: "de",
+      query: "zurih",
+    });
+    expect(results.some((r) => r.name === "Zürich")).toBe(true);
+  });
+
+  it("returns results with the expected shape", async () => {
+    const results = await searchMunicipalities({ locale: "de", query: "Bern" });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]).toHaveProperty("id");
+    expect(results[0]).toHaveProperty("name");
+  });
+});
+
+describe("Search - cantons", () => {
+  async function searchCantons(vars: CantonsQueryVariables) {
+    const result = await makeClient()
+      .query<CantonsQuery, CantonsQueryVariables>(CantonsDocument, vars)
+      .toPromise();
+    return result.data?.cantons ?? [];
+  }
+
+  it("returns cantons for a query", async () => {
+    const results = await searchCantons({ locale: "de", query: "Bern" });
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it("handles diacritics - zurich should match Zürich", async () => {
+    const results = await searchCantons({ locale: "de", query: "zurich" });
+    expect(results.some((r) => r.name.toLowerCase().includes("zürich"))).toBe(
+      true
+    );
+  });
+});
+
+describe("Search - operators", () => {
+  async function searchOperators(vars: OperatorsQueryVariables) {
+    const result = await makeClient()
+      .query<OperatorsQuery, OperatorsQueryVariables>(OperatorsDocument, vars)
+      .toPromise();
+    return result.data?.operators ?? [];
+  }
+
+  it("returns operators for an exact match", async () => {
+    const results = await searchOperators({
+      locale: "de",
+      query: "BKW Energie AG",
+    });
+    expect(results.some((r) => r.name === "BKW Energie AG")).toBe(true);
+  });
+
+  it("handles diacritics - aew should match AEW Energie AG", async () => {
+    const results = await searchOperators({
+      locale: "de",
+      query: "aew energie",
+    });
+    expect(results.some((r) => r.name === "AEW Energie AG")).toBe(true);
+  });
+
+  it("handles typos - axpo gid should match Axpo Grid AG", async () => {
+    const results = await searchOperators({
+      locale: "de",
+      query: "axpo gid",
+    });
+    expect(results.some((r) => r.name === "Axpo Grid AG")).toBe(true);
+  });
+});
+
+describe("Search - multi-type", () => {
+  it("returns mixed types when searching across all types", async () => {
+    const res = await fetch(GRAPHQL_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...makeDeploymentAuthHeaders(),
+      },
+      body: JSON.stringify({
+        query: `query { search(locale: "de", query: "bern") { __typename id name } }`,
+      }),
+    });
+    const { data } = await res.json();
+    const typeNames = new Set(
+      (data.search as { __typename: string }[]).map((r) => r.__typename)
+    );
+    expect(typeNames.has("MunicipalityResult")).toBe(true);
+    expect(typeNames.has("CantonResult")).toBe(true);
+  });
+});

--- a/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
+++ b/src/pages/sunshine/[entity]/[id]/costs-and-tariffs.tsx
@@ -309,6 +309,7 @@ const NetworkCosts = (props: Extract<Props, { status: "found" }>) => {
         latestYear={latestYear}
         peerGroup={peerGroup}
         sx={{ gridArea: "peer-group" }}
+        infoDialogProps={getInfoDialogProps("help-peer-group")}
       />
       <TableComparisonCard
         {...comparisonCardProps}
@@ -498,6 +499,7 @@ const EnergyTariffs = (props: Extract<Props, { status: "found" }>) => {
         latestYear={latestYear}
         peerGroup={peerGroup}
         sx={{ gridArea: "peer-group" }}
+        infoDialogProps={getInfoDialogProps("help-peer-group")}
       />
 
       <TableComparisonCard
@@ -690,6 +692,7 @@ const NetTariffs = (props: Extract<Props, { status: "found" }>) => {
         latestYear={latestYear}
         peerGroup={peerGroup}
         sx={{ gridArea: "peer-group" }}
+        infoDialogProps={getInfoDialogProps("help-peer-group")}
       />
 
       <TableComparisonCard

--- a/src/pages/sunshine/[entity]/[id]/operational-standards.tsx
+++ b/src/pages/sunshine/[entity]/[id]/operational-standards.tsx
@@ -205,6 +205,7 @@ const ServiceQuality = (props: Extract<Props, { status: "found" }>) => {
         latestYear={latestYear}
         peerGroup={peerGroup}
         sx={{ gridArea: "peer-group" }}
+        infoDialogProps={getInfoDialogProps("help-peer-group")}
       />
 
       <TableComparisonCard
@@ -325,6 +326,7 @@ const Compliance = (props: Extract<Props, { status: "found" }>) => {
         latestYear={latestYear}
         peerGroup={peerGroup}
         sx={{ gridArea: "peer-group" }}
+        infoDialogProps={getInfoDialogProps("help-peer-group")}
       />
 
       <TableComparisonCard

--- a/src/pages/sunshine/[entity]/[id]/power-stability.tsx
+++ b/src/pages/sunshine/[entity]/[id]/power-stability.tsx
@@ -207,6 +207,7 @@ const Saidi = (props: Extract<Props, { status: "found" }>) => {
         latestYear={latestYear}
         peerGroup={peerGroup}
         sx={{ gridArea: "peer-group" }}
+        infoDialogProps={getInfoDialogProps("help-peer-group")}
       />
 
       <TableComparisonCard
@@ -325,6 +326,7 @@ const Saifi = (props: Extract<Props, { status: "found" }>) => {
         latestYear={latestYear}
         peerGroup={peerGroup}
         sx={{ gridArea: "peer-group" }}
+        infoDialogProps={getInfoDialogProps("help-peer-group")}
       />
 
       <TableComparisonCard

--- a/src/rdf/namespace.ts
+++ b/src/rdf/namespace.ts
@@ -11,8 +11,8 @@ export const electricityPrice = namespace(
 export const electricityPriceDimension = namespace(
   "https://energy.ld.admin.ch/elcom/electricityprice/dimension/"
 );
-export const municipality = namespace("https://ld.admin.ch/municipality/");
-export const canton = namespace("https://ld.admin.ch/canton/");
+const municipality = namespace("https://ld.admin.ch/municipality/");
+const canton = namespace("https://ld.admin.ch/canton/");
 
 /**
  * Strips the namespace from an IRI to get shorter IDs

--- a/src/rdf/search-queries.ts
+++ b/src/rdf/search-queries.ts
@@ -5,11 +5,6 @@ import ParsingClient from "sparql-http-client/ParsingClient";
 
 import * as ns from "./namespace";
 
-const graphs = {
-  electricityPrice: rdf.namedNode(
-    "https://lindas.admin.ch/elcom/electricityprice"
-  ),
-};
 
 export type SearchResult = {
   id: string;

--- a/src/rdf/search-queries.ts
+++ b/src/rdf/search-queries.ts
@@ -1,22 +1,9 @@
-import { sparql, SparqlTemplateResult } from "@tpluscode/rdf-string";
 import { SELECT } from "@tpluscode/sparql-builder";
 import rdf from "rdf-ext";
 import { Literal, NamedNode, Quad } from "rdf-js";
 import ParsingClient from "sparql-http-client/ParsingClient";
 
-import { defaultLocale } from "src/locales/config";
-
 import * as ns from "./namespace";
-
-// regex based search query for municipalities and operators
-type SearchType = "municipality" | "operator" | "canton";
-
-const vars = {
-  type: rdf.variable("type"),
-  iri: rdf.variable("iri"),
-  municipalityClass: rdf.variable("municipalityClass"),
-  name: rdf.variable("name"),
-};
 
 const graphs = {
   electricityPrice: rdf.namedNode(
@@ -24,114 +11,122 @@ const graphs = {
   ),
 };
 
-const searchQueryBuilders = {
-  zipCode: ({ query }: { query: string }) => {
-    return sparql`{
-    SELECT DISTINCT ("municipality" AS ${vars.type}) (?municipality AS ${vars.iri}) (?municipalityLabel AS ${vars.name})
-      WHERE { GRAPH ${graphs.electricityPrice} {
-        ?offer a ${ns.schema.Offer} ;
-          ${ns.schema.areaServed} ?municipality;
-          ${ns.schema.postalCode} "${query}" .
-        }
-        ?municipality ${ns.schema.name} ?municipalityLabel .
-    }
-  }`;
-  },
-  query: {
-    municipality: ({ query, limit }: { query: string; limit: number }) => {
-      return sparql`{
-      SELECT DISTINCT ("municipality" AS ${vars.type}) (?municipality AS ${vars.iri}) (?municipalityLabel AS ${vars.name}) (?class as ?municipalityClass) WHERE {
-        VALUES ?class { ${ns.schemaAdmin.Municipality} ${ns.schemaAdmin.AbolishedMunicipality} }
-        ?municipality a ?class .
-        ?municipality ${ns.schema.name} ?municipalityLabel .
-        FILTER (regex(?municipalityLabel, ".*${query}.*", "i"))
-      } LIMIT ${limit}
-    }`;
-    },
+export type SearchResult = {
+  id: string;
+  name: string;
+  type: string;
+  isAbolished: boolean;
+  /** Space-separated postal codes, only present for municipalities. */
+  postalCodes?: string;
+};
 
-    operator: ({ query, limit }: { query: string; limit: number }) => {
-      return sparql`{
-      SELECT DISTINCT ("operator" AS ${vars.type}) (?operator AS ${vars.iri}) (?operatorLabel AS ${vars.name}) WHERE {
-        GRAPH ${graphs.electricityPrice} {
-          ?operator a ${ns.schema.Organization} .
-          ?operator ${ns.schema.name} ?operatorLabel.    
-        }
-        FILTER (regex(?operatorLabel, ".*${query}.*", "i"))
-      } LIMIT ${limit}
-    }`;
-    },
-    canton: ({
-      query,
-      limit,
-      locale,
-    }: {
-      query: string;
-      limit: number;
-      locale: string;
-    }) => {
-      return sparql`{
-      SELECT DISTINCT ("canton" AS ${vars.type}) (?canton AS ${vars.iri}) (?cantonLabel AS ${vars.name}) WHERE {
-        ?canton a ${ns.schemaAdmin.Canton} .
-        ?canton ${ns.schema.name} ?cantonLabel .    
-        FILTER (LANGMATCHES(LANG(?cantonLabel), "${locale}") && (regex(?cantonLabel, ".*${query}.*", "i")))
-      } LIMIT ${limit}
-    }`;
-    },
-  },
-  ids: {
-    canton: ({ ids, locale }: { ids: string[]; locale: string }) => {
-      return sparql`{
-      SELECT DISTINCT ("canton" AS ${vars.type}) (?canton AS ${
-        vars.iri
-      }) (?cantonLabel AS ${vars.name}) WHERE {
-        ?canton a ${ns.schemaAdmin.Canton} .
-        ?canton ${ns.schema.name} ?cantonLabel .
-        FILTER (LANGMATCHES(LANG(?cantonLabel), "${locale}") && (?canton IN (${ids
-        .map((id) => `<${ns.canton(id).value}>`)
-        .join(",")})))
+/**
+ * Returns all municipalities that have at least one offer in the electricity
+ * price graph, i.e. municipalities with observations.
+ */
+export const loadAllMunicipalities = async ({
+  client,
+}: {
+  client: ParsingClient;
+}): Promise<SearchResult[]> => {
+  const query = `
+    SELECT ("municipality" AS ?type) (?municipality AS ?iri) (?municipalityLabel AS ?name) (?class AS ?municipalityClass) (GROUP_CONCAT(DISTINCT STR(?postalCode); separator=" ") AS ?postalCodes) WHERE {
+      VALUES ?class {
+        <https://schema.ld.admin.ch/Municipality>
+        <https://schema.ld.admin.ch/AbolishedMunicipality>
       }
-    }`;
-    },
-    municipality: ({ ids }: { ids: string[]; locale: string }) => {
-      return sparql`{
-        SELECT DISTINCT ("municipality" AS ${vars.type}) (?municipality AS ${
-        vars.iri
-      }) (?municipalityLabel AS ${vars.name}) WHERE {
-          VALUES ?class { ${ns.schemaAdmin.Municipality} ${
-        ns.schemaAdmin.AbolishedMunicipality
-      } }
-          ?municipality a ?class .
-          ?municipality ${ns.schema.name} ?municipalityLabel .
-          FILTER (?municipality IN (${ids
-            .map((id) => `<${ns.municipality(id).value}>`)
-            .join(",")}))
-        }
-      }`;
-    },
-    operator: ({ ids }: { ids: string[]; locale: string }) => {
-      return sparql`{
-        SELECT DISTINCT ("operator" AS ${vars.type}) (?operator AS ${
-        vars.iri
-      }) (?operatorLabel AS ${vars.name}) WHERE {
-          GRAPH ${graphs.electricityPrice} {
-            ?operator a ${ns.schema.Organization} .
-            ?operator ${ns.schema.name} ?operatorLabel.    
-          }
-          FILTER (?operator IN (${ids
-            .map((id) => `<${ns.electricityPrice(`operator/${id}`).value}>`)
-            .join(",")}))
-        }
-      }`;
-    },
-  },
-} as const;
+      ?municipality a ?class .
+      ?municipality <http://schema.org/name> ?municipalityLabel .
+      OPTIONAL { ?municipality <http://schema.org/postalCode> ?postalCode . }
+      GRAPH <https://lindas.admin.ch/elcom/electricityprice> {
+        [] <http://schema.org/areaServed> ?municipality .
+      }
+    }
+    GROUP BY ?municipality ?municipalityLabel ?class
+  `;
 
-type SearchSparqlQueryOptions = {
-  query: string;
-  ids: string[];
+  const results = (await client.query.select(query)) as {
+    type: Literal;
+    iri: NamedNode;
+    name: Literal;
+    municipalityClass?: NamedNode;
+    postalCodes?: Literal;
+  }[];
+
+  return results.map((d) => ({
+    id: ns.stripNamespaceFromIri({ iri: d.iri.value }),
+    name: d.name.value,
+    type: d.type.value,
+    isAbolished: ns.schemaAdmin`AbolishedMunicipality`.equals(
+      d.municipalityClass
+    ),
+    postalCodes: d.postalCodes?.value || undefined,
+  }));
+};
+
+/**
+ * Returns all operators that have at least one offer in the electricity
+ * price graph, i.e. operators with observations.
+ */
+export const loadAllOperators = async ({
+  client,
+}: {
+  client: ParsingClient;
+}): Promise<SearchResult[]> => {
+  const query = `
+    SELECT DISTINCT ("operator" AS ?type) (?operator AS ?iri) (?operatorLabel AS ?name) WHERE {
+      GRAPH <https://lindas.admin.ch/elcom/electricityprice> {
+        ?operator a <http://schema.org/Organization> .
+        ?operator <http://schema.org/name> ?operatorLabel .
+        [] <http://schema.org/offeredBy> ?operator .
+      }
+    }
+  `;
+
+  const results = (await client.query.select(query)) as {
+    type: Literal;
+    iri: NamedNode;
+    name: Literal;
+  }[];
+
+  return results.map((d) => ({
+    id: ns.stripNamespaceFromIri({ iri: d.iri.value }),
+    name: d.name.value,
+    type: d.type.value,
+    isAbolished: false,
+  }));
+};
+
+/**
+ * Returns all cantons for the given locale.
+ */
+export const loadAllCantons = async ({
+  client,
+  locale,
+}: {
+  client: ParsingClient;
   locale: string;
-  types: SearchType[];
-  limit?: number;
+}): Promise<SearchResult[]> => {
+  const query = `
+    SELECT DISTINCT ("canton" AS ?type) (?canton AS ?iri) (?cantonLabel AS ?name) WHERE {
+      ?canton a <https://schema.ld.admin.ch/Canton> .
+      ?canton <http://schema.org/name> ?cantonLabel .
+      FILTER (LANGMATCHES(LANG(?cantonLabel), "${locale}"))
+    }
+  `;
+
+  const results = (await client.query.select(query)) as {
+    type: Literal;
+    iri: NamedNode;
+    name: Literal;
+  }[];
+
+  return results.map((d) => ({
+    id: ns.stripNamespaceFromIri({ iri: d.iri.value }),
+    name: d.name.value,
+    type: d.type.value,
+    isAbolished: false,
+  }));
 };
 
 const getOperatorQuery = ({ operatorId }: { operatorId: string }) => {
@@ -139,82 +134,6 @@ const getOperatorQuery = ({ operatorId }: { operatorId: string }) => {
     <https://energy.ld.admin.ch/elcom/electricityprice/operator/${operatorId}> a ${ns.schema.Organization} ;
       ${ns.schema.identifier} ?uid
   `;
-};
-
-const getSearchSparqlQuery = ({
-  query,
-  types,
-  ids,
-  limit,
-  locale,
-}: Required<SearchSparqlQueryOptions>) => {
-  const trimmedQuery = query.trim();
-  const isZipCode = /^[0-9]{4}$/.test(trimmedQuery);
-  const queryParts: SparqlTemplateResult[] = [];
-
-  if (isZipCode && types.includes("municipality")) {
-    queryParts.push(searchQueryBuilders.zipCode({ query: trimmedQuery }));
-  }
-
-  if (ids.length > 0) {
-    queryParts.push(
-      ...types.map((t) =>
-        searchQueryBuilders.ids[t]({
-          ids,
-          locale,
-        })
-      )
-    );
-  }
-
-  if (!isZipCode && trimmedQuery !== "") {
-    queryParts.push(
-      ...types.map((t) =>
-        searchQueryBuilders.query[t]({
-          query: trimmedQuery,
-          limit,
-          locale,
-        })
-      )
-    );
-  }
-
-  const sparqlQuery =
-    SELECT.DISTINCT`${vars.type} ${vars.iri} ${vars.name} ${vars.municipalityClass}`
-      .WHERE`${queryParts.map((p, i) =>
-      i < queryParts.length - 1 ? sparql`${p} UNION ` : p
-    )}`
-      .ORDER()
-      .BY(vars.name);
-
-  return {
-    sparqlQuery,
-    abort: queryParts.length === 0,
-  };
-};
-
-/**
- * Returns the set of municipality IRIs that are actually linked to observations
- * in the electricity price cube. Used to filter out municipalities with no data.
- */
-export const fetchLinkedMunicipalityIds = async ({
-  client,
-}: {
-  client: ParsingClient;
-}): Promise<Set<string>> => {
-  const query = `
-    SELECT DISTINCT ?municipality WHERE {
-      <https://energy.ld.admin.ch/elcom/electricityprice> <https://cube.link/observationSet> ?observationSet .
-      ?observationSet <https://cube.link/observation> ?obs .
-      ?obs <https://energy.ld.admin.ch/elcom/electricityprice/dimension/municipality> ?municipality .
-    }
-  `;
-
-  const results = (await client.query.select(query)) as {
-    municipality: NamedNode;
-  }[];
-
-  return new Set(results.map((r) => r.municipality.value));
 };
 
 export const fetchOperatorInfo = async ({
@@ -244,50 +163,4 @@ export const fetchOperatorInfo = async ({
       };
     })[0],
   };
-};
-
-export const search = async ({
-  query,
-  ids,
-  client,
-  locale = defaultLocale,
-  types = ["municipality", "operator"],
-  limit = 10,
-}: SearchSparqlQueryOptions & {
-  client: ParsingClient;
-}) => {
-  const { sparqlQuery, abort } = getSearchSparqlQuery({
-    query,
-    types,
-    ids,
-    locale,
-    limit,
-  });
-  if (abort) {
-    return [];
-  }
-
-  const results = (await client.query.select(sparqlQuery.build())) as {
-    type: Literal;
-    iri: NamedNode;
-    name: Literal;
-    municipalityClass?: NamedNode;
-  }[];
-
-  return results.map((d) => {
-    const iri = d.iri.value;
-    const type = d.type.value;
-    const name = d.name.value;
-
-    const isAbolished = ns.schemaAdmin`AbolishedMunicipality`.equals(
-      d.municipalityClass
-    );
-
-    return {
-      id: ns.stripNamespaceFromIri({ iri }),
-      name,
-      type,
-      isAbolished,
-    };
-  });
 };

--- a/src/rdf/search-queries.ts
+++ b/src/rdf/search-queries.ts
@@ -193,6 +193,30 @@ const getSearchSparqlQuery = ({
   };
 };
 
+/**
+ * Returns the set of municipality IRIs that are actually linked to observations
+ * in the electricity price cube. Used to filter out municipalities with no data.
+ */
+export const fetchLinkedMunicipalityIds = async ({
+  client,
+}: {
+  client: ParsingClient;
+}): Promise<Set<string>> => {
+  const query = `
+    SELECT DISTINCT ?municipality WHERE {
+      <https://energy.ld.admin.ch/elcom/electricityprice> <https://cube.link/observationSet> ?observationSet .
+      ?observationSet <https://cube.link/observation> ?obs .
+      ?obs <https://energy.ld.admin.ch/elcom/electricityprice/dimension/municipality> ?municipality .
+    }
+  `;
+
+  const results = (await client.query.select(query)) as {
+    municipality: NamedNode;
+  }[];
+
+  return new Set(results.map((r) => r.municipality.value));
+};
+
 export const fetchOperatorInfo = async ({
   operatorId,
   client,

--- a/src/rdf/search-queries.ts
+++ b/src/rdf/search-queries.ts
@@ -1,5 +1,4 @@
 import { SELECT } from "@tpluscode/sparql-builder";
-import rdf from "rdf-ext";
 import { Literal, NamedNode, Quad } from "rdf-js";
 import ParsingClient from "sparql-http-client/ParsingClient";
 

--- a/src/utils/test-utils.ts
+++ b/src/utils/test-utils.ts
@@ -1,0 +1,22 @@
+export const getHttpCredentialsFromEnv = () => {
+  const usernamePassword = process.env.BASIC_AUTH_CREDENTIALS;
+  if (!usernamePassword) {
+    return undefined;
+  }
+  const [username, password] = usernamePassword.split(":");
+  if (!username || !password) {
+    throw new Error(
+      "BASIC_AUTH_CREDENTIALS environment variable must be in the format 'username:password'",
+    );
+  }
+  return { username, password };
+};
+
+export const getExtraHttpHeadersFromEnv = () => {
+  return {
+    "x-vercel-skip-toolbar": "1",
+    ...(process.env.VERCEL_AUTOMATION_BYPASS_SECRET && {
+      "x-vercel-protection-bypass": process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+    }),
+  };
+};


### PR DESCRIPTION
## Description

Search was based on SPARQL queries with regex filters, which caused two main issues:

- **#365**: search did not handle diacritics (e.g. searching "Zurich" wouldn't match "Zürich") and did not support fuzzy matching, so results were often missing for slightly misspelled or accent-free queries.
- **#523**: some municipalities did not appear in results because they were not linked to any SPARQL observation directly (e.g. abolished/merged municipalities).

To fix this, the SPARQL-based search has been replaced by a server-side [MiniSearch](https://lucamontemagni.github.io/minisearch/) index built from RDF data. The index is cached and enables fast full-text search with diacritic folding and fuzzy matching, as well as municipalities not linked to observations. A fix was also added to prevent ID collisions between municipalities and operators when resolving search results.

On the UX side, the search field is cleared and blurred after selecting a result, and results are cleared when the field is empty.

## Notes for Reviewers

- The main changes are in `src/rdf/search-queries.ts` (refactor) and `src/lib/search-index-cache.ts` (new file: MiniSearch index cache).
- Issue #454 (link to the comparison group info dialog) is not related to search, but the change was tiny and has been included in this branch.

## How to Test

Use the query box in the top right of the app for all tests.

**Diacritics (#365)**
1. Type `Zurich` (without umlaut) — expect `Zürich` and related results to appear.
2. Type `Genf` or `Geneve` — expect Geneva-related results to appear.

**Fuzzy search (#365)**
1. Type `ewz` — expect `Elektrizitätswerk der Stadt Zürich` to appear in results.
2. Type a slightly misspelled name (e.g. `Zurych`) — expect fuzzy matches to still return relevant results.

**No ghost municipalities (#523)**
1. Type `Zurich` — verify that abolished/merged municipalities with no data (e.g. Zürichsee (ZH)) no longer appear in results.

**UX (#365)**
1. Select any result from the dropdown — verify the search field is cleared and focus is removed from it.

## Related Issues

- fix #365
- fix #523
- #454 (info dialog — not search-related, small change included here)

## Testing Performed

- [x] Tested with the following Browsers: Firefox
- [x] Tested on the following devices: MacBook Pro
- [x] Verified functionality: Search by zip code returns results, abolished municipalities appear, no ID collision between municipality and operator results
- [ ] Storybook updated
- [x] Automated tests added

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [ ] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog
- [ ] I have run locales:extract if I changed any locale string