### PR TITLE
Analytics consent

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -45,7 +45,7 @@ const nextConfig = async (): Promise<NextConfig> => {
     {
       ignore: (file) =>
         file.replace(/\\/g, "/").startsWith("node_modules/.bin/"),
-    }
+    },
   );
 
   const config: NextConfig = {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@emotion/react": "^11.13.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.13.0",
-    "@interactivethings/swiss-federal-ci": "3.4.0",
+    "@interactivethings/swiss-federal-ci": "3.4.1",
     "@lingui/babel-plugin-lingui-macro": "^5.9.2",
     "@lingui/core": "^3.17.2",
     "@lingui/react": "^3.17.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@emotion/react": "^11.13.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.13.0",
-    "@interactivethings/swiss-federal-ci": "^3.3.0",
+    "@interactivethings/swiss-federal-ci": "3.4.0",
     "@lingui/babel-plugin-lingui-macro": "^5.9.2",
     "@lingui/core": "^3.17.2",
     "@lingui/react": "^3.17.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@emotion/react": "^11.13.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.13.0",
-    "@interactivethings/swiss-federal-ci": "^3.1.1",
+    "@interactivethings/swiss-federal-ci": "^3.3.0",
     "@lingui/babel-plugin-lingui-macro": "^5.9.2",
     "@lingui/core": "^3.17.2",
     "@lingui/react": "^3.17.2",
@@ -75,7 +75,6 @@
     "@storybook/nextjs": "^8.6.12",
     "@testing-library/react": "^16.3.2",
     "@tpluscode/rdf-ns-builders": "^1.0.0",
-
     "@tpluscode/sparql-builder": "^2.0.3",
     "@turf/bbox": "^7.3.4",
     "@turf/centroid": "^6.5.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -70,6 +70,15 @@ export default defineConfig({
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
+    storageState: {
+      cookies: [],
+      origins: [
+        {
+          origin: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
+          localStorage: [{ name: "consent-banner", value: "rejected" }],
+        },
+      ],
+    },
   },
 
   /* Configure projects for major browsers */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^11.13.0
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@types/react@19.0.0)(react@18.3.1)
       '@interactivethings/swiss-federal-ci':
-        specifier: ^3.1.1
-        version: 3.1.1(a4661d0b902c74bc8e500100f2282327)
+        specifier: ^3.3.0
+        version: 3.3.0(a4661d0b902c74bc8e500100f2282327)
       '@lingui/babel-plugin-lingui-macro':
         specifier: ^5.9.2
         version: 5.9.2(babel-plugin-macros@3.1.0)(typescript@5.9.3)
@@ -2479,8 +2479,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@interactivethings/swiss-federal-ci@3.1.1':
-    resolution: {integrity: sha512-5HbXA2RTXS7ejdNwPcnkgc5b5pY354EGA/HFDBqZoWDR7T4obDArecjmpLsNAxiXLvbPDnbhjQoB+WJZ9U683g==}
+  '@interactivethings/swiss-federal-ci@3.3.0':
+    resolution: {integrity: sha512-i2iciavsWGSm+xwCKAh8/HVaBYU9M+v3632GXDZp2SbMcC3fPJms5tlPmmcqYyghqRgocB9Vb8TE2unlT76qew==}
     peerDependencies:
       '@emotion/react': ^11.11.0
       '@emotion/styled': ^11.11.0
@@ -14689,7 +14689,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.1
 
-  '@interactivethings/swiss-federal-ci@3.1.1(a4661d0b902c74bc8e500100f2282327)':
+  '@interactivethings/swiss-federal-ci@3.3.0(a4661d0b902c74bc8e500100f2282327)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.0.0)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@types/react@19.0.0)(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^11.13.0
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@types/react@19.0.0)(react@18.3.1)
       '@interactivethings/swiss-federal-ci':
-        specifier: ^3.3.0
-        version: 3.3.0(a4661d0b902c74bc8e500100f2282327)
+        specifier: 3.4.0
+        version: 3.4.0(a4661d0b902c74bc8e500100f2282327)
       '@lingui/babel-plugin-lingui-macro':
         specifier: ^5.9.2
         version: 5.9.2(babel-plugin-macros@3.1.0)(typescript@5.9.3)
@@ -103,7 +103,7 @@ importers:
         version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tpluscode/rdf-ns-builders':
         specifier: ^1.0.0
-        version: 1.1.0(@zazuko/rdf-vocabularies@2023.1.19)(clownface@2.0.3)(safe-identifier@0.4.2)(ts-morph@27.0.2)(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))
+        version: 1.1.0(@zazuko/rdf-vocabularies@2023.1.19)(clownface@2.0.3)(safe-identifier@0.4.2)(ts-morph@27.0.2)(ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3))
       '@tpluscode/sparql-builder':
         specifier: ^2.0.3
         version: 2.0.4(sparql-http-client@2.4.2(encoding@0.1.13))
@@ -238,7 +238,7 @@ importers:
         version: 3.1.0
       ts-node:
         specifier: 10.7.0
-        version: 10.7.0(@types/node@22.19.1)(typescript@5.9.3)
+        version: 10.7.0(@types/node@22.19.12)(typescript@5.9.3)
       tss-react:
         specifier: ^4.9.20
         version: 4.9.20(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@emotion/server@11.11.0)(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@types/react@19.0.0)(react@18.3.1))(@types/react@19.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@19.0.0)(react@18.3.1)
@@ -275,7 +275,7 @@ importers:
         version: 2.4.10
       '@graphql-codegen/cli':
         specifier: ^6.1.2
-        version: 6.1.2(@parcel/watcher@2.5.6)(@types/node@22.19.1)(encoding@0.1.13)(graphql@16.13.0)(typescript@5.9.3)
+        version: 6.1.2(@parcel/watcher@2.5.6)(@types/node@22.19.12)(encoding@0.1.13)(graphql@16.13.0)(typescript@5.9.3)
       '@graphql-codegen/typescript':
         specifier: ^5.0.8
         version: 5.0.8(encoding@0.1.13)(graphql@16.13.0)
@@ -290,13 +290,13 @@ importers:
         version: 4.0.1(encoding@0.1.13)(graphql-tag@2.12.6(graphql@16.13.0))(graphql@16.13.0)
       '@lingui/cli':
         specifier: ^3.17.2
-        version: 3.17.2(@babel/core@7.29.0)(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.17.2(@babel/core@7.29.0)(@types/node@22.19.12)(babel-plugin-macros@3.1.0)(ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3))(typescript@5.9.3)
       '@lingui/macro':
         specifier: ^3.17.2
-        version: 3.17.2(@lingui/core@3.17.2)(@lingui/react@3.17.2(react@18.3.1))(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.17.2(@lingui/core@3.17.2)(@lingui/react@3.17.2(react@18.3.1))(@types/node@22.19.12)(babel-plugin-macros@3.1.0)(ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3))(typescript@5.9.3)
       '@lingui/vite-plugin':
         specifier: ^5.9.2
-        version: 5.9.2(babel-plugin-macros@3.1.0)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 5.9.2(babel-plugin-macros@3.1.0)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))
       '@next/bundle-analyzer':
         specifier: 15.0.4
         version: 15.0.4
@@ -362,7 +362,7 @@ importers:
         version: 4.17.24
       '@types/node':
         specifier: ^22.13.16
-        version: 22.19.1
+        version: 22.19.12
       '@types/node-fetch':
         specifier: ^2.6.13
         version: 2.6.13
@@ -416,13 +416,13 @@ importers:
         version: 3.12.0(react@18.3.1)
       '@vitejs/plugin-react':
         specifier: ^5.1.4
-        version: 5.1.4(vite@7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 5.1.4(vite@7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))
       '@vitest/browser':
         specifier: 3.1.1
-        version: 3.1.1(playwright@1.58.2)(vite@7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))(vitest@4.0.15(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 3.1.1(playwright@1.58.2)(vite@7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))(vitest@4.0.15(@opentelemetry/api@1.9.0)(@types/node@22.19.12)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))
       accent-cli:
         specifier: ^0.16.2
-        version: 0.16.2(@types/node@22.19.1)(encoding@0.1.13)(typescript@5.9.3)
+        version: 0.16.2(@types/node@22.19.12)(encoding@0.1.13)(typescript@5.9.3)
       argparse:
         specifier: ^2.0.1
         version: 2.0.1
@@ -458,7 +458,7 @@ importers:
         version: 0.0.0
       knip:
         specifier: ^5.85.0
-        version: 5.85.0(@types/node@22.19.1)(typescript@5.9.3)
+        version: 5.85.0(@types/node@22.19.12)(typescript@5.9.3)
       oxlint:
         specifier: ^1.50.0
         version: 1.50.0
@@ -476,7 +476,7 @@ importers:
         version: 8.6.14(prettier@2.8.8)
       tpo-deepl:
         specifier: ^1.2.4
-        version: 1.2.4(@types/node@22.19.1)(typescript@5.9.3)
+        version: 1.2.4(@types/node@22.19.12)(typescript@5.9.3)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -485,10 +485,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.3.2
-        version: 7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
+        version: 7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
       vitest:
         specifier: ^4.0.15
-        version: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
+        version: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@22.19.12)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
 
 packages:
 
@@ -2479,8 +2479,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@interactivethings/swiss-federal-ci@3.3.0':
-    resolution: {integrity: sha512-i2iciavsWGSm+xwCKAh8/HVaBYU9M+v3632GXDZp2SbMcC3fPJms5tlPmmcqYyghqRgocB9Vb8TE2unlT76qew==}
+  '@interactivethings/swiss-federal-ci@3.4.0':
+    resolution: {integrity: sha512-fIyQxbXNHo/Vye/CXgbWawVxrjnYhcReYz8SHZLYixHaNfkZO+7y7TqWZmM7Q1xbab/1g5ds2SQFHxNsU0wnnQ==}
     peerDependencies:
       '@emotion/react': ^11.11.0
       '@emotion/styled': ^11.11.0
@@ -5228,14 +5228,8 @@ packages:
   '@types/node@18.19.127':
     resolution: {integrity: sha512-gSjxjrnKXML/yo0BO099uPixMqfpJU0TKYjpfLU7TrtA2WWDki412Np/RSTPRil1saKBhvVVKzVx/p/6p94nVA==}
 
-  '@types/node@22.19.1':
-    resolution: {integrity: sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==}
-
   '@types/node@22.19.12':
     resolution: {integrity: sha512-0QEp0aPJYSyf6RrTjDB7HlKgNMTY+V2C7ESTaVt6G9gQ0rPLzTGz7OF2NXTLR5vcy7HJEtIUsyWLsfX0kTqJBA==}
-
-  '@types/node@24.10.1':
-    resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
   '@types/nprogress@0.2.3':
     resolution: {integrity: sha512-k7kRA033QNtC+gLc4VPlfnue58CM1iQLgn1IMAU8VPHGOj7oIHPp9UlhedEnD/Gl8evoCjwkZjlBORtZ3JByUA==}
@@ -11188,9 +11182,6 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
-
   undici@7.24.6:
     resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
     engines: {node: '>=20.18.1'}
@@ -13770,7 +13761,7 @@ snapshots:
       graphql: 16.13.0
       tslib: 2.6.3
 
-  '@graphql-codegen/cli@6.1.2(@parcel/watcher@2.5.6)(@types/node@22.19.1)(encoding@0.1.13)(graphql@16.13.0)(typescript@5.9.3)':
+  '@graphql-codegen/cli@6.1.2(@parcel/watcher@2.5.6)(@types/node@22.19.12)(encoding@0.1.13)(graphql@16.13.0)(typescript@5.9.3)':
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/template': 7.28.6
@@ -13781,20 +13772,20 @@ snapshots:
       '@graphql-tools/apollo-engine-loader': 8.0.20(graphql@16.13.0)
       '@graphql-tools/code-file-loader': 8.1.20(graphql@16.13.0)
       '@graphql-tools/git-loader': 8.0.24(graphql@16.13.0)
-      '@graphql-tools/github-loader': 9.0.6(@types/node@22.19.1)(graphql@16.13.0)
+      '@graphql-tools/github-loader': 9.0.6(@types/node@22.19.12)(graphql@16.13.0)
       '@graphql-tools/graphql-file-loader': 8.0.20(graphql@16.13.0)
       '@graphql-tools/json-file-loader': 8.0.18(graphql@16.13.0)
       '@graphql-tools/load': 8.1.0(graphql@16.13.0)
-      '@graphql-tools/url-loader': 9.0.6(@types/node@22.19.1)(graphql@16.13.0)
+      '@graphql-tools/url-loader': 9.0.6(@types/node@22.19.12)(graphql@16.13.0)
       '@graphql-tools/utils': 10.10.3(graphql@16.13.0)
-      '@inquirer/prompts': 7.10.1(@types/node@22.19.1)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.12)
       '@whatwg-node/fetch': 0.10.8
       chalk: 4.1.2
       cosmiconfig: 9.0.0(typescript@5.9.3)
       debounce: 2.2.0
       detect-indent: 6.1.0
       graphql: 16.13.0
-      graphql-config: 5.1.5(@types/node@22.19.1)(graphql@16.13.0)(typescript@5.9.3)
+      graphql-config: 5.1.5(@types/node@22.19.12)(graphql@16.13.0)(typescript@5.9.3)
       is-glob: 4.0.3
       jiti: 2.6.1
       json-to-pretty-yaml: 1.2.2
@@ -14092,7 +14083,7 @@ snapshots:
       - crossws
       - utf-8-validate
 
-  '@graphql-tools/executor-http@1.3.3(@types/node@22.19.1)(graphql@16.13.0)':
+  '@graphql-tools/executor-http@1.3.3(@types/node@22.19.12)(graphql@16.13.0)':
     dependencies:
       '@graphql-hive/signal': 1.0.0
       '@graphql-tools/executor-common': 0.0.4(graphql@16.13.0)
@@ -14102,12 +14093,12 @@ snapshots:
       '@whatwg-node/fetch': 0.10.8
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.13.0
-      meros: 1.3.0(@types/node@22.19.1)
+      meros: 1.3.0(@types/node@22.19.12)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/node'
 
-  '@graphql-tools/executor-http@3.1.0(@types/node@22.19.1)(graphql@16.13.0)':
+  '@graphql-tools/executor-http@3.1.0(@types/node@22.19.12)(graphql@16.13.0)':
     dependencies:
       '@graphql-hive/signal': 2.0.0
       '@graphql-tools/executor-common': 1.0.6(graphql@16.13.0)
@@ -14117,7 +14108,7 @@ snapshots:
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.13.0
-      meros: 1.3.2(@types/node@22.19.1)
+      meros: 1.3.2(@types/node@22.19.12)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/node'
@@ -14178,9 +14169,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@graphql-tools/github-loader@9.0.6(@types/node@22.19.1)(graphql@16.13.0)':
+  '@graphql-tools/github-loader@9.0.6(@types/node@22.19.12)(graphql@16.13.0)':
     dependencies:
-      '@graphql-tools/executor-http': 3.1.0(@types/node@22.19.1)(graphql@16.13.0)
+      '@graphql-tools/executor-http': 3.1.0(@types/node@22.19.12)(graphql@16.13.0)
       '@graphql-tools/graphql-tag-pluck': 8.3.27(graphql@16.13.0)
       '@graphql-tools/utils': 11.0.0(graphql@16.13.0)
       '@whatwg-node/fetch': 0.10.13
@@ -14292,10 +14283,10 @@ snapshots:
       graphql: 16.13.0
       tslib: 2.8.1
 
-  '@graphql-tools/url-loader@8.0.31(@types/node@22.19.1)(graphql@16.13.0)':
+  '@graphql-tools/url-loader@8.0.31(@types/node@22.19.12)(graphql@16.13.0)':
     dependencies:
       '@graphql-tools/executor-graphql-ws': 2.0.5(graphql@16.13.0)
-      '@graphql-tools/executor-http': 1.3.3(@types/node@22.19.1)(graphql@16.13.0)
+      '@graphql-tools/executor-http': 1.3.3(@types/node@22.19.12)(graphql@16.13.0)
       '@graphql-tools/executor-legacy-ws': 1.1.17(graphql@16.13.0)
       '@graphql-tools/utils': 10.10.3(graphql@16.13.0)
       '@graphql-tools/wrap': 10.0.36(graphql@16.13.0)
@@ -14315,10 +14306,10 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
-  '@graphql-tools/url-loader@9.0.6(@types/node@22.19.1)(graphql@16.13.0)':
+  '@graphql-tools/url-loader@9.0.6(@types/node@22.19.12)(graphql@16.13.0)':
     dependencies:
       '@graphql-tools/executor-graphql-ws': 3.1.4(graphql@16.13.0)
-      '@graphql-tools/executor-http': 3.1.0(@types/node@22.19.1)(graphql@16.13.0)
+      '@graphql-tools/executor-http': 3.1.0(@types/node@22.19.12)(graphql@16.13.0)
       '@graphql-tools/executor-legacy-ws': 1.1.25(graphql@16.13.0)
       '@graphql-tools/utils': 11.0.0(graphql@16.13.0)
       '@graphql-tools/wrap': 11.1.8(graphql@16.13.0)
@@ -14566,130 +14557,130 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@22.19.1)':
+  '@inquirer/checkbox@4.3.2(@types/node@22.19.12)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/core': 10.3.2(@types/node@22.19.12)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.12)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
-  '@inquirer/confirm@5.1.21(@types/node@22.19.1)':
+  '@inquirer/confirm@5.1.21(@types/node@22.19.12)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.1)
-      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      '@inquirer/core': 10.3.2(@types/node@22.19.12)
+      '@inquirer/type': 3.0.10(@types/node@22.19.12)
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
-  '@inquirer/core@10.3.2(@types/node@22.19.1)':
+  '@inquirer/core@10.3.2(@types/node@22.19.12)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.12)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
-  '@inquirer/editor@4.2.23(@types/node@22.19.1)':
+  '@inquirer/editor@4.2.23(@types/node@22.19.12)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.1)
-      '@inquirer/external-editor': 1.0.3(@types/node@22.19.1)
-      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      '@inquirer/core': 10.3.2(@types/node@22.19.12)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.12)
+      '@inquirer/type': 3.0.10(@types/node@22.19.12)
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
-  '@inquirer/expand@4.0.23(@types/node@22.19.1)':
+  '@inquirer/expand@4.0.23(@types/node@22.19.12)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.1)
-      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      '@inquirer/core': 10.3.2(@types/node@22.19.12)
+      '@inquirer/type': 3.0.10(@types/node@22.19.12)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.19.1)':
+  '@inquirer/external-editor@1.0.3(@types/node@22.19.12)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@22.19.1)':
+  '@inquirer/input@4.3.1(@types/node@22.19.12)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.1)
-      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      '@inquirer/core': 10.3.2(@types/node@22.19.12)
+      '@inquirer/type': 3.0.10(@types/node@22.19.12)
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
-  '@inquirer/number@3.0.23(@types/node@22.19.1)':
+  '@inquirer/number@3.0.23(@types/node@22.19.12)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.1)
-      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      '@inquirer/core': 10.3.2(@types/node@22.19.12)
+      '@inquirer/type': 3.0.10(@types/node@22.19.12)
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
-  '@inquirer/password@4.0.23(@types/node@22.19.1)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.1)
-      '@inquirer/type': 3.0.10(@types/node@22.19.1)
-    optionalDependencies:
-      '@types/node': 22.19.1
-
-  '@inquirer/prompts@7.10.1(@types/node@22.19.1)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@22.19.1)
-      '@inquirer/confirm': 5.1.21(@types/node@22.19.1)
-      '@inquirer/editor': 4.2.23(@types/node@22.19.1)
-      '@inquirer/expand': 4.0.23(@types/node@22.19.1)
-      '@inquirer/input': 4.3.1(@types/node@22.19.1)
-      '@inquirer/number': 3.0.23(@types/node@22.19.1)
-      '@inquirer/password': 4.0.23(@types/node@22.19.1)
-      '@inquirer/rawlist': 4.1.11(@types/node@22.19.1)
-      '@inquirer/search': 3.2.2(@types/node@22.19.1)
-      '@inquirer/select': 4.4.2(@types/node@22.19.1)
-    optionalDependencies:
-      '@types/node': 22.19.1
-
-  '@inquirer/rawlist@4.1.11(@types/node@22.19.1)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.1)
-      '@inquirer/type': 3.0.10(@types/node@22.19.1)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.19.1
-
-  '@inquirer/search@3.2.2(@types/node@22.19.1)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.1)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.1)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.19.1
-
-  '@inquirer/select@4.4.2(@types/node@22.19.1)':
+  '@inquirer/password@4.0.23(@types/node@22.19.12)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.1)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      '@inquirer/core': 10.3.2(@types/node@22.19.12)
+      '@inquirer/type': 3.0.10(@types/node@22.19.12)
+    optionalDependencies:
+      '@types/node': 22.19.12
+
+  '@inquirer/prompts@7.10.1(@types/node@22.19.12)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@22.19.12)
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.12)
+      '@inquirer/editor': 4.2.23(@types/node@22.19.12)
+      '@inquirer/expand': 4.0.23(@types/node@22.19.12)
+      '@inquirer/input': 4.3.1(@types/node@22.19.12)
+      '@inquirer/number': 3.0.23(@types/node@22.19.12)
+      '@inquirer/password': 4.0.23(@types/node@22.19.12)
+      '@inquirer/rawlist': 4.1.11(@types/node@22.19.12)
+      '@inquirer/search': 3.2.2(@types/node@22.19.12)
+      '@inquirer/select': 4.4.2(@types/node@22.19.12)
+    optionalDependencies:
+      '@types/node': 22.19.12
+
+  '@inquirer/rawlist@4.1.11(@types/node@22.19.12)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.12)
+      '@inquirer/type': 3.0.10(@types/node@22.19.12)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
-  '@inquirer/type@3.0.10(@types/node@22.19.1)':
+  '@inquirer/search@3.2.2(@types/node@22.19.12)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.12)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.12)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
-  '@interactivethings/swiss-federal-ci@3.3.0(a4661d0b902c74bc8e500100f2282327)':
+  '@inquirer/select@4.4.2(@types/node@22.19.12)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.12)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.12)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.12
+
+  '@inquirer/type@3.0.10(@types/node@22.19.12)':
+    optionalDependencies:
+      '@types/node': 22.19.12
+
+  '@interactivethings/swiss-federal-ci@3.4.0(a4661d0b902c74bc8e500100f2282327)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.0.0)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@types/react@19.0.0)(react@18.3.1)
@@ -14727,7 +14718,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
       '@types/yargs': 15.0.19
       chalk: 4.1.2
 
@@ -14736,7 +14727,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -14769,11 +14760,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lingui/babel-plugin-extract-messages@3.17.2(@types/node@22.19.1)(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)':
+  '@lingui/babel-plugin-extract-messages@3.17.2(@types/node@22.19.12)(ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@babel/generator': 7.28.6
       '@babel/runtime': 7.28.4
-      '@lingui/conf': 3.17.2(@types/node@22.19.1)(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)
+      '@lingui/conf': 3.17.2(@types/node@22.19.12)(ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3))(typescript@5.9.3)
       mkdirp: 1.0.4
     transitivePeerDependencies:
       - '@types/node'
@@ -14796,7 +14787,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lingui/cli@3.17.2(@babel/core@7.29.0)(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)':
+  '@lingui/cli@3.17.2(@babel/core@7.29.0)(@types/node@22.19.12)(babel-plugin-macros@3.1.0)(ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.28.6
@@ -14804,8 +14795,8 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
       '@babel/runtime': 7.28.4
       '@babel/types': 7.28.6
-      '@lingui/babel-plugin-extract-messages': 3.17.2(@types/node@22.19.1)(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)
-      '@lingui/conf': 3.17.2(@types/node@22.19.1)(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)
+      '@lingui/babel-plugin-extract-messages': 3.17.2(@types/node@22.19.12)(ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3))(typescript@5.9.3)
+      '@lingui/conf': 3.17.2(@types/node@22.19.12)(ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3))(typescript@5.9.3)
       '@lingui/core': 3.17.2
       '@messageformat/parser': 5.1.1
       babel-plugin-macros: 3.1.0
@@ -14870,16 +14861,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lingui/conf@3.17.2(@types/node@22.19.1)(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)':
+  '@lingui/conf@3.17.2(@types/node@22.19.12)(ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.28.4
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@22.19.1)(cosmiconfig@8.3.6(typescript@5.9.3))(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@22.19.12)(cosmiconfig@8.3.6(typescript@5.9.3))(ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3))(typescript@5.9.3)
       jest-validate: 26.6.2
       lodash.get: 4.4.2
     optionalDependencies:
-      ts-node: 10.7.0(@types/node@22.19.1)(typescript@5.9.3)
+      ts-node: 10.7.0(@types/node@22.19.12)(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
@@ -14917,11 +14908,11 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@lingui/macro@3.17.2(@lingui/core@3.17.2)(@lingui/react@3.17.2(react@18.3.1))(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)':
+  '@lingui/macro@3.17.2(@lingui/core@3.17.2)(@lingui/react@3.17.2(react@18.3.1))(@types/node@22.19.12)(babel-plugin-macros@3.1.0)(ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@babel/types': 7.28.6
-      '@lingui/conf': 3.17.2(@types/node@22.19.1)(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)
+      '@lingui/conf': 3.17.2(@types/node@22.19.12)(ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3))(typescript@5.9.3)
       '@lingui/core': 3.17.2
       '@lingui/react': 3.17.2(react@18.3.1)
       babel-plugin-macros: 3.1.0
@@ -14948,11 +14939,11 @@ snapshots:
     optionalDependencies:
       next: 15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@lingui/vite-plugin@5.9.2(babel-plugin-macros@3.1.0)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@lingui/vite-plugin@5.9.2(babel-plugin-macros@3.1.0)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))':
     dependencies:
       '@lingui/cli': 5.9.2(babel-plugin-macros@3.1.0)(typescript@5.9.3)
       '@lingui/conf': 5.9.2(typescript@5.9.3)
-      vite: 7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -15317,7 +15308,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@oclif/core@2.16.0(@types/node@22.19.1)(typescript@5.9.3)':
+  '@oclif/core@2.16.0(@types/node@22.19.12)(typescript@5.9.3)':
     dependencies:
       '@types/cli-progress': 3.11.6
       ansi-escapes: 4.3.2
@@ -15342,7 +15333,7 @@ snapshots:
       strip-ansi: 6.0.1
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
-      ts-node: 10.9.2(@types/node@22.19.1)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@22.19.12)(typescript@5.9.3)
       tslib: 2.8.1
       widest-line: 3.1.0
       wordwrap: 1.0.0
@@ -15384,18 +15375,18 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@oclif/plugin-help@5.2.20(@types/node@22.19.1)(typescript@5.9.3)':
+  '@oclif/plugin-help@5.2.20(@types/node@22.19.12)(typescript@5.9.3)':
     dependencies:
-      '@oclif/core': 2.16.0(@types/node@22.19.1)(typescript@5.9.3)
+      '@oclif/core': 2.16.0(@types/node@22.19.12)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
       - typescript
 
-  '@oclif/plugin-not-found@2.4.3(@types/node@22.19.1)(typescript@5.9.3)':
+  '@oclif/plugin-not-found@2.4.3(@types/node@22.19.12)(typescript@5.9.3)':
     dependencies:
-      '@oclif/core': 2.16.0(@types/node@22.19.1)(typescript@5.9.3)
+      '@oclif/core': 2.16.0(@types/node@22.19.12)(typescript@5.9.3)
       chalk: 4.1.2
       fast-levenshtein: 3.0.0
     transitivePeerDependencies:
@@ -16254,7 +16245,7 @@ snapshots:
 
   '@rdfjs/types@2.0.1':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 22.19.12
 
   '@repeaterjs/repeater@3.0.6': {}
 
@@ -17110,7 +17101,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
-  '@tpluscode/rdf-ns-builders@1.1.0(@zazuko/rdf-vocabularies@2023.1.19)(clownface@2.0.3)(safe-identifier@0.4.2)(ts-morph@27.0.2)(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))':
+  '@tpluscode/rdf-ns-builders@1.1.0(@zazuko/rdf-vocabularies@2023.1.19)(clownface@2.0.3)(safe-identifier@0.4.2)(ts-morph@27.0.2)(ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3))':
     dependencies:
       '@rdf-esm/namespace': 0.5.5
       '@rdfjs/types': 2.0.1
@@ -17120,7 +17111,7 @@ snapshots:
       fs-extra: 10.1.0
       safe-identifier: 0.4.2
       ts-morph: 27.0.2
-      ts-node: 10.7.0(@types/node@22.19.1)(typescript@5.9.3)
+      ts-node: 10.7.0(@types/node@22.19.12)(typescript@5.9.3)
 
   '@tpluscode/rdf-ns-builders@4.3.0':
     dependencies:
@@ -18351,7 +18342,7 @@ snapshots:
 
   '@types/cli-progress@3.11.6':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 22.19.12
 
   '@types/clownface@1.5.2':
     dependencies:
@@ -18359,7 +18350,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
   '@types/d3-array@2.12.7': {}
 
@@ -18534,7 +18525,7 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 22.19.12
 
   '@types/geojson@7946.0.16': {}
 
@@ -18544,7 +18535,7 @@ snapshots:
 
   '@types/gettext-parser@8.0.0':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 22.19.12
       '@types/readable-stream': 4.0.21
 
   '@types/hammerjs@2.0.46': {}
@@ -18553,7 +18544,7 @@ snapshots:
 
   '@types/http-link-header@1.0.7':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -18572,7 +18563,7 @@ snapshots:
 
   '@types/jsdom@21.1.7':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 22.19.12
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -18596,28 +18587,20 @@ snapshots:
 
   '@types/mysql@2.15.26':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
       form-data: 4.0.4
 
   '@types/node@18.19.127':
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@22.19.1':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@22.19.12':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/node@24.10.1':
-    dependencies:
-      undici-types: 7.16.0
 
   '@types/nprogress@0.2.3': {}
 
@@ -18631,13 +18614,13 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
       pg-protocol: 1.10.3
       pg-types: 2.2.0
 
   '@types/pg@8.6.1':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
       pg-protocol: 1.10.3
       pg-types: 2.2.0
 
@@ -18672,7 +18655,7 @@ snapshots:
   '@types/rdfjs__environment@1.0.0':
     dependencies:
       '@rdfjs/types': 2.0.1
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
   '@types/rdfjs__formats@4.0.1':
     dependencies:
@@ -18758,7 +18741,7 @@ snapshots:
 
   '@types/readable-stream@4.0.21':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 22.19.12
 
   '@types/readable-stream@4.0.23':
     dependencies:
@@ -18781,7 +18764,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
   '@types/topojson-client@3.1.5':
     dependencies:
@@ -19135,7 +19118,7 @@ snapshots:
       d3-time-format: 4.1.0
       internmap: 2.0.3
 
-  '@vitejs/plugin-react@5.1.4(vite@7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@vitejs/plugin-react@5.1.4(vite@7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -19143,20 +19126,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.1.1(playwright@1.58.2)(vite@7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))(vitest@4.0.15(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@vitest/browser@3.1.1(playwright@1.58.2)(vite@7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))(vitest@4.0.15(@opentelemetry/api@1.9.0)(@types/node@22.19.12)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.1.1(vite@7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))
+      '@vitest/mocker': 3.1.1(vite@7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))
       '@vitest/utils': 3.1.1
       magic-string: 0.30.21
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
+      vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@22.19.12)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
       ws: 8.18.2
     optionalDependencies:
       playwright: 1.58.2
@@ -19182,21 +19165,21 @@ snapshots:
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@3.1.1(vite@7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@vitest/mocker@3.1.1(vite@7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
 
-  '@vitest/mocker@4.0.15(vite@7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@vitest/mocker@4.0.15(vite@7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 4.0.15
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -19432,13 +19415,13 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
-  accent-cli@0.16.2(@types/node@22.19.1)(encoding@0.1.13)(typescript@5.9.3):
+  accent-cli@0.16.2(@types/node@22.19.12)(encoding@0.1.13)(typescript@5.9.3):
     dependencies:
       '@oclif/command': 1.8.36(@oclif/config@1.18.17)(supports-color@8.1.1)
       '@oclif/config': 1.18.17
-      '@oclif/core': 2.16.0(@types/node@22.19.1)(typescript@5.9.3)
-      '@oclif/plugin-help': 5.2.20(@types/node@22.19.1)(typescript@5.9.3)
-      '@oclif/plugin-not-found': 2.4.3(@types/node@22.19.1)(typescript@5.9.3)
+      '@oclif/core': 2.16.0(@types/node@22.19.12)(typescript@5.9.3)
+      '@oclif/plugin-help': 5.2.20(@types/node@22.19.12)(typescript@5.9.3)
+      '@oclif/plugin-not-found': 2.4.3(@types/node@22.19.12)(typescript@5.9.3)
       chalk: 4.1.2
       cli-ux: 5.6.7(@oclif/config@1.18.17)
       decamelize: 5.0.1
@@ -20485,11 +20468,11 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@22.19.1)(cosmiconfig@8.3.6(typescript@5.9.3))(ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@22.19.12)(cosmiconfig@8.3.6(typescript@5.9.3))(ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
       cosmiconfig: 8.3.6(typescript@5.9.3)
-      ts-node: 10.7.0(@types/node@22.19.1)(typescript@5.9.3)
+      ts-node: 10.7.0(@types/node@22.19.12)(typescript@5.9.3)
       typescript: 5.9.3
 
   cosmiconfig@7.1.0:
@@ -20886,7 +20869,7 @@ snapshots:
 
   deepl-node@1.18.0:
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 22.19.12
       adm-zip: 0.5.16
       axios: 1.13.2(debug@4.4.3)
       form-data: 4.0.4
@@ -21996,13 +21979,13 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql-config@5.1.5(@types/node@22.19.1)(graphql@16.13.0)(typescript@5.9.3):
+  graphql-config@5.1.5(@types/node@22.19.12)(graphql@16.13.0)(typescript@5.9.3):
     dependencies:
       '@graphql-tools/graphql-file-loader': 8.0.20(graphql@16.13.0)
       '@graphql-tools/json-file-loader': 8.0.18(graphql@16.13.0)
       '@graphql-tools/load': 8.1.0(graphql@16.13.0)
       '@graphql-tools/merge': 9.1.5(graphql@16.13.0)
-      '@graphql-tools/url-loader': 8.0.31(@types/node@22.19.1)(graphql@16.13.0)
+      '@graphql-tools/url-loader': 8.0.31(@types/node@22.19.12)(graphql@16.13.0)
       '@graphql-tools/utils': 10.10.3(graphql@16.13.0)
       cosmiconfig: 8.3.6(typescript@5.9.3)
       graphql: 16.13.0
@@ -22649,7 +22632,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -22828,10 +22811,10 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  knip@5.85.0(@types/node@22.19.1)(typescript@5.9.3):
+  knip@5.85.0(@types/node@22.19.12)(typescript@5.9.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
       fast-glob: 3.3.3
       formatly: 0.3.0
       jiti: 2.6.1
@@ -23077,13 +23060,13 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  meros@1.3.0(@types/node@22.19.1):
+  meros@1.3.0(@types/node@22.19.12):
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
-  meros@1.3.2(@types/node@22.19.1):
+  meros@1.3.2(@types/node@22.19.12):
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
 
   micromark-extension-gfm-autolink-literal@0.5.7:
     dependencies:
@@ -25287,7 +25270,7 @@ snapshots:
     dependencies:
       tldts: 6.1.86
 
-  tpo-deepl@1.2.4(@types/node@22.19.1)(typescript@5.9.3):
+  tpo-deepl@1.2.4(@types/node@22.19.12)(typescript@5.9.3):
     dependencies:
       chalk: 5.6.2
       cli-table3: 0.6.5
@@ -25297,7 +25280,7 @@ snapshots:
       dotenv-flow: 4.1.0
       fast-glob: 3.3.3
       gettext-parser: 8.0.0
-      knip: 5.85.0(@types/node@22.19.1)(typescript@5.9.3)
+      knip: 5.85.0(@types/node@22.19.12)(typescript@5.9.3)
       path-to-regexp: 8.2.0
       signale: 1.4.0
     transitivePeerDependencies:
@@ -25324,14 +25307,14 @@ snapshots:
       '@ts-morph/common': 0.28.1
       code-block-writer: 13.0.3
 
-  ts-node@10.7.0(@types/node@22.19.1)(typescript@5.9.3):
+  ts-node@10.7.0(@types/node@22.19.12)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.7.0
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -25342,14 +25325,14 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@22.19.12)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -25498,8 +25481,6 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
-
-  undici-types@7.16.0: {}
 
   undici@7.24.6: {}
 
@@ -25667,7 +25648,7 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.4.1
 
-  vite@7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0):
+  vite@7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0):
     dependencies:
       esbuild: 0.27.1
       fdir: 6.5.0(picomatch@4.0.4)
@@ -25676,17 +25657,17 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.40.0
       tsx: 4.21.0
       yaml: 2.8.0
 
-  vitest@4.0.15(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0):
+  vitest@4.0.15(@opentelemetry/api@1.9.0)(@types/node@22.19.12)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 4.0.15
-      '@vitest/mocker': 4.0.15(vite@7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))
+      '@vitest/mocker': 4.0.15(vite@7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0))
       '@vitest/pretty-format': 4.0.15
       '@vitest/runner': 4.0.15
       '@vitest/snapshot': 4.0.15
@@ -25703,11 +25684,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.2(@types/node@22.19.12)(jiti@2.6.1)(terser@5.40.0)(tsx@4.21.0)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 22.19.1
+      '@types/node': 22.19.12
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^11.13.0
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@types/react@19.0.0)(react@18.3.1)
       '@interactivethings/swiss-federal-ci':
-        specifier: 3.4.0
-        version: 3.4.0(a4661d0b902c74bc8e500100f2282327)
+        specifier: 3.4.1
+        version: 3.4.1(a4661d0b902c74bc8e500100f2282327)
       '@lingui/babel-plugin-lingui-macro':
         specifier: ^5.9.2
         version: 5.9.2(babel-plugin-macros@3.1.0)(typescript@5.9.3)
@@ -2479,8 +2479,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@interactivethings/swiss-federal-ci@3.4.0':
-    resolution: {integrity: sha512-fIyQxbXNHo/Vye/CXgbWawVxrjnYhcReYz8SHZLYixHaNfkZO+7y7TqWZmM7Q1xbab/1g5ds2SQFHxNsU0wnnQ==}
+  '@interactivethings/swiss-federal-ci@3.4.1':
+    resolution: {integrity: sha512-aOGXiUMAfXDYio5DDKZJpfZF1MICDHggVsCDRRaO/r4AsqyxnMEYoeZvcTy36CnokOU/kJCbyZdUBTixIvkWmA==}
     peerDependencies:
       '@emotion/react': ^11.11.0
       '@emotion/styled': ^11.11.0
@@ -14680,7 +14680,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.12
 
-  '@interactivethings/swiss-federal-ci@3.4.0(a4661d0b902c74bc8e500100f2282327)':
+  '@interactivethings/swiss-federal-ci@3.4.1(a4661d0b902c74bc8e500100f2282327)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.0.0)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.0.0)(react@18.3.1))(@types/react@19.0.0)(react@18.3.1)

--- a/src/components/app-layout.tsx
+++ b/src/components/app-layout.tsx
@@ -1,5 +1,6 @@
 import {
   ConsentBanner,
+  forgetMatomoConsent,
   giveMatomoConsent,
   useConsentBanner,
 } from "@interactivethings/swiss-federal-ci/dist/components";
@@ -74,7 +75,10 @@ export const ApplicationLayout = ({
             giveConsent();
             giveMatomoConsent();
           }}
-          onConsentReject={rejectConsent}
+          onConsentReject={() => {
+            rejectConsent();
+            forgetMatomoConsent();
+          }}
         />
       )}
     </HighlightContext.Provider>

--- a/src/components/app-layout.tsx
+++ b/src/components/app-layout.tsx
@@ -11,7 +11,7 @@ import {
 import { Trans, t } from "@lingui/macro";
 import { Box } from "@mui/system";
 import { useRouter } from "next/router";
-import { ReactNode, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 
 import { Footer } from "src/components/footer";
 import { Header } from "src/components/header";
@@ -36,7 +36,16 @@ export const ApplicationLayout = ({
 }: ApplicationLayoutProps) => {
   const [highlightContext, setHighlightContext] = useState<HighlightValue>();
   const matomoId = useMatomo();
-  const { isShown, giveConsent, rejectConsent } = useConsentBanner();
+  const { hasConsented, isShown, giveConsent, rejectConsent } =
+    useConsentBanner();
+
+  useEffect(() => {
+    if (hasConsented === "accepted") {
+      giveMatomoConsent();
+    } else if (hasConsented === "rejected") {
+      forgetMatomoConsent();
+    }
+  }, [hasConsented]);
 
   return (
     <HighlightContext.Provider
@@ -71,14 +80,8 @@ export const ApplicationLayout = ({
           }
           acceptButtonLabel={<Trans id="cookie.banner.accept">Accept</Trans>}
           rejectButtonLabel={<Trans id="cookie.banner.reject">Reject</Trans>}
-          onConsentGive={() => {
-            giveConsent();
-            giveMatomoConsent();
-          }}
-          onConsentReject={() => {
-            rejectConsent();
-            forgetMatomoConsent();
-          }}
+          onConsentGive={giveConsent}
+          onConsentReject={rejectConsent}
         />
       )}
     </HighlightContext.Provider>

--- a/src/components/app-layout.tsx
+++ b/src/components/app-layout.tsx
@@ -1,8 +1,13 @@
 import {
+  ConsentBanner,
+  giveMatomoConsent,
+  useConsentBanner,
+} from "@interactivethings/swiss-federal-ci/dist/components";
+import {
   MenuButton,
   MenuContainer,
 } from "@interactivethings/swiss-federal-ci/dist/components/pages-router";
-import { t } from "@lingui/macro";
+import { Trans, t } from "@lingui/macro";
 import { Box } from "@mui/system";
 import { useRouter } from "next/router";
 import { ReactNode, useState } from "react";
@@ -15,6 +20,7 @@ import {
 } from "src/components/highlight-context";
 import { SafeHydration } from "src/components/hydration";
 import { Search } from "src/components/search";
+import { useMatomo } from "src/domain/analytics";
 
 type ApplicationLayoutProps = {
   children: ReactNode;
@@ -28,6 +34,8 @@ export const ApplicationLayout = ({
   showHeaderCaption = true,
 }: ApplicationLayoutProps) => {
   const [highlightContext, setHighlightContext] = useState<HighlightValue>();
+  const matomoId = useMatomo();
+  const { isShown, giveConsent, rejectConsent } = useConsentBanner();
 
   return (
     <HighlightContext.Provider
@@ -48,6 +56,27 @@ export const ApplicationLayout = ({
         </Box>
         <Footer />
       </Box>
+      {matomoId && (
+        <ConsentBanner
+          isShown={isShown}
+          content={
+            <Trans id="cookie.banner.content">
+              To optimally tailor our website to your needs, we use the
+              analytics tool Matomo. Your behaviour on the website is recorded
+              in anonymised form. No personal data is transmitted or stored. If
+              you do not agree, you can prevent data collection by Matomo and
+              still use this website without restrictions.
+            </Trans>
+          }
+          acceptButtonLabel={<Trans id="cookie.banner.accept">Accept</Trans>}
+          rejectButtonLabel={<Trans id="cookie.banner.reject">Reject</Trans>}
+          onConsentGive={() => {
+            giveConsent();
+            giveMatomoConsent();
+          }}
+          onConsentReject={rejectConsent}
+        />
+      )}
     </HighlightContext.Provider>
   );
 };

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,9 +1,9 @@
 import {
-  Footer as SwissFederalCiFooter,
   FooterSection,
   FooterSectionButton,
   FooterSectionText,
   FooterSectionTitle,
+  Footer as SwissFederalCiFooter,
   useConsentBanner,
 } from "@interactivethings/swiss-federal-ci/dist/components";
 import { t } from "@lingui/macro";
@@ -133,7 +133,7 @@ export const Footer = ({ sx }: { sx?: SxProps }) => {
             onClick={showBanner}
             label={t({
               id: "footer.usage-statistics-choice",
-              message: "Manage Analytics Preferences",
+              message: "Manage cookie preferences",
             })}
           />
         )}
@@ -168,7 +168,9 @@ export const Footer = ({ sx }: { sx?: SxProps }) => {
           />
         </Link>
 
-        <Link href={`/api/sunshine-data-export?period=${period}&locale=${locale}`}>
+        <Link
+          href={`/api/sunshine-data-export?period=${period}&locale=${locale}`}
+        >
           <FooterSectionButton
             iconName="download"
             label={t({

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -4,10 +4,12 @@ import {
   FooterSectionButton,
   FooterSectionText,
   FooterSectionTitle,
+  useConsentBanner,
 } from "@interactivethings/swiss-federal-ci/dist/components";
 import { t } from "@lingui/macro";
 import { Link, SxProps } from "@mui/material";
 
+import { useMatomo } from "src/domain/analytics";
 import { useQueryStateEnergyPricesMap } from "src/domain/query-states";
 import { useLocale } from "src/lib/use-locale";
 
@@ -20,6 +22,8 @@ export const Footer = ({ sx }: { sx?: SxProps }) => {
   const helpCalculationDisclosure = useDisclosure();
   const helpCsvDisclosure = useDisclosure();
   const helpMunicipalitiesInfoDisclosure = useDisclosure();
+  const matomoId = useMatomo();
+  const { showBanner } = useConsentBanner();
 
   const bottomLinks = [
     {
@@ -123,6 +127,16 @@ export const Footer = ({ sx }: { sx?: SxProps }) => {
             })}
           />
         </Link>
+        {matomoId && (
+          <FooterSectionButton
+            iconName="arrow-right"
+            onClick={showBanner}
+            label={t({
+              id: "footer.usage-statistics-choice",
+              message: "Manage Analytics Preferences",
+            })}
+          />
+        )}
       </FooterSection>
       <FooterSection>
         <FooterSectionTitle

--- a/src/domain/analytics.ts
+++ b/src/domain/analytics.ts
@@ -1,8 +1,17 @@
+import { useState } from "react";
+
+import { runtimeEnv } from "src/env/runtime";
+
 declare global {
   interface Window {
     _paq?: $IntentionalAny[];
   }
 }
+
+export const useMatomo = (): string | undefined => {
+  const [matomoId] = useState<string | undefined>(() => runtimeEnv.MATOMO_ID);
+  return matomoId;
+};
 
 // See https://developer.matomo.org/guides/spa-tracking
 export const analyticsPageView = (path: string): void => {

--- a/src/lib/search-index-cache.ts
+++ b/src/lib/search-index-cache.ts
@@ -48,7 +48,7 @@ function buildIndex(data: SearchResult[]): MiniSearch {
 async function loadAll(
   locale: string,
   type: SearchType,
-  client: ParsingClient
+  client: ParsingClient,
 ): Promise<SearchResult[]> {
   switch (type) {
     case "municipality":
@@ -63,7 +63,7 @@ async function loadAll(
 async function buildCacheEntry(
   locale: string,
   type: SearchType,
-  client: ParsingClient
+  client: ParsingClient,
 ): Promise<CacheEntry> {
   const data = await loadAll(locale, type, client);
   const index = buildIndex(data);
@@ -77,7 +77,7 @@ function getEndpointUrl(client: ParsingClient): string {
 async function getTypeEntry(
   locale: string,
   type: SearchType,
-  client: ParsingClient
+  client: ParsingClient,
 ): Promise<CacheEntry> {
   const key = `${getEndpointUrl(client)}:${locale}:${type}`;
   const cached = cache.get(key);
@@ -100,14 +100,14 @@ async function getTypeEntry(
 export async function getSearchIndex(
   locale: string,
   types: SearchType[],
-  client: ParsingClient
+  client: ParsingClient,
 ): Promise<CacheEntry> {
   if (types.length === 1) {
     return getTypeEntry(locale, types[0], client);
   }
 
   const entries = await Promise.all(
-    types.map((t) => getTypeEntry(locale, t, client))
+    types.map((t) => getTypeEntry(locale, t, client)),
   );
   const data = entries.flatMap((e) => e.data);
   const index = buildIndex(data);

--- a/src/locales/aa/messages.po
+++ b/src/locales/aa/messages.po
@@ -62,6 +62,18 @@ msgstr "combobox.prompt"
 msgid "controls.search.clear"
 msgstr "controls.search.clear"
 
+#: src/components/app-layout.tsx
+msgid "cookie.banner.accept"
+msgstr "cookie.banner.accept"
+
+#: src/components/app-layout.tsx
+msgid "cookie.banner.content"
+msgstr "cookie.banner.content"
+
+#: src/components/app-layout.tsx
+msgid "cookie.banner.reject"
+msgstr "cookie.banner.reject"
+
 #: src/pages/api/data-export.ts
 msgid "data-export.column.aid-fee"
 msgstr "data-export.column.aid-fee"
@@ -425,6 +437,10 @@ msgstr "footer.swiss-municipalities-grid"
 #: src/components/footer.tsx
 msgid "footer.tariff-components"
 msgstr "footer.tariff-components"
+
+#: src/components/footer.tsx
+msgid "footer.usage-statistics-choice"
+msgstr "footer.usage-statistics-choice"
 
 #: src/components/header.tsx
 msgid "header.long-title"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -62,6 +62,18 @@ msgstr "Bezeichnung eingeben…"
 msgid "controls.search.clear"
 msgstr "Suchfeld leeren"
 
+#: src/components/app-layout.tsx
+msgid "cookie.banner.accept"
+msgstr ""
+
+#: src/components/app-layout.tsx
+msgid "cookie.banner.content"
+msgstr "Damit wir unser Webangebot optimal auf Ihre Bedürfnisse ausrichten können, verwenden wir das Analysetool Matomo. Dabei wird Ihr Verhalten auf der Website in anonymisierter Form erfasst. Es werden also keine personenbezogenen Daten übermittelt oder gespeichert. Wenn Sie damit nicht einverstanden sind, können Sie die Datenerfassung durch Matomo unterbinden und diese Website trotzdem ohne Einschränkungen nutzen."
+
+#: src/components/app-layout.tsx
+msgid "cookie.banner.reject"
+msgstr ""
+
 #: src/pages/api/data-export.ts
 msgid "data-export.column.aid-fee"
 msgstr "Gebühr für die Beihilfe"
@@ -425,6 +437,10 @@ msgstr "Schweizerische Gemeinden und zuständige Stromnetzbetreiber"
 #: src/components/footer.tsx
 msgid "footer.tariff-components"
 msgstr "Tarifkomponenten Übertragungsnetz - Swissgrid"
+
+#: src/components/footer.tsx
+msgid "footer.usage-statistics-choice"
+msgstr ""
 
 #: src/components/header.tsx
 msgid "header.long-title"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -64,7 +64,7 @@ msgstr "Suchfeld leeren"
 
 #: src/components/app-layout.tsx
 msgid "cookie.banner.accept"
-msgstr ""
+msgstr "Akzeptieren"
 
 #: src/components/app-layout.tsx
 msgid "cookie.banner.content"
@@ -72,7 +72,7 @@ msgstr "Damit wir unser Webangebot optimal auf Ihre Bedürfnisse ausrichten kön
 
 #: src/components/app-layout.tsx
 msgid "cookie.banner.reject"
-msgstr ""
+msgstr "Ablehnen"
 
 #: src/pages/api/data-export.ts
 msgid "data-export.column.aid-fee"
@@ -440,7 +440,7 @@ msgstr "Tarifkomponenten Übertragungsnetz - Swissgrid"
 
 #: src/components/footer.tsx
 msgid "footer.usage-statistics-choice"
-msgstr ""
+msgstr "Cookie-Einstellungen verwalten"
 
 #: src/components/header.tsx
 msgid "header.long-title"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -440,7 +440,7 @@ msgstr "Transmission grid tariff components - Swissgrid"
 
 #: src/components/footer.tsx
 msgid "footer.usage-statistics-choice"
-msgstr "Your choice on Usage Statistics"
+msgstr "Manage cookie preferences"
 
 #: src/components/header.tsx
 msgid "header.long-title"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -62,6 +62,18 @@ msgstr "Enter designation ..."
 msgid "controls.search.clear"
 msgstr "Clear search field"
 
+#: src/components/app-layout.tsx
+msgid "cookie.banner.accept"
+msgstr "Accept"
+
+#: src/components/app-layout.tsx
+msgid "cookie.banner.content"
+msgstr "This website uses Matomo to collect anonymized usage statistics to help us improve the service. No personal data is stored."
+
+#: src/components/app-layout.tsx
+msgid "cookie.banner.reject"
+msgstr "Reject"
+
 #: src/pages/api/data-export.ts
 msgid "data-export.column.aid-fee"
 msgstr "Aid Fee"
@@ -425,6 +437,10 @@ msgstr "Swiss municipalities and responsible electricity grid operators"
 #: src/components/footer.tsx
 msgid "footer.tariff-components"
 msgstr "Transmission grid tariff components - Swissgrid"
+
+#: src/components/footer.tsx
+msgid "footer.usage-statistics-choice"
+msgstr "Your choice on Usage Statistics"
 
 #: src/components/header.tsx
 msgid "header.long-title"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -62,6 +62,18 @@ msgstr "Saisir la description…"
 msgid "controls.search.clear"
 msgstr "Supprimer"
 
+#: src/components/app-layout.tsx
+msgid "cookie.banner.accept"
+msgstr ""
+
+#: src/components/app-layout.tsx
+msgid "cookie.banner.content"
+msgstr "Afin d'adapter au mieux notre offre web à vos besoins, nous utilisons l'outil d'analyse Matomo. Votre comportement sur le site web est enregistré sous forme anonymisée. Aucune donnée personnelle n'est transmise ou stockée. Si vous n'êtes pas d'accord, vous pouvez empêcher la collecte de données par Matomo et continuer à utiliser ce site web sans restrictions."
+
+#: src/components/app-layout.tsx
+msgid "cookie.banner.reject"
+msgstr ""
+
 #: src/pages/api/data-export.ts
 msgid "data-export.column.aid-fee"
 msgstr "Frais d'aide"
@@ -425,6 +437,10 @@ msgstr "Communes suisses et gestionnaires de réseau d'électricité compétents
 #: src/components/footer.tsx
 msgid "footer.tariff-components"
 msgstr "Composantes tarifaires du réseau de transport - Swissgrid"
+
+#: src/components/footer.tsx
+msgid "footer.usage-statistics-choice"
+msgstr ""
 
 #: src/components/header.tsx
 msgid "header.long-title"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -64,7 +64,7 @@ msgstr "Supprimer"
 
 #: src/components/app-layout.tsx
 msgid "cookie.banner.accept"
-msgstr ""
+msgstr "Accepter"
 
 #: src/components/app-layout.tsx
 msgid "cookie.banner.content"
@@ -72,7 +72,7 @@ msgstr "Afin d'adapter au mieux notre offre web à vos besoins, nous utilisons l
 
 #: src/components/app-layout.tsx
 msgid "cookie.banner.reject"
-msgstr ""
+msgstr "Rejeter"
 
 #: src/pages/api/data-export.ts
 msgid "data-export.column.aid-fee"
@@ -440,7 +440,7 @@ msgstr "Composantes tarifaires du réseau de transport - Swissgrid"
 
 #: src/components/footer.tsx
 msgid "footer.usage-statistics-choice"
-msgstr ""
+msgstr "Gérer les préférences en matière de cookies"
 
 #: src/components/header.tsx
 msgid "header.long-title"

--- a/src/locales/it/messages.po
+++ b/src/locales/it/messages.po
@@ -64,7 +64,7 @@ msgstr "Svuotare il campo di ricerca"
 
 #: src/components/app-layout.tsx
 msgid "cookie.banner.accept"
-msgstr ""
+msgstr "Accettare"
 
 #: src/components/app-layout.tsx
 msgid "cookie.banner.content"
@@ -72,7 +72,7 @@ msgstr "Per adattare al meglio la nostra offerta web alle vostre esigenze, utili
 
 #: src/components/app-layout.tsx
 msgid "cookie.banner.reject"
-msgstr ""
+msgstr "Rifiuto"
 
 #: src/pages/api/data-export.ts
 msgid "data-export.column.aid-fee"
@@ -442,7 +442,7 @@ msgstr "Componenti tariffarie della rete di trasmissione - Swissgrid"
 
 #: src/components/footer.tsx
 msgid "footer.usage-statistics-choice"
-msgstr ""
+msgstr "Gestione delle preferenze sui cookie"
 
 #: src/components/header.tsx
 msgid "header.long-title"

--- a/src/locales/it/messages.po
+++ b/src/locales/it/messages.po
@@ -62,6 +62,18 @@ msgstr "Inserire la descrizione..."
 msgid "controls.search.clear"
 msgstr "Svuotare il campo di ricerca"
 
+#: src/components/app-layout.tsx
+msgid "cookie.banner.accept"
+msgstr ""
+
+#: src/components/app-layout.tsx
+msgid "cookie.banner.content"
+msgstr "Per adattare al meglio la nostra offerta web alle vostre esigenze, utilizziamo lo strumento di analisi Matomo. Il vostro comportamento sul sito web viene registrato in forma anonima. Non vengono trasmessi o memorizzati dati personali. Se non siete d'accordo, potete impedire la raccolta di dati da parte di Matomo e continuare a utilizzare questo sito web senza restrizioni."
+
+#: src/components/app-layout.tsx
+msgid "cookie.banner.reject"
+msgstr ""
+
 #: src/pages/api/data-export.ts
 msgid "data-export.column.aid-fee"
 msgstr "Tassa di aiuto"
@@ -427,6 +439,10 @@ msgstr "Comuni svizzeri e gestori di rete elettrica responsabili"
 #: src/components/footer.tsx
 msgid "footer.tariff-components"
 msgstr "Componenti tariffarie della rete di trasmissione - Swissgrid"
+
+#: src/components/footer.tsx
+msgid "footer.usage-statistics-choice"
+msgstr ""
 
 #: src/components/header.tsx
 msgid "header.long-title"

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,11 +7,11 @@ import { CssBaseline, ThemeProvider } from "@mui/material";
 import { AppProps } from "next/app";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { analyticsPageView, useMatomo } from "src/domain/analytics";
 import createEmotionCache from "src/emotion-cache";
-import { getClientRuntimeEnv, runtimeEnv } from "src/env/runtime";
+import { getClientRuntimeEnv } from "src/env/runtime";
 import { GraphqlProvider } from "src/graphql/context";
 import { LocaleProvider } from "src/lib/use-locale";
 import { useNProgress } from "src/lib/use-nprogress";

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,7 +9,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
-import { analyticsPageView } from "src/domain/analytics";
+import { analyticsPageView, useMatomo } from "src/domain/analytics";
 import createEmotionCache from "src/emotion-cache";
 import { getClientRuntimeEnv, runtimeEnv } from "src/env/runtime";
 import { GraphqlProvider } from "src/graphql/context";
@@ -155,9 +155,4 @@ export default function App(props: AppProps & { emotionCache?: EmotionCache }) {
       {matomoId && !query.download && <Matomo siteId={matomoId} />}
     </CacheProvider>
   );
-}
-
-function useMatomo() {
-  const [matomoId] = useState<string | undefined>(() => runtimeEnv.MATOMO_ID);
-  return matomoId;
 }

--- a/src/rdf/search-queries.ts
+++ b/src/rdf/search-queries.ts
@@ -4,7 +4,6 @@ import ParsingClient from "sparql-http-client/ParsingClient";
 
 import * as ns from "./namespace";
 
-
 export type SearchResult = {
   id: string;
   name: string;
@@ -31,9 +30,10 @@ export const loadAllMunicipalities = async ({
       }
       ?municipality a ?class .
       ?municipality <http://schema.org/name> ?municipalityLabel .
-      OPTIONAL { ?municipality <http://schema.org/postalCode> ?postalCode . }
+
       GRAPH <https://lindas.admin.ch/elcom/electricityprice> {
-        [] <http://schema.org/areaServed> ?municipality .
+        [] <http://schema.org/areaServed> ?municipality ;
+            <http://schema.org/postalCode> ?postalCode .
       }
     }
     GROUP BY ?municipality ?municipalityLabel ?class
@@ -52,7 +52,7 @@ export const loadAllMunicipalities = async ({
     name: d.name.value,
     type: d.type.value,
     isAbolished: ns.schemaAdmin`AbolishedMunicipality`.equals(
-      d.municipalityClass
+      d.municipalityClass,
     ),
     postalCodes: d.postalCodes?.value || undefined,
   }));

--- a/src/rdf/search-queries.ts
+++ b/src/rdf/search-queries.ts
@@ -1,4 +1,3 @@
-import { SELECT } from "@tpluscode/sparql-builder";
 import { Literal, NamedNode, Quad } from "rdf-js";
 import ParsingClient from "sparql-http-client/ParsingClient";
 
@@ -22,7 +21,7 @@ export const loadAllMunicipalities = async ({
 }: {
   client: ParsingClient;
 }): Promise<SearchResult[]> => {
-  const query = `
+  const query = /* sparql */ `
     SELECT ("municipality" AS ?type) (?municipality AS ?iri) (?municipalityLabel AS ?name) (?class AS ?municipalityClass) (GROUP_CONCAT(DISTINCT STR(?postalCode); separator=" ") AS ?postalCodes) WHERE {
       VALUES ?class {
         <https://schema.ld.admin.ch/Municipality>
@@ -67,7 +66,7 @@ export const loadAllOperators = async ({
 }: {
   client: ParsingClient;
 }): Promise<SearchResult[]> => {
-  const query = `
+  const query = /* sparql */ `
     SELECT DISTINCT ("operator" AS ?type) (?operator AS ?iri) (?operatorLabel AS ?name) WHERE {
       GRAPH <https://lindas.admin.ch/elcom/electricityprice> {
         ?operator a <http://schema.org/Organization> .
@@ -101,7 +100,7 @@ export const loadAllCantons = async ({
   client: ParsingClient;
   locale: string;
 }): Promise<SearchResult[]> => {
-  const query = `
+  const query = /* sparql */ `
     SELECT DISTINCT ("canton" AS ?type) (?canton AS ?iri) (?cantonLabel AS ?name) WHERE {
       ?canton a <https://schema.ld.admin.ch/Canton> .
       ?canton <http://schema.org/name> ?cantonLabel .
@@ -124,10 +123,14 @@ export const loadAllCantons = async ({
 };
 
 const getOperatorQuery = ({ operatorId }: { operatorId: string }) => {
-  return SELECT`?uid`.WHERE`
-    <https://energy.ld.admin.ch/elcom/electricityprice/operator/${operatorId}> a ${ns.schema.Organization} ;
-      ${ns.schema.identifier} ?uid
-  `;
+  return {
+    build: () => /* sparql */ `
+      SELECT ?uid WHERE {
+        <https://energy.ld.admin.ch/elcom/electricityprice/operator/${operatorId}> a <http://schema.org/Organization> ;
+          <http://schema.org/identifier> ?uid .
+      }
+    `,
+  };
 };
 
 export const fetchOperatorInfo = async ({


### PR DESCRIPTION
- **refactor: Extract useMatomo**
- **feat: Update swiss-federal-ci**
- **feat: Use a consent banner to register user consent to analytics**

## Description

User analytics were not being sent without user content

- Add consent banner from swiss-federal-ci to register user consent to analytics.
- Add opportunity for users to manage their consent via a footer link

## Testing Performed

Tested locally that events were sent to matomo, could see events popping in.

