### PR TITLE
fix: Exclude image paths from middleware to fix broken images on REF/ABN (#482)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -51,4 +51,11 @@ const middleware: NextMiddleware = (request: NextRequest, ev) => {
 
 export default middleware;
 
-export const config: MiddlewareConfig = {};
+export const config: MiddlewareConfig = {
+  // Exclude Next.js image optimization and static assets so the image
+  // optimization backend can fetch source images without being blocked
+  // by the basic auth middleware (issue #482).
+  matcher: [
+    "/((?!_next/image|_next/static|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};


### PR DESCRIPTION
Next.js image optimization makes backend requests without Basic Auth credentials,
causing the middleware to block source image fetches on environments where
BASIC_AUTH_CREDENTIALS is set.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
