### PR TITLE
feat: use reference ID for Gever document search (#470)

### DIFF
--- a/src/components/detail-page/filter-set-description.tsx
+++ b/src/components/detail-page/filter-set-description.tsx
@@ -20,12 +20,18 @@ type ObjectEntry<T> = {
 
 export const FilterSetDescription = ({
   filters,
+  hideYear = false,
 }: {
   filters: Partial<FilterSet>;
+  hideYear?: boolean;
 }) => {
   return Object.entries(filters).map((entry_, i) => {
     const entry = entry_ as ObjectEntry<FilterSet>;
     if (!entry) {
+      return null;
+    }
+
+    if (hideYear && entry[0] === "period") {
       return null;
     }
 

--- a/src/components/detail-page/price-distribution-histogram.tsx
+++ b/src/components/detail-page/price-distribution-histogram.tsx
@@ -1,7 +1,8 @@
 import { Trans, t } from "@lingui/macro";
 import { useLingui } from "@lingui/react";
-import { Box } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { groups } from "d3";
+import { Fragment } from "react";
 
 import {
   ChartContainer,
@@ -72,6 +73,8 @@ export const PriceDistributionHistograms = ({ id, entity }: SectionProps) => {
     setQueryState,
   ] = useQueryStateEnergyPricesDetails();
 
+  const sortedPeriods = [...period].sort();
+
   const getItemLabel = (id: TranslationKey) => getLocalizedLabel({ id });
 
   const comparisonIds =
@@ -122,7 +125,10 @@ export const PriceDistributionHistograms = ({ id, entity }: SectionProps) => {
           </Trans>
         </CardTitle>
         <CardDescription>
-          <FilterSetDescription filters={filters} />
+          <FilterSetDescription
+            filters={filters}
+            hideYear={sortedPeriods.length > 1}
+          />
         </CardDescription>
       </CardHeader>
       {!download && (
@@ -188,16 +194,25 @@ export const PriceDistributionHistograms = ({ id, entity }: SectionProps) => {
           </Box>
         </>
       )}
-      {period.map((p) => (
-        <PriceDistributionHistogram
-          key={p}
-          year={p}
-          priceComponent={priceComponent[0] as PriceComponent}
-          category={category}
-          product={product}
-          annotationIds={annotationIds}
-          entity={entity}
-        />
+      {sortedPeriods.map((p) => (
+        <Fragment key={p}>
+          {/* When multiple periods are selected, show the period */}
+          {sortedPeriods.length > 1 && (
+            <Typography variant="subtitle2" key={p}>
+              <Trans id="detail.card.subtitle.year" values={{ period: p }}>
+                Year: {p}
+              </Trans>
+            </Typography>
+          )}
+          <PriceDistributionHistogram
+            year={p}
+            priceComponent={priceComponent[0] as PriceComponent}
+            category={category}
+            product={product}
+            annotationIds={annotationIds}
+            entity={entity}
+          />
+        </Fragment>
       ))}
       {/*FIXME: placeholder values */}
       {/* <CardFooter date="March 7, 2024, 1:28 PM" source="Lindas" /> */}

--- a/src/domain/gever/message.ts
+++ b/src/domain/gever/message.ts
@@ -229,7 +229,7 @@ const makeRpStsRequest = async (ipStsInfo: IPSTSInfo) => {
 
   // Fill timestamp
   const creationDate = new Date().toISOString();
-  const expirationDate = new Date(Date.now()+ 5 * 60 * 1000).toISOString();
+  const expirationDate = new Date(Date.now() + 5 * 60 * 1000).toISOString();
   $(timestampNode, ns.u, "Created").textContent = creationDate;
   $(timestampNode, ns.u, "Expires").textContent = expirationDate;
 
@@ -284,7 +284,7 @@ const setupGeverAPIRequest = (
 
   // Fill timestamp
   const creationDate = new Date().toISOString();
-  const expirationDate = new Date(Date.now()+ 5 * 60 * 1000).toISOString();
+  const expirationDate = new Date(Date.now() + 5 * 60 * 1000).toISOString();
   $(timestampNode, ns.u, "Created").textContent = creationDate;
   $(timestampNode, ns.u, "Expires").textContent = expirationDate;
 
@@ -351,25 +351,30 @@ const makeSearchRequest = async (
 ) => {
   const doc = setupGeverAPIRequest(searchDocumentsTemplate, rpStsInfo);
 
-  if (!searchOptions.uid && !searchOptions.operatorId) {
+  if (
+    !searchOptions.referenceId &&
+    !searchOptions.uid &&
+    !searchOptions.operatorId
+  ) {
     throw new Error(
-      "Both uid and operatorId cannot be falsy when searching operator documents"
+      "referenceId, uid, and operatorId cannot all be falsy when searching operator documents"
     );
   }
 
   const parameterNameNode = doc.getElementsByTagName("ParameterName")[0];
-  const parameterName = searchOptions.uid
+  const parameterName = searchOptions.referenceId
+    ? "Gtx_ELCOM_ERH_REFID_Suche"
+    : searchOptions.uid
     ? "Gtx_ELCOM_ERH_UID_Suche"
     : "Gtx_ELCOM_ERH_OpID_Suche";
   parameterNameNode.textContent = parameterName;
 
   const parameterValueNode = doc.getElementsByTagName("ParameterValue")[0];
-  const parameterValue = searchOptions.uid
-    ? searchOptions.uid
-    : searchOptions.operatorId;
+  const parameterValue =
+    searchOptions.referenceId ?? searchOptions.uid ?? searchOptions.operatorId;
 
   if (!parameterValue) {
-    throw new Error("At least uid or operatorId must be passed");
+    throw new Error("At least referenceId, uid, or operatorId must be passed");
   }
   parameterValueNode.textContent = parameterValue;
 
@@ -455,6 +460,7 @@ export const downloadGeverDocument = memoize(
 type SearchOptions = {
   operatorId: string | undefined;
   uid: string | undefined;
+  referenceId: string | undefined;
 };
 
 export const searchGeverDocuments = async (searchOptions: SearchOptions) => {

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -111,8 +111,9 @@ const expectedCubeDimensions = [
 const Query: QueryResolvers = {
   sunshineData: async (_parent, args, context) => {
     const { filter } = args;
-    const sunshineData =
-      await context.sunshineDataService.getSunshineData(filter);
+    const sunshineData = await context.sunshineDataService.getSunshineData(
+      filter
+    );
     return sunshineData;
   },
   sunshineDataByIndicator: async (_parent, args, context) => {
@@ -152,9 +153,9 @@ const Query: QueryResolvers = {
         if (medianParams) {
           const medianRows = sortBy(
             await context.sunshineDataService.getYearlyIndicatorMedians(
-              medianParams,
+              medianParams
             ),
-            (x) => x.period,
+            (x) => x.period
           );
           const medianResult = filter.period
             ? medianRows.find((x) => `${x.period}` === filter.period!)
@@ -163,7 +164,7 @@ const Query: QueryResolvers = {
             getMedianValueFromResult(
               medianResult,
               typedIndicator,
-              filter.saidiSaifiType ?? undefined,
+              filter.saidiSaifiType ?? undefined
             ) ?? undefined;
         }
       } catch (_error) {
@@ -171,7 +172,7 @@ const Query: QueryResolvers = {
         console.error(
           `Failed to calculate median for indicator ${filter.indicator}: ${
             _error instanceof Error ? _error.message : _error
-          }`,
+          }`
         );
       }
     }
@@ -205,9 +206,9 @@ const Query: QueryResolvers = {
       if (medianParams) {
         const medianRows = sortBy(
           await context.sunshineDataService.getYearlyIndicatorMedians(
-            medianParams,
+            medianParams
           ),
-          (x) => x.period,
+          (x) => x.period
         );
         const medianResult = filter.period
           ? medianRows.find((x) => `${x.period}` === filter.period!)
@@ -216,14 +217,14 @@ const Query: QueryResolvers = {
           getMedianValueFromResult(
             medianResult,
             typedIndicator!,
-            filter.saidiSaifiType ?? undefined,
+            filter.saidiSaifiType ?? undefined
           ) ?? 0;
       } else {
         throw new GraphQLError(
           `Unsupported indicator for median calculation: ${typedIndicator}`,
           {
             extensions: { code: "UNSUPPORTED_INDICATOR" },
-          },
+          }
         );
       }
     } catch (_error) {
@@ -233,7 +234,7 @@ const Query: QueryResolvers = {
         }`,
         {
           extensions: { code: "MEDIAN_CALCULATION_ERROR" },
-        },
+        }
       );
     }
 
@@ -244,8 +245,9 @@ const Query: QueryResolvers = {
     if (!filter.operatorId && !filter.period) {
       throw new Error("Must either filter by year or by provider.");
     }
-    const sunshineData =
-      await context.sunshineDataService.getSunshineData(filter);
+    const sunshineData = await context.sunshineDataService.getSunshineData(
+      filter
+    );
     return sunshineData;
   },
   sunshineTariffsByIndicator: async (_parent, args, context) => {
@@ -308,7 +310,7 @@ const Query: QueryResolvers = {
             {
               filters,
               dimensions: observationDimensionKeys,
-            },
+            }
           )
         : [];
 
@@ -318,7 +320,7 @@ const Query: QueryResolvers = {
     })) as ResolvedOperatorObservation[];
 
     const years = Array.from(
-      new Set(operatorObservations.map((x) => x.period).filter(truthy)),
+      new Set(operatorObservations.map((x) => x.period).filter(truthy))
     );
     if (years) {
       const defaultNetworkLevel = "NE7";
@@ -327,7 +329,7 @@ const Query: QueryResolvers = {
       operatorObservations.forEach((x) => {
         const coverageRatio = coverageManager.getCoverage(
           x,
-          defaultNetworkLevel,
+          defaultNetworkLevel
         );
         x.coverageRatio = coverageRatio;
         return x;
@@ -336,14 +338,14 @@ const Query: QueryResolvers = {
 
     return CoverageCacheManager.filterByCoverageRatio(
       operatorObservations,
-      (o) => o.coverageRatio,
+      (o) => o.coverageRatio
     );
   },
   cantonMedianObservations: async (
     _,
     { locale, filters, observationKind },
     ctx,
-    info,
+    info
   ) => {
     if (observationKind && observationKind !== ObservationKind.Canton) {
       return null;
@@ -365,7 +367,7 @@ const Query: QueryResolvers = {
     // Look ahead to select proper dimensions for query
     const medianObservationFields = getResolverFields(
       info,
-      "CantonMedianObservation",
+      "CantonMedianObservation"
     );
 
     const medianDimensionKeys = medianObservationFields
@@ -390,7 +392,7 @@ const Query: QueryResolvers = {
             {
               filters,
               dimensions: medianDimensionKeys,
-            },
+            }
           )
         : [];
 
@@ -420,7 +422,7 @@ const Query: QueryResolvers = {
     // Look ahead to select proper dimensions for query
     const medianObservationFields = getResolverFields(
       info,
-      "SwissMedianObservation",
+      "SwissMedianObservation"
     );
 
     const medianDimensionKeys = medianObservationFields
@@ -445,7 +447,7 @@ const Query: QueryResolvers = {
             {
               filters,
               dimensions: medianDimensionKeys,
-            },
+            }
           )
         : [];
 
@@ -511,7 +513,7 @@ const Query: QueryResolvers = {
     const { data } = await getSearchIndex(
       locale,
       ["municipality"],
-      context.sparqlClient,
+      context.sparqlClient
     );
     return data;
   },
@@ -569,7 +571,7 @@ const Query: QueryResolvers = {
     // Exit early if home-banner is requested and it's disabled
     const extraInfo = await getExtraInfo(slug);
     const wikiPage = await getWikiPage(
-      `${slug}/${locale === "en" ? "de" : locale}`,
+      `${slug}/${locale === "en" ? "de" : locale}`
     );
 
     if (!wikiPage) {
@@ -651,7 +653,7 @@ const Query: QueryResolvers = {
   operatorMunicipalities: async (
     _,
     { period, electricityCategory, networkLevel },
-    context,
+    context
   ) => {
     const category = electricityCategory
       ? asElectricityCategory(electricityCategory)
@@ -672,7 +674,7 @@ const Query: QueryResolvers = {
           municipality: String(item.municipality),
           operator: item.operator,
         },
-        level,
+        level
       );
       return coverage;
     });
@@ -682,7 +684,7 @@ const Query: QueryResolvers = {
 const getExtraInfo = async (slug: string) => {
   if (slug === "home-banner") {
     const bannerEnabled = (await getWikiPage("home"))?.content.match(
-      /home_banner_enabled:\W*true/,
+      /home_banner_enabled:\W*true/
     );
     return { bannerEnabled };
   } else {
@@ -729,16 +731,18 @@ const Operator: OperatorResolvers = {
       client: ctx.sparqlClient,
     });
     const uid = operatorInfo?.uid;
+    const referenceId = operatorInfo?.referenceId;
     try {
       const { docs } = await searchGeverDocuments({
         operatorId,
         uid,
+        referenceId,
       });
       return docs || [];
     } catch (e) {
       console.warn(
         "Could not search documents",
-        e instanceof Error ? e.message : e,
+        e instanceof Error ? e.message : e
       );
       return [];
     }
@@ -746,11 +750,11 @@ const Operator: OperatorResolvers = {
 
   peerGroup: async ({ id }, _args, context) => {
     const latestYear = await context.sunshineDataService.getLatestYearSunshine(
-      parseInt(id, 10),
+      parseInt(id, 10)
     );
     const peerGroups = await context.sunshineDataService.getOperatorPeerGroup(
       id,
-      latestYear,
+      latestYear
     );
     return peerGroups;
   },
@@ -860,7 +864,7 @@ export const resolvers: Resolvers = {
 
 // Helper function to create indicator median params from structured filter
 const createIndicatorMedianParams = (
-  filter: SunshineDataFilter,
+  filter: SunshineDataFilter
 ): IndicatorMedianParams | null => {
   if (!filter.indicator) return null;
 
@@ -931,7 +935,7 @@ const createIndicatorMedianParams = (
 const getMedianValueFromResult = (
   result_: PeerGroupRecord<any> | undefined,
   indicator: SunshineIndicator,
-  saidiSaifiType?: string,
+  saidiSaifiType?: string
 ): number | undefined => {
   if (!result_) return undefined;
 

--- a/src/pages/_system/api-status.tsx
+++ b/src/pages/_system/api-status.tsx
@@ -613,6 +613,7 @@ const DocumentDownloadStatus = () => {
     ) as {
       uid: string;
       oid: string;
+      referenceId: string;
     };
     execute(formData);
   };
@@ -647,6 +648,15 @@ const DocumentDownloadStatus = () => {
             <p style={{ fontSize: "small", color: "#111" }}>
               Either OID or UID is mandatory.
             </p>
+            <label>
+              Reference ID (NBReferenzID):{" "}
+              <input
+                type="value"
+                name="referenceId"
+                placeholder="fetched automatically from OID"
+                disabled
+              />
+            </label>
             <button disabled={query.status === "fetching"} type="submit">
               fetch documents
             </button>
@@ -663,6 +673,8 @@ const DocumentDownloadStatus = () => {
                 </textarea>
                 <br />
                 Lindas data <pre>{JSON.stringify(data.lindasInfo?.data)}</pre>
+                Reference ID (NBReferenzID){" "}
+                <pre>{data.referenceId ?? "not found"}</pre>
               </div>
               <div>
                 Bindings

--- a/src/pages/api/debug-download.ts
+++ b/src/pages/api/debug-download.ts
@@ -29,6 +29,7 @@ const handler = api({
     }
 
     let uid: string;
+    let referenceId: string | undefined;
     let lindasInfo: Awaited<ReturnType<typeof fetchOperatorInfo>> | null = null;
     if (queryUid && !Array.isArray(queryUid)) {
       uid = queryUid;
@@ -36,6 +37,7 @@ const handler = api({
       const client = await getSparqlClientFromRequest(req);
       lindasInfo = await fetchOperatorInfo({ operatorId: queryOid, client });
       uid = lindasInfo?.data.uid;
+      referenceId = lindasInfo?.data.referenceId;
     } else {
       uid = "Not found";
     }
@@ -43,11 +45,13 @@ const handler = api({
     const searchResp = await searchGeverDocuments({
       operatorId: queryOid,
       uid,
+      referenceId,
     });
     return {
       lindasEndpoint: client.query.endpoint.endpointUrl,
       lindasInfo,
       uid,
+      referenceId,
       searchResp,
     };
   },

--- a/src/rdf/common-integration-tests.ts
+++ b/src/rdf/common-integration-tests.ts
@@ -1,0 +1,12 @@
+import ParsingClient from "sparql-http-client/ParsingClient";
+
+const SPARQL_ENDPOINT = "https://cached.lindas.admin.ch/query";
+const SPARQL_TEST_ENDPOINT = "https://test.lindas.admin.ch/query";
+
+export const sparqlClient = new ParsingClient({
+  endpointUrl: SPARQL_ENDPOINT,
+});
+
+export const sparqlTestClient = new ParsingClient({
+  endpointUrl: SPARQL_TEST_ENDPOINT,
+});

--- a/src/rdf/search-queries.integration.spec.ts
+++ b/src/rdf/search-queries.integration.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  sparqlClient,
+  sparqlTestClient,
+} from "src/rdf/common-integration-tests";
+import { fetchOperatorInfo } from "src/rdf/search-queries";
+
+describe("fetchOperatorInfo", () => {
+  it("returns uid for an operator", async () => {
+    const result = await fetchOperatorInfo({
+      operatorId: "218",
+      client: sparqlClient,
+    });
+
+    expect(result.data.uid).toBeDefined();
+  });
+
+  it("returns referenceId (NBReferenzID) when present", async () => {
+    const result = await fetchOperatorInfo({
+      operatorId: "2",
+      client: sparqlTestClient,
+    });
+
+    expect(result.data.referenceId).toBe(
+      "CB0AB0BA-E129-4320-8533-9E3609CB4CF6"
+    );
+  });
+});

--- a/src/rdf/search-queries.ts
+++ b/src/rdf/search-queries.ts
@@ -51,7 +51,7 @@ export const loadAllMunicipalities = async ({
     name: d.name.value,
     type: d.type.value,
     isAbolished: ns.schemaAdmin`AbolishedMunicipality`.equals(
-      d.municipalityClass,
+      d.municipalityClass
     ),
     postalCodes: d.postalCodes?.value || undefined,
   }));
@@ -125,9 +125,16 @@ export const loadAllCantons = async ({
 const getOperatorQuery = ({ operatorId }: { operatorId: string }) => {
   return {
     build: () => /* sparql */ `
-      SELECT ?uid WHERE {
+      SELECT ?uid ?referenceId WHERE {
         <https://energy.ld.admin.ch/elcom/electricityprice/operator/${operatorId}> a <http://schema.org/Organization> ;
           <http://schema.org/identifier> ?uid .
+        OPTIONAL {
+          <https://energy.ld.admin.ch/elcom/electricityprice/operator/${operatorId}> <http://schema.org/identifier> [
+            a <http://schema.org/PropertyValue> ;
+            <http://schema.org/name> "NBReferenzID" ;
+            <http://schema.org/value> ?referenceId
+          ] .
+        }
       }
     `,
   };
@@ -143,20 +150,19 @@ export const fetchOperatorInfo = async ({
   const sparqlQuery = getOperatorQuery({ operatorId });
   const results = (await client.query.select(sparqlQuery.build())) as {
     uid: Literal;
+    referenceId?: Literal;
   }[];
 
-  if (results.length > 1) {
-    console.warn(`Multiple uid results for operator id ${operatorId}`);
-  } else if (results.length === 0) {
+  if (results.length === 0) {
     console.warn(`No uid results for operator id ${operatorId}`);
   }
 
   return {
     query: sparqlQuery.build(),
     data: results.map((d) => {
-      const uid = d.uid.value;
       return {
-        uid,
+        uid: d.uid.value,
+        referenceId: d.referenceId?.value,
       };
     })[0],
   };

--- a/src/rdf/sunshine.integration.spec.ts
+++ b/src/rdf/sunshine.integration.spec.ts
@@ -177,8 +177,9 @@ describe("SPARQL Sunshine Data Service", () => {
       });
 
       expect(result.length).toMatchInlineSnapshot(`589`);
-      expect(result.filter((x) => x.saidi_total !== null).slice(0, 3))
-        .toMatchInlineSnapshot(`
+      expect(
+        result.filter((x) => x.saidi_total !== null).slice(0, 3),
+      ).toMatchInlineSnapshot(`
           [
             {
               "operator_id": 11,
@@ -383,9 +384,8 @@ describe("SPARQL Sunshine Data Service", () => {
     });
 
     it("should return default year when no data found for non-existent operator", async () => {
-      const result = await sunshineDataServiceSparql.getLatestYearSunshine(
-        99999
-      );
+      const result =
+        await sunshineDataServiceSparql.getLatestYearSunshine(99999);
 
       expect(result).toMatchInlineSnapshot(`2024`);
     });
@@ -399,9 +399,8 @@ describe("SPARQL Sunshine Data Service", () => {
     });
 
     it("should return default year when no stability data found for non-existent operator", async () => {
-      const result = await sunshineDataServiceSparql.getLatestYearSunshine(
-        99999
-      );
+      const result =
+        await sunshineDataServiceSparql.getLatestYearSunshine(99999);
 
       expect(result).toMatchInlineSnapshot(`2024`);
     });
@@ -411,7 +410,7 @@ describe("SPARQL Sunshine Data Service", () => {
     it("should return peer group information", async () => {
       const result = await sunshineDataServiceSparql.getOperatorPeerGroup(
         8,
-        2024
+        2024,
       );
 
       expect(result).toMatchInlineSnapshot(`
@@ -426,7 +425,7 @@ describe("SPARQL Sunshine Data Service", () => {
     it("should return peer group information for string id", async () => {
       const result = await sunshineDataServiceSparql.getOperatorPeerGroup(
         "8",
-        2025
+        2025,
       );
 
       expect(result).toMatchInlineSnapshot(`


### PR DESCRIPTION
## Summary

> **Note:** this branch is based on `feat/csv-download` (#646) and should be merged after it.

- Uses the SPARQL `schema:identifier` (reference ID) instead of the internal partner ID when querying Gever for document downloads, resolving issue #470.
- Adds integration tests for the updated search queries (`src/rdf/search-queries.integration.spec.ts`).
- Exposes a debug download page at `_system/api-status` with richer diagnostic output.

## Test plan

- [x] Merge #646 first, then merge this PR
- [x] Run `pnpm test` — new integration specs should pass
- [ ] Verify Gever document downloads resolve correctly using the reference ID

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)