### PR TITLE
fix(#626): Add small download option, rename A4/A3 to Medium/Large

### DIFF
--- a/src/components/map-download-image.tsx
+++ b/src/components/map-download-image.tsx
@@ -42,12 +42,32 @@ const MapDownloadContent = ({
       sx={{ py: 2 }}
     >
       <FormControlLabel
+        value="small"
+        control={<Radio size="small" sx={{ mt: -2 }} />}
+        sx={{ alignItems: "flex-start", mb: 1 }}
+        label={
+          <Typography variant="body3" display="flex" alignItems="center" gap={1}>
+            {t({ id: "map.download.paper-size.small", message: "Small" })}
+            <Tooltip
+              title={t({
+                id: "map.download.paper-size.small.info",
+                message: `${SCREENSHOT_SIZES.small.image.width} × ${SCREENSHOT_SIZES.small.image.height} px`,
+              })}
+            >
+              <span style={{ display: "flex", alignItems: "center" }}>
+                <Icon name="infocircle" size={16} />
+              </span>
+            </Tooltip>
+          </Typography>
+        }
+      />
+      <FormControlLabel
         value="a4"
         control={<Radio size="small" sx={{ mt: -2 }} />}
         sx={{ alignItems: "flex-start", mb: 1 }}
         label={
           <Typography variant="body3" display="flex" alignItems="center" gap={1}>
-            {t({ id: "map.download.paper-size.a4", message: "A4" })}
+            {t({ id: "map.download.paper-size.a4", message: "Medium (A4)" })}
             <Tooltip
               title={t({
                 id: "map.download.paper-size.a4.info",
@@ -69,7 +89,7 @@ const MapDownloadContent = ({
         label={
           <div>
             <Typography variant="body3" display="flex" alignItems="center" gap={1}>
-              {t({ id: "map.download.paper-size.a3", message: "A3" })}
+              {t({ id: "map.download.paper-size.a3", message: "Large (A3)" })}
               <Tooltip
                 title={t({
                   id: "map.download.paper-size.a3.info",

--- a/src/domain/screenshot.ts
+++ b/src/domain/screenshot.ts
@@ -6,7 +6,7 @@ const toBlob = (canvas: HTMLCanvasElement, type: string) =>
     canvas.toBlob((blob) => resolve(blob), type);
   });
 
-export type PaperSize = "a4" | "a3";
+export type PaperSize = "small" | "a4" | "a3";
 
 interface ScreenshotSizeConfig {
   image: { width: number; height: number };
@@ -21,6 +21,18 @@ const A3_IMAGE_WIDTH = 4961;
 const A3_CANVAS_WIDTH = 1490;
 
 export const SCREENSHOT_SIZES: Record<PaperSize, ScreenshotSizeConfig> = {
+  small: {
+    image: {
+      width: 1120,
+      height: 730,
+    },
+    canvas: {
+      width: 1120,
+      height: 730,
+    },
+    legendScale: 0.5,
+    legendPaddingPercent: 0.6,
+  },
   a4: {
     image: {
       width: Math.round(A3_IMAGE_WIDTH / Math.SQRT2),
@@ -47,8 +59,7 @@ export const SCREENSHOT_SIZES: Record<PaperSize, ScreenshotSizeConfig> = {
   },
 };
 
-export const DEFAULT_PAPER_SIZE: PaperSize = "a4";
-
+export const DEFAULT_PAPER_SIZE: PaperSize = "small";
 
 /**
  * Get the map as an image, using the Deck.gl canvas and html2canvas to get
@@ -57,7 +68,7 @@ export const DEFAULT_PAPER_SIZE: PaperSize = "a4";
 export const getMapImageData = async (
   deck: Deck,
   legend: HTMLElement | undefined,
-  paperSize: PaperSize = DEFAULT_PAPER_SIZE
+  paperSize: PaperSize = DEFAULT_PAPER_SIZE,
 ) => {
   if (!deck || "canvas" in deck === false) {
     return;
@@ -113,7 +124,7 @@ export const getMapImageData = async (
     0,
     (newCanvas.height - drawnMapHeight) / 2,
     newCanvas.width,
-    drawnMapHeight
+    drawnMapHeight,
   );
 
   if (legend) {
@@ -129,13 +140,13 @@ export const getMapImageData = async (
       legendPadding,
       legendPadding,
       width * ratio * sizeConfig.legendScale,
-      height * ratio * sizeConfig.legendScale
+      height * ratio * sizeConfig.legendScale,
     );
   }
 
   // Returns the canvas as a png
   const res = await toBlob(newCanvas, "image/png").then((blob) =>
-    blob ? URL.createObjectURL(blob) : undefined
+    blob ? URL.createObjectURL(blob) : undefined,
   );
 
   Object.assign(canvas, initialSize);

--- a/src/locales/aa/messages.po
+++ b/src/locales/aa/messages.po
@@ -751,6 +751,14 @@ msgid "map.download.paper-size.a4.info"
 msgstr "map.download.paper-size.a4.info"
 
 #: src/components/map-download-image.tsx
+msgid "map.download.paper-size.small"
+msgstr "map.download.paper-size.small"
+
+#: src/components/map-download-image.tsx
+msgid "map.download.paper-size.small.info"
+msgstr "map.download.paper-size.small.info"
+
+#: src/components/map-download-image.tsx
 #: src/components/map-download-image.tsx
 msgid "map.download.title"
 msgstr "map.download.title"
@@ -1512,6 +1520,7 @@ msgstr "sunshine.costs-and-tariffs.no-network-costs"
 msgid "sunshine.costs-and-tariffs.operator"
 msgstr "sunshine.costs-and-tariffs.operator"
 
+#: src/components/info-dialog-props.ts
 #: src/components/peer-group-card.tsx
 msgid "sunshine.costs-and-tariffs.peer-group"
 msgstr "sunshine.costs-and-tariffs.peer-group"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Last-Translator: \n"
 "Language: de\n"
 "Language-Team: \n"
-"Content-Type: \n"
+"Content-Type: text/plain\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
@@ -749,6 +749,14 @@ msgstr "Mittel (A4)"
 #: src/components/map-download-image.tsx
 msgid "map.download.paper-size.a4.info"
 msgstr "{0} × {1} px, 300dpi"
+
+#: src/components/map-download-image.tsx
+msgid "map.download.paper-size.small"
+msgstr "Klein"
+
+#: src/components/map-download-image.tsx
+msgid "map.download.paper-size.small.info"
+msgstr "{0} × {1} px"
 
 #: src/components/map-download-image.tsx
 #: src/components/map-download-image.tsx
@@ -1512,6 +1520,7 @@ msgstr "Für diesen Netzbetreiber sind für das ausgewählte Tarifjahr keine Dat
 msgid "sunshine.costs-and-tariffs.operator"
 msgstr "{operatorLabel}"
 
+#: src/components/info-dialog-props.ts
 #: src/components/peer-group-card.tsx
 msgid "sunshine.costs-and-tariffs.peer-group"
 msgstr "Vergleichsgruppe"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -753,6 +753,14 @@ msgid "map.download.paper-size.a4.info"
 msgstr "{0} × {1} px, 300dpi"
 
 #: src/components/map-download-image.tsx
+msgid "map.download.paper-size.small"
+msgstr "Small"
+
+#: src/components/map-download-image.tsx
+msgid "map.download.paper-size.small.info"
+msgstr "{0} × {1} px"
+
+#: src/components/map-download-image.tsx
 #: src/components/map-download-image.tsx
 msgid "map.download.title"
 msgstr "Download image"
@@ -1514,6 +1522,7 @@ msgstr "No network costs data available for this operator in the selected year."
 msgid "sunshine.costs-and-tariffs.operator"
 msgstr "{operatorLabel}"
 
+#: src/components/info-dialog-props.ts
 #: src/components/peer-group-card.tsx
 msgid "sunshine.costs-and-tariffs.peer-group"
 msgstr "Peer Group"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Last-Translator: \n"
 "Language: fr\n"
 "Language-Team: \n"
-"Content-Type: \n"
+"Content-Type: text/plain\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
@@ -752,6 +752,14 @@ msgstr "Moyen (A4)"
 #: src/components/map-download-image.tsx
 msgid "map.download.paper-size.a4.info"
 msgstr "{0} × {1} px, 300dpi"
+
+#: src/components/map-download-image.tsx
+msgid "map.download.paper-size.small"
+msgstr "Petit"
+
+#: src/components/map-download-image.tsx
+msgid "map.download.paper-size.small.info"
+msgstr "{0} × {1} px"
 
 #: src/components/map-download-image.tsx
 #: src/components/map-download-image.tsx
@@ -1518,6 +1526,7 @@ msgstr "Aucune donnée sur les coûts de réseau n'est disponible pour ce gestio
 msgid "sunshine.costs-and-tariffs.operator"
 msgstr "{operatorLabel}"
 
+#: src/components/info-dialog-props.ts
 #: src/components/peer-group-card.tsx
 msgid "sunshine.costs-and-tariffs.peer-group"
 msgstr "Groupe de comparaison"

--- a/src/locales/it/messages.po
+++ b/src/locales/it/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Last-Translator: \n"
 "Language: it\n"
 "Language-Team: \n"
-"Content-Type: \n"
+"Content-Type: text/plain\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -751,6 +751,14 @@ msgstr "Medio (A4)"
 #: src/components/map-download-image.tsx
 msgid "map.download.paper-size.a4.info"
 msgstr "{0} × {1} px, 300dpi"
+
+#: src/components/map-download-image.tsx
+msgid "map.download.paper-size.small"
+msgstr "Piccolo"
+
+#: src/components/map-download-image.tsx
+msgid "map.download.paper-size.small.info"
+msgstr "{0} × {1} px"
 
 #: src/components/map-download-image.tsx
 #: src/components/map-download-image.tsx
@@ -1514,6 +1522,7 @@ msgstr "Non sono disponibili dati sui costi di rete per questo gestore di rete n
 msgid "sunshine.costs-and-tariffs.operator"
 msgstr "{operatorLabel}"
 
+#: src/components/info-dialog-props.ts
 #: src/components/peer-group-card.tsx
 msgid "sunshine.costs-and-tariffs.peer-group"
 msgstr "Gruppo di confronto"


### PR DESCRIPTION
## Description

Adds the previous small resolution (1120×730) back as a download option and renames the existing A4 and A3 options to Medium (A4) and Large (A3), per ElCom's feedback after testing. Small is now the default.

## Related Issues

fix #626

## Testing Performed

- [x] Tested with the following Browsers: Firefox
- [x] Tested on the following devices: MacBook Pro
- [x] Verified functionality: Tested all three download options manually
- [ ] Storybook updated
- [ ] Automated tests added

## Screenshots

<!-- N/A -->

## Checklist

- [x] I have tested my changes thoroughly
- [ ] I have updated the documentation as needed
- [x] My commits use clear, descriptive messages
- [x] My PR includes only related changes
- [x] I have marked this PR with the appropriate label
- [ ] I have added an entry in the changelog
- [x] I have run locales:extract if I changed any locale string